### PR TITLE
add performance visualization page

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,22 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      # Install python and jupyter to execute performance.ipynb to keep it up-to-date
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+
+      - name: Install Jupyter nbconvert
+        run: |
+          python -m pip install --upgrade pip
+          pip install jupyter pandas matplotlib plotly
+
+      - name: Execute Jupyter Notebook
+        run: |
+          # Execute hello.ipynb
+          jupyter nbconvert --execute performance.ipynb --to notebook --output performance.ipynb
+
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -26,6 +26,8 @@ website:
         text: "Price"
       - href: blog.qmd
         text: "Blog"
+      - href: performance.ipynb
+        text: "Performance"
     right:
       - icon: twitter
         href: https://twitter.com/ninjalabo
@@ -56,6 +58,11 @@ website:
       contents: 
         - blog.qmd
         # navigation items
+    - title: "Performance"
+      style: "docked"
+      search: true
+      contents:
+        - performance.ipynb
 
 format:
   html:

--- a/performance.ipynb
+++ b/performance.ipynb
@@ -1,0 +1,7227 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "id": "1e00c4da-1ec9-4402-a28b-6ad4b241b3a8",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: \"Quarto Basics\"\n",
+    "format: \n",
+    "  html:\n",
+    "    code-fold: true\n",
+    "jupyter: python3\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8776c2d1-722b-4e14-8b78-4b3f50f45bd4",
+   "metadata": {},
+   "source": [
+    "# Performance comparison\n",
+    "\n",
+    "Here, we visualize the performance of three runtimes: PyTorch, our custom-built tinyRuntime (both non-quantized and quantized versions), using the ResNet18 model and 100 images from the Imagenette dataset. We focus on four key metrics: accuracy, execution time, model size and memory usage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec64e51e-971e-4213-b4ea-506aa3b9bb7d",
+   "metadata": {},
+   "source": [
+    "## x86"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "dbc1a135-339f-4e3d-bc38-5d909dd57be5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "displayModeBar": false,
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": "rgba(31, 119, 180, 0.8)"
+         },
+         "name": "PyTorch",
+         "showlegend": true,
+         "type": "bar",
+         "x": [
+          "PyTorch"
+         ],
+         "xaxis": "x",
+         "y": [
+          99
+         ],
+         "yaxis": "y"
+        },
+        {
+         "marker": {
+          "color": "rgba(255, 127, 14, 0.8)"
+         },
+         "name": "tinyRuntime (no quant)",
+         "showlegend": true,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (no quant)"
+         ],
+         "xaxis": "x",
+         "y": [
+          99
+         ],
+         "yaxis": "y"
+        },
+        {
+         "marker": {
+          "color": "rgba(44, 160, 44, 0.8)"
+         },
+         "name": "tinyRuntime (quant)",
+         "showlegend": true,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (quant)"
+         ],
+         "xaxis": "x",
+         "y": [
+          99
+         ],
+         "yaxis": "y"
+        },
+        {
+         "marker": {
+          "color": "rgba(31, 119, 180, 0.8)"
+         },
+         "name": "PyTorch",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "PyTorch"
+         ],
+         "xaxis": "x2",
+         "y": [
+          11.552532196044922
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "marker": {
+          "color": "rgba(255, 127, 14, 0.8)"
+         },
+         "name": "tinyRuntime (no quant)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (no quant)"
+         ],
+         "xaxis": "x2",
+         "y": [
+          10.451820135116575
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "marker": {
+          "color": "rgba(44, 160, 44, 0.8)"
+         },
+         "name": "tinyRuntime (quant)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (quant)"
+         ],
+         "xaxis": "x2",
+         "y": [
+          72.08225703239441
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "marker": {
+          "color": "rgba(31, 119, 180, 0.8)"
+         },
+         "name": "PyTorch",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "PyTorch"
+         ],
+         "xaxis": "x3",
+         "y": [
+          469.3828125
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "marker": {
+          "color": "rgba(255, 127, 14, 0.8)"
+         },
+         "name": "tinyRuntime (no quant)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (no quant)"
+         ],
+         "xaxis": "x3",
+         "y": [
+          65.33984375
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "marker": {
+          "color": "rgba(44, 160, 44, 0.8)"
+         },
+         "name": "tinyRuntime (quant)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (quant)"
+         ],
+         "xaxis": "x3",
+         "y": [
+          33.9765625
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "marker": {
+          "color": "rgba(31, 119, 180, 0.8)"
+         },
+         "name": "PyTorch",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "PyTorch"
+         ],
+         "xaxis": "x4",
+         "y": [
+          44.93835258483887
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "marker": {
+          "color": "rgba(255, 127, 14, 0.8)"
+         },
+         "name": "tinyRuntime (no quant)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (no quant)"
+         ],
+         "xaxis": "x4",
+         "y": [
+          44.66026306152344
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "marker": {
+          "color": "rgba(44, 160, 44, 0.8)"
+         },
+         "name": "tinyRuntime (quant)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (quant)"
+         ],
+         "xaxis": "x4",
+         "y": [
+          11.949405670166016
+         ],
+         "yaxis": "y4"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "Accuracy",
+          "x": 0.225,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "Time",
+          "x": 0.775,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "Max memory usage",
+          "x": 0.225,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 0.375,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "Model size",
+          "x": 0.775,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 0.375,
+          "yanchor": "bottom",
+          "yref": "paper"
+         }
+        ],
+        "font": {
+         "size": 14
+        },
+        "height": 600,
+        "legend": {
+         "itemclick": false,
+         "itemdoubleclick": false,
+         "orientation": "h",
+         "x": 1,
+         "xanchor": "right",
+         "y": 1.1,
+         "yanchor": "bottom"
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#f2f5fa"
+            },
+            "error_y": {
+             "color": "#f2f5fa"
+            },
+            "marker": {
+             "line": {
+              "color": "rgb(17,17,17)",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "rgb(17,17,17)",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#A2B1C6",
+             "gridcolor": "#506784",
+             "linecolor": "#506784",
+             "minorgridcolor": "#506784",
+             "startlinecolor": "#A2B1C6"
+            },
+            "baxis": {
+             "endlinecolor": "#A2B1C6",
+             "gridcolor": "#506784",
+             "linecolor": "#506784",
+             "minorgridcolor": "#506784",
+             "startlinecolor": "#A2B1C6"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "marker": {
+             "line": {
+              "color": "#283442"
+             }
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "line": {
+              "color": "#283442"
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#506784"
+             },
+             "line": {
+              "color": "rgb(17,17,17)"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#2a3f5f"
+             },
+             "line": {
+              "color": "rgb(17,17,17)"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#f2f5fa",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#f2f5fa"
+          },
+          "geo": {
+           "bgcolor": "rgb(17,17,17)",
+           "lakecolor": "rgb(17,17,17)",
+           "landcolor": "rgb(17,17,17)",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#506784"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "dark"
+          },
+          "paper_bgcolor": "rgb(17,17,17)",
+          "plot_bgcolor": "rgb(17,17,17)",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "bgcolor": "rgb(17,17,17)",
+           "radialaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           },
+           "yaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           },
+           "zaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#f2f5fa"
+           }
+          },
+          "sliderdefaults": {
+           "bgcolor": "#C8D4E3",
+           "bordercolor": "rgb(17,17,17)",
+           "borderwidth": 1,
+           "tickwidth": 0
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "bgcolor": "rgb(17,17,17)",
+           "caxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "updatemenudefaults": {
+           "bgcolor": "#506784",
+           "borderwidth": 0
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#283442",
+           "linecolor": "#506784",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#283442",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#283442",
+           "linecolor": "#506784",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#283442",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "width": 900,
+        "xaxis": {
+         "anchor": "y",
+         "autorange": true,
+         "domain": [
+          0,
+          0.45
+         ],
+         "range": [
+          -0.5,
+          2.5
+         ],
+         "showticklabels": false,
+         "type": "category"
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "autorange": true,
+         "domain": [
+          0.55,
+          1
+         ],
+         "range": [
+          -0.5,
+          2.5
+         ],
+         "showticklabels": false,
+         "type": "category"
+        },
+        "xaxis3": {
+         "anchor": "y3",
+         "autorange": true,
+         "domain": [
+          0,
+          0.45
+         ],
+         "range": [
+          -0.5,
+          2.5
+         ],
+         "showticklabels": false,
+         "type": "category"
+        },
+        "xaxis4": {
+         "anchor": "y4",
+         "autorange": true,
+         "domain": [
+          0.55,
+          1
+         ],
+         "range": [
+          -0.5,
+          2.5
+         ],
+         "showticklabels": false,
+         "type": "category"
+        },
+        "yaxis": {
+         "anchor": "x",
+         "autorange": true,
+         "domain": [
+          0.625,
+          1
+         ],
+         "range": [
+          0,
+          104.21052631578948
+         ],
+         "title": {
+          "text": "Accuracy (%)"
+         },
+         "type": "linear"
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "autorange": true,
+         "domain": [
+          0.625,
+          1
+         ],
+         "range": [
+          0,
+          75.87606003409938
+         ],
+         "title": {
+          "text": "Time (s)"
+         },
+         "type": "linear"
+        },
+        "yaxis3": {
+         "anchor": "x3",
+         "autorange": true,
+         "domain": [
+          0,
+          0.375
+         ],
+         "range": [
+          0,
+          494.08717105263156
+         ],
+         "title": {
+          "text": "Max memory usage (MB)"
+         },
+         "type": "linear"
+        },
+        "yaxis4": {
+         "anchor": "x4",
+         "autorange": true,
+         "domain": [
+          0,
+          0.375
+         ],
+         "range": [
+          0,
+          47.303529036672494
+         ],
+         "title": {
+          "text": "Model size (MB)"
+         },
+         "type": "linear"
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA/AAAAJYCAYAAADFZw05AAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAD8KADAAQAAAABAAACWAAAAAAy8YL1AABAAElEQVR4AezdBZwU5RvA8ec4OqS7G0QkRLoFRKRLwEBaJeSP2AECNiIiYqEo3SkgIZJSSirSSHc3V//3eY9d9469uz24PW6X38tn2dmZd2be+c7e7j4zbwSkT58+TEgIIIAAAggggAACCCCAAAIIIJCgBRIl6NJROAQQQAABBBBAAAEEEEAAAQQQsAIE8LwREEAAAQQQQAABBBBAAAEEEPABAQJ4HzhJFBEBBBBAAAEEEEAAAQQQQAABAnjeAwgggAACCCCAAAIIIIAAAgj4gAABvA+cJIqIAAIIIIAAAggggAACCCCAAAE87wEEEEAAAQQQQAABBBBAAAEEfECAAN4HThJFRAABBBBAAAEEEEAAAQQQQIAAnvcAAggggAACCCCAAAIIIIAAAj4gQADvAyeJIiKAAAIIIIAAAggggAACCCBAAM97AAEEEEAAAQQQQAABBBBAAAEfECCA94GTRBERQAABBBBAAAEEEEAAAQQQIIDnPYAAAggggAACCCCAAAIIIICADwgQwPvASaKICCCAAAIIIIAAAggggAACCBDA8x5AAAEEEEAAAQQQQAABBBBAwAcECOB94CRRRAQQQAABBBBAAAEEEEAAAQQI4HkPIIAAAggggAACCCCAAAIIIOADAgTwPnCSKCICCCCAAAIIIIAAAggggAACBPC8BxBAAAEEEEAAAQQQQAABBBDwAQECeB84SRQRAQQQQAABBBBAAAEEEEAAAQJ43gMIIIAAAggggAACCCCAAAII+IAAAbwPnCSKiAACCCCAAAIIIIAAAggggAABPO8BBBBAAAEEEEAAAQQQQAABBHxAgADeB04SRUQAAQQQQAABBBBAAAEEEECAAJ73AAIIIIAAAggggAACCCCAAAI+IEAA7wMniSIigAACCCCAAAIIIIAAAgggQADPewABBBBAAAEEEEAAAQQQQAABHxAggPeBk0QREUAAAQQQQAABBBBAAAEEECCA5z2AAAIIIIAAAggggAACCCCAgA8IEMD7wEmiiAgggAACCCCAAAIIIIAAAggQwPMeQAABBBBAAAEEEEAAAQQQQMAHBAjgfeAkUUQEEEAAAQQQQAABBBBAAAEECOB5DyCAAAIIIIAAAggggAACCCDgAwIE8D5wkigiAggggAACCCCAAAIIIIAAAgTwvAcQQAABBBBAAAEEEEAAAQQQ8AGBxD5QRoqIAAIIIIDA7QsEmGvVAQGerR8WJhIW6llect2WgJ4KvXsQm1MSYk4LCQEE3AjE5lac/h3xt+QGkVkI+JYAAbxvnS9KiwACCCAQS4Hk1Z6VwEz5PFor5NS/cm35Dx7l9ZdMqVKlkiRJksi5c+fi5ZD0UsqQ2qFSMrNnu1t/LEBeXerhBRjPNkkuLwrcd19aSZw4UM6cOePFvST8TSdNmlRSp04tV65ckWvXrnmlwAGBAZL5RQ//kEwJTg47KWHBRPBeORlxvNFEiRJJunTpJDQ0NN4+m+/0EDJkyCDBwSFy4cL5O90U68cgQAAfAxCLEUAAAQQQ8FSgz0uvSI6cOW320NAQOX36tCyYP082bdoY4yYaN2kq1WvUijbfvLk/y5JfF0WbJ7YL3x34vrRs9YSUebC4nD17NrarJ+j8GkRVqFhJ9u3bK4cOHnSWtUfPF6VU6bLS7+3X5ciRI875dzJR/7HHpU7deuGbMDU5rl2/Ljt3bJdZM2fI+fNxe3HE3XEFBgbK8BHfyIkTx81xvXknh3Lb65YqVVqmz5orQUFBUqNqRTl+/Nhtb8uXVixUuLBkzZpNVq1c4Sx2o8ZNZcjQL2T3rl3SsEFduXr1qnOZL064O0ZvvOdy5Mghffq+6iQKDg6WE8ePy5w5M2XXzp3O+XE18VC5h+0Flr//2urc5AMlH5QXe78kc2bPkNmzZjrnx+fESy+/Kj169pZ169ZIq+ZN4nPXMe7L3edPtmzZZcmyVZIieXJp0byxbPjzjxi3Q4bbFyCAv3071kQAAQQQQCCCQOOmzSR//gISGhIiiUxApemF7r3kk4/el+FffB4hb+QXhQsXlVat20SeHeH1wYMH4jyA1x0EmPrsSZMmi7Avf3ihP87Hjp8sH74/SL4a8YXzkIoVLyH1Hq0vnw35JM4C+JIPPmjPn557bR+gd9A0dX3uBWnepKENrJ0FuMMJd8cVYJqKPNagoezf/6/ZevwH8BrMDR32pbn7nli6dHr2ngne9VR27NRVnnzqGalc8SE5fOiQzpJpUyfLw+UrSNt2T8lLJiAdNLC/ne+r/7k7Rm+859KmS+/8HHT9HNWLbs8/10UW/DIvTgl/+HGsHDyw31xkuXnxzWy9UKHC9vNh164ddyWAL/lgKfu9ceTwYenWuUOcHm9cbMzd58+xY0flua4dZcy4SfL5FyOkVvXK5m58cFzsjm24EYhNyxk3qzMLAQQQQAABBFwFLl28KPnz5pDiRfLLu/3esov0B3xyc2ciuqTBZKH8uZwPrYKsP+Bc5w0bOsRuImXKlCbgThrd5qJcptXlo0tp06aLbrFPLXME0ZEL/fJLL0rZ0iVk299/RV5kX9+JQftn2kkBc/71B6zefc2dO4/Uf6yB2/14MjOVqYatQbFrcndcwcFBUrpkMWn42H+BiOs6yZIlE324Jn1PRp7nujxNmvtu2bfrctfpuvXqS4GCheS3JYujvMik7z1tshFV0uPUfcY2aVXjO0369+TJ31R0743I5+WjDwaJfh60M8H97RzXnR6TN9Z3PcaY3nPu3ruelmnihHH2c/SB4oVl3NjREmjeGx07dfZ0dbf5ojt3rivMmztHypa6X4YOGew6207rxc7I51JNtOlIVEnXic17tNtz3e0FwCGffuy2KYq6xvQ5HlVZHPO1zPo9ElNydw5d3wOu6y9ftlQWLJgvefLklQaPN3RdxHQcCxDAxzEom0MAAQQQQEAFtO3rD99/J39t3WLvxrds/YTMnrtAnu0Q8Ueovtb5FStVtlWPtfqxPsJMNWx9OF7rc/nyFWXBot/k7+175J+d+2Ty1BlSoEBBJ/iL/3tJZs6eJzVMVXy9CzJzznzzo7eLDZoGDHpf1v25WXbvOyS/r/lTBr3/UYRgqmev3rJm3UbZ8vcOWb9hi92Gc8M+OKE/qD8dMsyWvH2HjtZYPVKnSSOdu3QTvfOWPn16u1zd5v2yWF557Q23Bu/0H2jX12rErum773+S6TN/viXI1fO2d+8eGTP6R5u9YKFC9rnsQ+XsdpxV7c1crbGh579psxY2T/Hi99vXn342TGb9/Iv8tW2XbNuxV958q59dHt1xffHlN/LGW+/YfPrfuAlT5Kcx42XE19/JVrMdfeh2HyxVytZMsO8js21dz/UiQZu2T8qq1X/IX//ssu+z70eNkSxZsjq3626iRcvWdvbnNy8yOfJoGX4cPU6+GP61eW/ttO/dKdNnSabM/7Xdzpgxo3zz3Q9mf7vtPleuXi9NTG2W6JIGRc8829Ger81/7TDHtlPmzl9kz4cu04eeG4ebY1t6LIOH/Fcb5sOPP5U/Nm6VXXsPys49B2TxkhUR9h3Te0ObTuhDk9b20HM5+NOh9rU2SRk9epT9O3usQXgeu8DH/ovuGF3fczG9dx+pU9f6RPUZWLlK1VtkLl68IIMGhL/3CxUq4lz++htvy9Tps8379r8Lkt2e7263nzlzFpsvpnP30SdDbGB9//0l7Hp67h5v2Fjy5csvo0aPF70opcmxHX0v6Weo/l38PG+haJORdwe+Jxs2b7PvP33vFDR37x1Jg1/dh36m6nt009bt0rtPX2ftHEc+1+cUKVJIA/Ne0SY/06dNcV1k/25nmCYq+pmwfde/svDXZbbc+t2hyROTRo2byG+mqru+3/U7RMukn2+OCwIxncPoPn+0DJ9/9qk+iePzwL7gvzgXIICPc1I2iAACCCCAwH8CGkho2rtntzxQ4gHp3rOX80en/mjq0etFKVasuGz/Z9t/K7mZ0uBx/KSpUswEeJs3b5J/9+0z7bsr2x+xjjtCere3TNmHZPS4idLYtMHNlSuXZM+ewwSrY6T9s50kVcpU8sv8uabN51V5+plnJYMJnBzp6fYd5OSpk7Jm9SobrL386uuORT75nCRpEjlwcL8tu1blPHzooBw9cliSGvPcefJI6dJlJMXNO1DqVuKBktK9x4tuDQ7s329/rHfo2MVpUaVqNVvNVjtsiqqqaKZMmWz+bdv+ts96PvRHf4aM4fN1pgbGOi937tw2TzZzvvS19kuQNWtWc0f7V7t9rYqvd7aiO66y5twXN8GII+kFg5q1HrGPNWt+lzOmTwbd7py5C6V0mTKmzfZy2++B9r9Q7uHydjV9X2jQoRc6Zs6YJju2/2Pb9n/x5VeOzbp9LmnaDWsb5Y0b/oywXMtQq3YdqWuaLPz5x3r599999kJUq1bhzUX0bt5PYybYIPjcubPy+6qVkjNnLhlmAn7XCx0RNmpe6Pt14KAPJFv27KJ3/tauWSNFihYTrd6r29S/O50uWqxYhFXLlCkrD5hz7Uj6PtA21pMnjrfHm9Oco6HDRogGMppiem9oXxfmSpvN+6/pa0HfZ3qMjjRpwng7+UDJ//bpWOYrz9Edo+t7Lqb37ra//76tz8C8efNZKsffkb7Ilz+/baKQLNl/NZFymfeN/u2kMe9dTTGdOz3vmq7fuGHPm547rTGh7yndTs6b/Zk4tqN/g9pEQt/jWs1dA379XN2ze5e9UFu4SBHp0PG/C7QjzQU+vRh2/NhxG4xrjYX/9XlZnnq6vd2vu//0811rG0yZMlFCtDnOzZTLfD5MnjpL9O9J32ezZ82wFx+0nFmyhF+w8MQkZ67cohcW5s+ba2s26OdXp85dpWev/9k9xXQOo/v80Q1oXwL6KFmy1M2S8+QNAQJ4b6iyTQQQQACBe1YgubmDoj+ytI213p3SwFDbJa9bu1bmm+BZA7aGjRpbn8ZNmoneLZoxfarbqpKuiF27PW/vkn7w/kBp2ugxeaRWVfujMKMJEls/EbHtvLb3fqBEESlXpqQsXbrE3N2vYoOr8uVKSbcuHaVO7eryfLfOcvLECecuunRqL41MO9AnWjW31aD1B6oG/76aTp865bwbNG7MaHu8eszR9Y4elYH+mNYf9npXyVENt1Pnbpbm+5HfRiBq1rylPPdCD3vHuXuPXrYDu8ULF0TI48mLKZMmSNVK5aXjs0/JO2+FX0zR91Rsj+uAad9bs1oleebJNtKh/ZN21ztM53rVKpeXZ55qKz26hx9HbRNka/qf6YhRe03X99eLPV+wbYP/MRcg9D2k7zV3SWsyZDedj2n1eXdJ+27QMjzVrrU0fry+rVWix6KparXqNhjSoKhqpYel7RMtTBv68ABH+4+IKvV6MTzgaPT4o/L0k09I547PyOrfV0aVPcr52vZZH8OGfWZrTMydM8teAHiwdOkI60T13li44Bf55Wa77LfefM2+z1z7u9BgXjtRLFHCdwP4mI4xApR5EdV79+jRIx5/BhY1F2O0psxbb/c3Fy6n2dpIU6dMirwrj15Hde4+HfyR7eFdA3D9bNDHsmW/RbnNTh2elqaNG0izJo/bC7KasaXpsK1Fs0bSuGF9OXXypNQyF8w06V1xrVGg26tTu5r878Uezs7oGpq74FGlEuYir6al5sKda+rc5TnRu/MjvhwmtWtWtdsb/PGHrlk8mv7um6+k/EOlbAeeE8aPdX5G6oVf1xTVOfTk82eJKbt+VsRUa8d1f0zHTiBx7LKTGwEEEEAAAQSiE9CqyFrN0ZH0boT+eNO7tBrsNWzURDqaOx56d1Ort2v6/rtvHNmjfNZO7jTpj2lH+nXxImneolWEapu6bNT3I+XypUs2m+NOogYZly9ftvN0aCJt5+maNm/a5Hypd1L1rmnmLJlFf3TfKyk6g0kmoNY7VW3aPSkLf5kvtR+pIzt37pAVy5dF4NHz4Zrq161lRyNwnefJ9D+mRobesdO0y+xHk6NqsH3h4X96kUZ7ptekF5I0afVcx4gD+2/eLdYq7fqDW6uza1q+cq191v8c7db1jqT+gI+cHHf9D5o7mO6S3unUTq406R0/fZ355l3DwoWL2PlLTPDvqMmgptpkxLU6ss108z8to1po4LV1y2bXRbGefsbcye9h7j46jtuxgWTJkjsm7XN0740IGd28UG/t2fxeSdG9dz39DNSA0jWofP3VvmZEh+m3RXgn5851h1u3bLEvtYmM/i1pnw+O95/eLdf3v+Pz1vGszZm0CYxrypEjp+vLCNP33wzg9aKXaypevLh9OWPaVHsxw3VZbKa1pswHHw0Wx34c67rWZNB50Z1DxzpRPWtNBk1aa8zx2RNVXubfngAB/O25sRYCCCCAAAJuBUJMoP5ct072LqZWvdY7oBowa9KhdbT6u1Z71Lu0+qN+5YrlNhB0uzGXmVqtUtO1q1eccx0Bj+353Dk34kRiU2Vc01XTJt/TFHQzcPQ0vz/mi2zw4w8jbfXY9u072qq5WkX7h0h339Xhua6dbBVbbcagdxF1aMG+L/WOQBRoqnjHJgWZ91RcJMf7xXVbOm6zJg1KkiZLaqd1+Lfhw8LbcdsZN//7d9+/ri+d07pubJLaaq/1mhzvz+tm2D1H0nKqkePvxjHf8ZzsZoeQF29epHLMd1eORInC9+PI4/qsd0j7vTvIBhkD+r9tqv7+ZdsZv2nu+kaXIr83HHlNy3vH5C3PjqY0tyzwsRnRHaO7Q4n83vX0M3C2GX5RazT06t3H3ol/vntP20Fa5AtI0Z1f9+UJvyjmuux2zo3j78Z1O/rZ70hJb3YYqRdZl/4W8W762bNnHNlueXb3HtZMyVOEdzh30dQEiilFZaJNS7Rtf7q0aeXHUSNl2dKltumAtqWPLkU+h9HlZVn8CMTuGyR+ysReEEAAAQQQ8FkBHe9Z75Jru1ytPhs5CHEEfdrhkKbIVbCjOnBt96ipRs3azixaTVOT4+6mc4HLhN6l1BS5PbEGl64dQLms4jeTjqAwbbqoe4j29GD1QsziRQtF20hrO3G9gz3DNH2InC5fvmTPx7OmN3q9+9TqibZ2GDHNd+H8BZs9Z85cztWyZA1vv+qc4cFEXB6X6+501AN9/2pVXX0Pj/5plPPxh2m/fuVKeA0O13V02tF/g7ZBjm1yvK+rVavhXFXvvCYyAf6xKGp/HD92zN6t17bsjo4ItQf5dOkzOLehgZA2e3C0Y9YF2vzBcZFCXz9kmrpo0r9BfWg/ARcuhJ8ju8DD//47H+ncrqHtlx21KNxm8IGZMR1jbA7Bk8/AK+ZC5fnz5+S9gf1tvx3a/8NPJvh01Aa5cP683aX2K6FJg3DXjhHtTA/+u3HjutxnAtq4To7PXS2X69+RVlvftm1blLvT5iqacpm26q7p0M078tVr1nTO1jbvrikmk3z58kuGDBnkbzP6Rr+337SjRRw5csRZ88V1W9FN//decO+m7ew16SgcJO8IcAfeO65sFQEEEEAAAbcCP8+ZLW++3c9WV95neiqPqt1w5JW1HXeTps1lgOm4q0LFSpI6dRrRXp014Jo2NWJvxa7ranVkre6p7fK192Hdv3a29Gj9BlK9agXXrH43vXnTRhvEtW33tFy/dt1W2/7gvYG3fZw/fP+t7dtANzBu7E+2lkVUG9NguOOzT5uOp2bau4h6kUXb8GozBm1CkTJVKtHArm7dR6PaRJTz4/q4HDvSi016jNqZ35x5C8TRAVv5ChVsh4k6pJf2Ch456cUMbWpRyzQreP+9AZEXR/t66W9LbJX+atVryLQZc+SQqX6rzRM0OXrxj7wBra78s2mrrj33r/x9vW1nXKpUGevpyKsBvLbF1Q76tBf+8ybga/B4owhDgK0yHeb1NStorQqtkp/ddF722GOx7y1+1crltjnMgIHv27IEm+r/jnbwGjTpSAMrzAU9X07RHWNsjys2n4H6ntS+GCZOmSHaAeFX34y0f1eLzZ3t1m3ayVAz2oZ+xlWtWi1CB46elmnVyhWi/Vbo6Ax6d/vXxQs9XTXafMuW/mZrVul7WUddWLpkiejFujp1HrV9Imh/EO6SBtea9G9Ja2s5kja50uZXH308RBo1airJkieznUE6lutzTCb6PaCfS9rr/ieDPxMNxPVvwnUECtftRTUd1eeP47Ohdu1HbFMbqs9HJXjn8wng79yQLSCAAAIIJGCBayt/MqWLumprxKLHripwxHXFttvVHo2jS9qued3aNfbHmA4zF1WVycjbWLt2tWg70Lf7DbA/OHX5yZMnpE/vns526u7ukGqHZNr5kv7w0165tUqqJu0R/KK52+huncuXwu+0Bt24tbqpXfkO/+v7m/YS7tlGQu/glGg7au2crFu3F+zwTWr9xeefySVzfDodHBRe5dVTg/Xr1jrvVo3+cVSEA3CYuc7U9rE9TSdx3438UQa996Ho+p+ZsZ2fN52zaXt6bfqgY9FrU4obpqyu6ZK5kx856fFoiuq4dBtBQf+9/3Ta9XWowdRqvnrX0ZFCQoKthWPbn336ickTIp27Pic9TUdx+iM/iWm+oUGS63qO9R3Pf23daobdetQGWRs3bnDMtvt3LYMu0PdVaGCIzaPb1w7oho/41vaEr73haxmHfzFUdCzwqJJWedeAW0di0KG/tIaEVr13DUb0YkTBggXtct3OJnNBR3udd1hrde7x48bYzgm1wzTdr96R1AsrQTf/jj15b2gzmEULF5je/mvbC2W6XUcA/0TbdvYQtprhJOM6hZnzefLzkx5vVvPfborqGCO/53T70b13dXl0n4FXbvbT4eivQ/M7PsNmzZlvayC9YDqH1M7YdESNOuYCWEHTFv2SaU5x1Jw77Uzxxs2/AU/OnV4k0tpIOjqDpoPmfbRr1047fePm55+77eg8LVdISHjzKLuC+c/xN6J/T9pp5MBBH9r3hQ4Bqkn7gFhranpElXTUB30fanm0GYuj2Yu+v/Rv4rnne4he7NILt9oHR5EiRZ2bWm46zIvORC98vf/eu/LWO+/aix+6ol4k0A7nHMfq2Fh05zCqzx8N4LXTVn0sM52nkrwnEGCqHt3+X7P3ysWWEUAAAQQQ8EsBHUd3zfqN5odfsFQoV9qOFx+bA9UAJX+BAjYI0jsqnl4A0H3o8EHZsmUXbeOs1YvvlaRmWm391OlTzs79bufYdWxyHd5MO9Pq1eP529mEXUebLhQpWtQOB3UlFn0TRN5hXB1X5O3qa636q53a6ftLh3e7EcOFKQ2MZ8yeJ3p3Tnvpjs370rH/HCb4SpIkqW2C4Kim61gW1bNWCVZPvds3euwEG+AVyJsjwhBc+p7X8uj73l3Sv0ntxO706dM2wHKXx5N5up370t5nqv5rFf8gO1yhjg2u+61rRn7w9Jg82dfdyhP5GG+nHHf6Gei6T20WoU0+9PxHbq7kmi+maX3vBZkLenpRNK6TNu/IkCGj/ZvS90JM5dTmVdpHijYf+NZcqHBNuq2s2bLZO+k6KsYnnw61Fwlnz5rpzBaTifY/ocPVaVt8vSN/u8nd58/kaTPDh4ls0cResLzdbbNe9ALcgY/eh6UIIIAAAgjEqUC7p5627Ti/+erLWAfvWhC9I6O9xN9O0p7pHW0zb2d9X11HzfRix52mzl3Dg3ZPRg2Ibl8a3Omd9ztNcXVc7soRXcDrLr/e3R435ic7Prt23KdDdMU26d3v2KbohgV0bCu6PiI0j94V1cedJtftaFA57IuvJLnpcO+tN171i+A9rqzu9DPQ9TxpO3l93Gm6nfeep/vUi18xvQddtzX0s8HSqHFT6dP3VRsEu9Zo0W0dPHDANfst0zGZ6J14HR3lTlPkz5+evXpLhQqVbM0ZrW1E8p5AIu9tmi0jgAACCCCAQGSBggUKinZU9OOP30dexOsELJAuXTpblVzbXru2TU3ARY73on304fu2aYZWpc+dJ0+873+b+bvaYpotxHSHMz4KpsMJahA/+scfbIeW8bFPX9kHn4HRnymtHv+mueijHTx2e757lJm1Zox+l5w6devQjlGu5KUF2bPnsE1V9GLDB7HsB8NLRfLrzVKF3q9PLweHAAIIIIAAAggggAACCCDgLwLcgfeXM8lxIIAAAggggAACCCCAAAII+LUAAbxfn14ODgEEEEAAAQQQQAABBBBAwF8ECOD95UxyHAgggAACCCCAAAIIIIAAAn4tQADv16eXg0MAAQQQQAABBBBAAAEEEPAXAQJ4fzmTHAcCCCCAAAIIIIAAAggggIBfCxDA+/Xp5eAQQAABBBBAAAEEEEAAAQT8RYAA3l/OJMeBAAIIIIAAAggggAACCCDg1wIE8H59ejk4BBBAAAEEEEAAAQQQQAABfxEggPeXM8lxIIAAAggggAACCCCAAAII+LUAAbxfn14ODgEEEEAAAQQQQAABBBBAwF8ECOD95UxyHAgggAACCCCAAAIIIIAAAn4tQADv16eXg0MAAQQQQAABBBBAAAEEEPAXAQJ4fzmTHAcCCCCAAAIIIIAAAggggIBfCxDA+/Xp5eAQQAABBBBAAAEEEEAAAQT8RYAA3l/OJMeBAAIIIIAAAggggAACCCDg1wIE8H59ejk4BBBAAAEEEEAAAQQQQAABfxEggPeXM8lxIIAAAggggAACCCCAAAII+LUAAbxfn14ODgEEEEAAAQQQQAABBBBAwF8ECOD95UxyHAgggAACCCCAAAIIIIAAAn4tQADv16eXg0MAAQQQQAABBBBAAAEEEPAXAQJ4fzmTHAcCCCCAAAIIIIAAAggggIBfCxDA+/Xp5eAQQAABBBBAAAEEEEAAAQT8RYAA3l/OJMeBAAIIIIAAAggggAACCCDg1wIE8H59ejk4BBBAAAEEEEAAAQQQQAABfxEggPeXM8lxIIAAAggggAACCCCAAAII+LUAAbxfn14ODgEEEEAAAQQQQAABBBBAwF8ECOD95UxyHAgggAACCCCAAAIIIIAAAn4tQADv16eXg0MAAQQQQAABBBBAAAEEEPAXAQJ4fzmTHAcCCCCAAAIIIIAAAggggIBfCxDA+/Xp5eAQQAABBBBAAAEEEEAAAQT8RYAA3l/OJMeBAAIIIIAAAggggAACCCDg1wKJ/froODgE/FggR44ckiRJUrl+/bocO3bUj4+UQ0MAAQQQQODuCyRKlEhy584TY0FCQkPk7JkzUqRIUbly5Yrs2LE9xnXIgAACCHgqQADvqRT5EEhAAunSpZPlq9aZAD6JXL50ScqWLiHXrl1LQCWkKAgggAACCPiXQPnyFWXS1BkeHVSnDs/I96NGy6WLF6VE8UIerUMmBBBAwBMBAnhPlMiDQAITaNS4qQ3etVipUqeWR+s/JrNmevajIoEdCsVBAAEEEEDAJwROnDwhv69a6SxrylSppHTpMva16/zQ0FDZ/++/su3vv+Ts2bPO/EwggAACcSEQkD59+rC42BDbQACB+BOYMWuulH2onL3rnjx5cln626/S/ul2URYgdZo0cu3qVQkODnabJ2nSpJI4cWJb1c9thjucqdtOlz69XLxwwVb5j25zMZU1unVZhgACCCCAQHwJZM6cRf7YuNV+dxYvkj/Wu82WLbucOXNabty44Vw3ceIkki17Njly+LDohYCoUo6cOeX8uXNy+fLlqLIwHwEE/FSATuz89MRyWP4rkC9ffhu8h5hgvFuXjvZAq1evKZkyZ45w0BqUv/bGW/L7mj/l7392y1/mMW7CFGnUuIkz36P1G8i8XxbL9p375O/te2TB4qXS56VXJGXKlPL0M8/K1OmzpXqNms78OvHGm+/Y+UWLFrPz9QeI5hs67EupVLmKfDx4iEyeNlMGvfehdOzURZYsXSk7d++XPzf+Zfcz2VQ/rFixcoRtRlfWvi+/ZrffqnWbCOvoj5zR4ybaZVoGEgIIIIAAAglFQIN7/W4c/OlQZ5EGvf+Rndft+e6yeMkKWfvHJtm4eZu89XZ/+x3+0SdDZNPWbbJq9R+y+a/t0qRpc+e6OqEX7PsPeM8s2yGr126w3+uzfv5F7i/xQIR8vEAAAf8WoAq9f59fjs4PBZq3aGWPauXK5fbO+/79/0revPmkqfmiH/ndN3aZdrQzfuJUebh8Bfv6jOlMR1PVatUlU6ZMMmf2LOnUuau803+gna9X/08cPSoalBcrVlxmzpgmuXLltusXLlxEli9bavPpf0WKFrXzM2fJYjvm0R8Uuh99NGve0pkvTeo0kiFjRilYqLAcPnRItOphHtP5TwUTvP80doI8Vq+27N27R2Iq68QJ4+y2s2XPLtOmTnbekdALETVq1LJ3KU6dOuncLxMIIIAAAgjcbYFkyZPZ7y79znWksmUfkhIPlLTz9e76qZMnbeDepdvzog9NV01tuYsXL8h996WVge99IHN/nm1rz+l35Zjxk0Tb4YeFhcnOnTvs97RW4dcL4zWrV7bbc+yLZwQQ8F8B7sD777nlyPxUoFmL8CDZ0eZ99qyZ9kgdgb2+aPVEG/sDQXu/7dThaSlX5gEpW+p+6fFCV1myZLH9wfDKa2/a9b4eMdwsLylVKpWTeo/UMG3pp8v5C+ftstj+t2jhAnmybSupVrm8PN+ts3w25BO73coVH5KmjR6T8uVKydo1v9u7CHq3XlNMZZ08aYL9MaM9/9Z79DFnkbp0fc5Ojxo1MsqmAc7MTCCAAAIIIJBABKZMnmi/lx8y3836PalJv6/79nlRShQraL+TNUBPmzadlCtX3i7X73gN3o8fP2a/V+vWrm6/1//8Y72kSXOftGkTdTM6uwH+QwABvxHgDrzfnEoO5F4QKPdwecmTJ69tR75gwXx7yLNNwN2zV297VV+HrNEvff2S17R82W+yeNFCO63/6Z13fdR+pK4NonUIus+Hfups+67r9uoRfhfAuZKHE3t275LOHZ+JkFurxj/1dHupZqr4a7n1jrz2oK/J9L9hn2Mqq2aaMG6sdH3uBencpZv8Mn+uVKxU2R6vtv3TZSQEEEAAAQR8ReCbr7+U06dP2+Iu+22J/K/Py6LfoRrYawoJCZG1q3+3w9AVv/9+WWMufFeoEP69niJFCulmvg8dSdvCaypQsJBjFs8IIODnAgTwfn6COTz/EnDcZU+WLJnMnb/oloNr3rKVfPj+IDNObW67bO2a1bfk0Rm5bi7fumWzM3h3mzEWM0NDI/aHqVXrZ86eJ8XvL2Gr+2lV/61bN9tq+q5t1mMqqxZB77JrlX+tpv9gqVLSpWv4RQbH3flYFJOsCCCAAAIIJBgBrTLvLkWen9tcBNekVetbtorYJ4xezA4KCnK3GeYhgIAfClCF3g9PKofknwJ6N7tho8b24LR32oCAAOfjxInjdn7TZi1sm/Ljx0/Y11F1bHP82DG7XNuza2dw0aXkyVNEtzjKZdpRnQbv50wvuQ3q15EaVSvKM0+2kbFjfoqwTkxl1cx6vPPNnXdN733wiTxSp65tC//DyG/tPP5DAAEEEEDAFwW0Pbu7FHn+yRPh3+sD+r8t9xctcMvj1Zf7uNsM8xBAwA8FCOD98KRySP4poNXetT2cVrurVqW8VK9Swfl47NFHRHulz549h61ermPPanqkTj1bBc8hUrhIEVsNffs/2+wsvZLftt2TEhgYaF/rmPK9evexV/j3mA7mNJWvEN4Rnk7r3e/ChYvqZIwpT758Ns9ZM0SOozxabb5KlWoR1nUsi6qsjsyODvoefLCUvXCxaNECOXBgv2MxzwgggAACCPitgNZg0/R8956SO08e53Fq53bagWzNWo845zGBAAL+LUAA79/nl6PzIwGtHq9pzuwZt3Tapj3ZrlixzC7XavajR4+So0ePSIYMGWTRkuWiw8zo0G4LFy8THY5Nq7Nr7+6adFib39f+Kd+PGiPr1m+Sl/q+anuqX2Ta2Ieadnj6o+CXhUvsEHOzf17grH5vV47mv80bN9il+QsUlBW/r5NpM+bIKjOknaPzOseqMZXVkW/jhj9lw59/OF7KyG+/dk4zgQACCCCAgD8LjP5plOzbt1d0eLolS1fJj6PHyWgzosu6PzfbYVxLlynjz4fPsSGAgIsAAbwLBpMIJFQBrS5fyXTcpmn61Cluizl9Wvj8ypWryuVLl6Rt6xaycsVy2/5ch5mpUKGSXLp00XQCN8+u3+/tN0R7oNeO7LRNep269SRlqlTy25LFcsbcNT979qx8dzNI1qrwOrzcjh3b5eDBA3b9a9eu2edLly/ZQP9CpJ7rN2/eJO/2e8teSNAO7LQDPt3XoYMH7Xo6rcmTstqM5j/dpiZtu79u7Ro7zX8IIIAAAgjcDYHg4CD7/ef4PnMtg363ac0412WO6RvXbziz6jCumhzLHAscrx3P+p37RMtmoiPP6F33WrVN07SatW1A/8+2vyNc4HZsg2cEEPBPgQBTpdV94xv/PF6OCoF7TkB7rNUA+vKVy3L0yBHbu60rgv4Q0CHakiZLaoPryB3nZMqc2Y4zr+3Q9a5+bJNuX6u964+P3bt3m9oDUXe0E11ZtQ+A1Ws32CHwtKd8He6OhAACCCCAwL0mkDhxYvu9rR3aHjp8SC5dvHivEXC8CNzTAgTw9/Tp5+AR8B2B1maM208GfybHjh2VKhUfjvZCgO8cFSVFAAEEEEAAAQQQQMBzAarQe25FTgQQuIsCOp68pp9G/UDwfhfPA7tGAAEEEEAAAQQQuHsC3IG/e/bsGQEEYiFQsFBhuS9NGtsO/8qVK7FYk6wIIIAAAggggAACCPiHAAG8f5xHjgIBBBBAAAEEEEAAAQQQQMDPBQJNp1H9/fUYtXOPoZ9/ace43rlzxy2HWf+xx6XvK69J9x4vmrGzq8hl05u2Dq/lmjzJ45qfaQQQQAABBBBAAAEEEEAAAQS8IeCXd+B17OuHy1eQFi1by6P1G9ihsAYN6BfBr1nzlvLZ58MlLDTU9Kx9VLLnyCFmvC3p0P4pWbp0ic3rSZ4IG+UFAggggAACCCCAAAIIIIAAAl4S8MtO7Mqb8a6/HfmjDd6jcuvUuavo2Npdu3SQyhUfktdf7SuJAgOlQ6fOzlU8yePMzAQCCCCAAAIIIIAAAggggAACXhTwywB+86aN8vZbr8v3I791S5cxY0Ypacal3rN7lyxauMDmmTRxvJw9e1aqVathq9x7ksftxpmJAAIIIIAAAggggAACCCCAgBcEEnthm3d9k0ePHpHRP/5gg3S9ix45ZcmS1c7asmWzc1GYqT6/ZcsmqVGjlmTIkFEyZcoUY56TJ09IYJJkzm0wgQACCCDg3wJhoSESGhLs3wfJ0SGAAAIIIIBAghXwywA+Ju2MN4PzCxfOR8h68cIF+9p07Cee5NHM6bMXjLANXiCAAAII+K/AtUtn5dKZo/57gBwZAggggAACCCRogXsygA+6EWRPSqKAiC0IAk0beE2JkyQRT/Jo3lMHtumT5ylRoAQk5q6952DxlDM0WMKCb3h1Z4kCRFIn9eou2PhtCISEilwO/0i4jbU9XyUgeYDtd8PzNcjpbQGteRV2Lczbu2H7CCCAAAJxIBCQxHyPJjY/pkgJSiDshvkuDeG7ND5Pyj0ZwGvVd02Ou+wO8MyZs9jJUydP2h7pY8zjWDE2z6b6ZYpa3WKzBnnjQeDKomFe30ty89f2ZqUwyZWGDzmvY8diB8/8HPFCXixWjVXWFKVSSIoHUsRqHTJ7V+DqX1flytor3t0JW0cAAQQQiBsBc8E9fbv0cbMtthJnAqe/Px1n22JDngnckwH8kSOHzZjvl6VCxcqSMmVKuXLlimindaVKl5ETJ46LVq2/ceN6jHk8I741V0AqPnxuVbnLc8yIBPGRMqcIk+yp4mNP7MNTAXvq4+GaSqIUiSQwbXgtH0/LRj7vCug5ISGAAAII+I4A36O+c64oqfcE/DKAz50njzRp0kxy58lr5cpXqCg9er4oW7dskWXLfpNr167J7FkzpG27p2TMuEmyfv1a23ldElN1ftKE8XYdT/J477SwZQQQQAABBBBAAAEEEEAAAQQiCvhlAF+4cFF5+dU3nEdaqlRp0cfECeNsAK8LBg7oJ9mzZ5caNWtLuYfLS2hoqMyaOV2GfT7EuZ4neZyZmUAAAQQQQAABBBBAAAEEEEDAiwJ+GcAv+XWR5M0VPlRcVHaXL12S9k+3k/vuS2urz58w7eJ1nmvyJI9rfqYRQAABBBBAAAEEEEAAAQQQ8JaAXwbwscHS9u6Rh5OLvL4neSKvw2sEEEAAAQQQQAABBBBAAAEE4lKAHnziUpNtIYAAAggggAACCCCAAAIIIOAlAQJ4L8GyWQQQQAABBBBAAAEEEEAAAQTiUoAAPi412RYCCCCAAAIIIIAAAggggAACXhIggPcSLJtFAAEEEEAAAQQQQAABBBBAIC4FCODjUpNtIYAAAggggAACCCCAAAIIIOAlAQJ4L8GyWQQQQAABBBBAAAEEEEAAAQTiUoAAPi412RYCCCCAAAIIIIAAAggggAACXhKItwA+efLkkixZMi8dBptFAAEEEEAAAQQQQAABBBBAwL8FEnvr8GrVriN16z0qlatUlWzZsosG8Ddu3JBEiRLJqZMnZf26tbJkyWL5ec4sCQoK8lYx2C4CCCCAAAIIIIAAAggggAACfiEQ5wF8gQIF5b0PPraBe2ShpEmTSkBAgGTPkUMaN21mHz169pY3XntZ1q5dHTk7rxFAAAEEEEAAAQQQQAABBBBA4KZAnAXwGpx37/GivNCjl+h0cHCw/LbkV5k5Y5r8/ddWOXz4kISGhkqWrFmlUKHC0rhxU2nweCMpVLiwTJ42U6ZMmiDvDXpXzp49y8lBAAEEEEAAAQQQQAABBBBAAIFIAnHWBv7R+o9J7z59bfA+f97PUrXSw9K54zO2ivy+fXtt9XkN6o8cPizLly2Vvi/1lofLlZKR330jIWZ+qyfaSrfnu0cqHi8RQAABBBBAAAEEEEAAAQQQQEAF4iyA141pgP5izxfkua6d5OjRIzor2nT50iUZ+O470qJ5Y+68RyvFQgQQQAABBBBAAAEEEEAAgXtdIM6q0K9ZvVqeaNVM/li/LtamGzf8Kc2bNpQkieOsOLEuAysggAACCCCAQOwFChcpIk2aNJcHSpaULFmymg5qf5XBH3/g3FC+fPnl+e49pfj9JeT8uXOycuVy+e6br2yzOmcmJhBAAAEEEEDAI4E4i5hPnjwh+rjdtHfP7ttdlfUQQAABBBBA4C4INGrcRD759HNJkSKFXL58Wa5euWL6uSnkLImOQjN91lzJmDGjHD9+TAoXLiLVa9QUDepff7WvMx8TCCCAAAIIIOCZQJwF8NHtLkmSJNLIdFpXrFhx2wv9tWvXZM7smbJz547oVmMZAggggAACCCRQgbRp09ngPVmyZLY53Pcjv5WwsDAbzDuK3Kx5Sxu8z5g+VXr36i7Zs+eQX39bIa1at5EP3x8k58+fc2TlGQEEEEAAAQQ8EIiXAH7cxClSoUKlCMXp1buPzJ45Q3r2eC7CfF4ggAACCCCAQMIXaPfk0zZYX7jgF9shraPEV69edUxKrdq17fTXI4bbZ+0fZ9asGaLrVqlaTebNnePMywQCCCCAAAIIxCzg9QC+YqXKNng/ceK4TJo4QczleUluqtq1a/eUHQd+xIgv5J9tf8dcUnIggAACCCCAQIIRqFqtui1L6tSp5YvhX0uy5Mlk3969Mnr0KDl86JBdpm3ir1+/Ljt2bHeWe9OmDTaAz2qGlSUhgAACCCCAQOwEvB7AV6lSzZZo+Befy0+jvneWLpkZK/6ZZztKwYKFCOCdKkwggAACCCDgGwK5cue2Ba1UuYocOLBf0qS5Tx6t38BWj2/auIGdl8G0fb908aKtWu84qosXLtrJFClS2ufkqdNJkmSpHIt5RgABBNwKXDp/VBIlTuJ2GTPvokCASJoMOWNVgIunD8cqP5kjCsRpAP/U0+1l186dsnbtaudeTp0+ZaerVashixbMlzNnzkiOHDml7EPl7PyzZ8848zKBAAIIIIAAAr4hoB3TXbhwXurWriHHjh2VxGYkmQ8//tQG8K3btLM90QcHBYvp/CbCAQUGho9gmzhJ+E+Q0JAQCQkJipCHFwgggMCtAmFmlj5ICU2Az/D4PSNxGsC3NJ3SlClTVpYt+00++egD2bplsyxf+ptop3V16z1qH66Hpz3Sbt68yXUW0wgggAACCCDgAwJHjx6VQqYW3alT4Rfqg4ODZf68n20AnzNn+N0YHZ2mYKHCktTUurtx44Y9qkyZMtvnkyfCR665cfWi6IOEAAIIRCcQEBggoeZzhpTABMw1lSvnbn8ksgR2ND5RnPDL4HFU1HFjfrJDydWoUUvmzF0gX30zUgITB0q7Ni1l2tTJcvnSJbuns2fPypJfF0v7p9raqnVxtHs2gwACCCCAAALxJLBn9y5JFBgY4eJ8qVJl7N7PmfHeNe00tfJ0JJpq1WvY1/pfrUfq2OndZn0SAggggAACCMROIE7vwE+ZPFF+njNLOnTsIs+90F0aPN5I6pv2cNOmTZEhn34sfXr3lEDzZR9iqsuREEAAAQQQQMB3Bb75eoTUf+xxGfzpUCle/H7RNvH6vR9i7pDNmD7FHtjkSeOlcZOm8sngoTLWXOTPmy+f6EX+vXt2y/p1a3334Ck5AggggAACd0kgMEWKFP3jct9ahW79+rXmi3q0hISGyoOlSkvp0mXkmfYdJFPmTKZa/Ra5cuVyXO7S57aVtHgtnyuzvxc4aMcy06wq1KuHmSRQpEGBMEmX3Ku7YeOxFBjzt6mSFw9N6pLmSypJstP5TixPj1ezBx0Nkhv/hlfr9uqO/HTjx0wVeq0iX71mLdGO7EqUeEAunD8vff7XS1atXGGP+sD+/eY7/4oZTq6OlK9Q0ebZt3ePdOrYXugDx0/fGBwWAl4SCEgUIKkq0uGll3hve7OXV9/bcd1tw93BigHp06f36k/XjJkySY+evUU7uNM2cDo+7KgfvpOvR3wp58+HV7G7g/L75Kqpmg/wyXL7c6EvzzLnJMS77apSmthteJ1QyZfWnyV979jqTU4kwd69dmNRUtdMLSnLhve67XtK/lniKxuuyKWl4U27/PMI4+eoEpteobNkzSKJEiWSI4cPS6i5eB85aZ5M5vdAgOnQTseCJyGAAAKxFdA28JlfDO9DI7brkt97AieG0P7de7rutxynbeD1C7pDx84yZfosWbDoN1nx+zp5861+pr37IqlRraIZB36c6PBxL3TvJStXr5OevXqbXmu5I+X+1DAXAQQQQACBhC8QHBxkA/dDBw+6Dd71CDSP9lRP8J7wzyclRAABBBBI2AJxGsC3adtO+g94T8qXryjFTHu4PHnySouWrWXs+MlSuXJVeaVvH3mkVjXbTl7Hi+37yuuSOTNX0hL2W4TSIYAAAggggAACCCCAAAIIJASBOA3g9c66pjdff0UaP/6oNGxQT0Z8OczOa96ilX3ea9q+dX++qzSoX8cG8jduXLfz+Q8BBBBAAAEEEEAAAQQQQAABBKIWiLNe6LV3+Rxm3Fft0EZ7mnUkDdg1sM+ePbtjln3e9vdfNpCPMJMXCCCAAAIIIIAAAggggAACCCDgViDOAngdGk47r8mZK5f0e3eQHR4mMDCRHWJG97xly2a3BWAmAggggAACCNyZQKrUqSV3rtyiHcfqBfXr167LqdOn5MD+fyUoKOjONs7aCCCAAAIIIJBgBOIsgNcj+vabr+Tdge9Jx05d7MNxlGFhYTJieHhVesc8nhFAAAEEEEDg9gW01/cn2rSTZs1bSLly5SUw8a1f6TqEmw7pNnb0j7J06ZLb3xlrIoAAAggggECCELj12/4OivXjqJHy+6oV0tT8mChW7H479uuZM6dk8qSJsmPH9jvYMqsigAACCCCAgEOgxAMl5YOPBkupUqUds+TixQty+NAhO0RrpkyZTbO2XJIyZUqpW+9R+5j782x5t9/bcvz4Mec6TCCAAAIIIICAbwnEaQCvh75z5w75+MP3fUuB0iKAAAIIIOADAnrX/c23+0tHM2RrIlNV/ty5czJ1yiSZMX2q/LV1S4Qj0LyVq1QV7US2cZNm8njDxlKjRi0ZNLC/TBg/NkJeXiCAAAIIIICAbwjEWS/02v6uQIGCt33UmTNnkfz5C9z2+qyIAAIIIICAvwskT55cOnfpJgEmOJ80cZzUrFZRBr77zi3BuzqEhobKyhXLpU/vnlKvTk1Z/fsqSZ0mjXTs3NXfmTg+BBBAAAEE/FYgzgL42rUfkTlzF0jFSpVjjZUvX36ZMXuuPGHGkSchgAACCCCAgHsB7VMmJDhY+vZ5UV7p20fOnj3rPmOkuXv37Ja2T7SQUT+MFN0GCQEEEEAAAQR8UyBOq9Drlf3xE6bIqFHfy5DBH8nly5ejVdGecp/t0Ele6vuq6B18EgIIIIAAAghELXD16lUp/3BpOXXyZNSZoliigXv/d96UTJkzR5GD2QgggAACCCCQ0AXi7A788mXLZMqkCbZNnlbvW7n6Dxkw6H0pU/YhSZYsmdNBg/aChQrL//q8LEtXrJZ3+g+0wbv2kjthHG3ynFBMIIAAAggg4EYgcvCeIkUK0YdrKlCwkB3GtdzD5V1n2+nI69+SgRkIIIAAAgggkGAF4uwO/Pnz56TvS71lyuRJ8v6Hn0ihwoWl/bOd7EOP/vSpUxIUHCRZTFt37XjHkXT+ANN+b+aMaY5ZPCOAAAIIIICABwI5c+WSVeaCeUBAgNR7pIYd8eWtd96VLl2fc649ccI4efXlPs7XTCCAAAIIIICA7wrE2R14B8Hataulfr1a8ubrr8jS336Va9eu2UUZM2WSbNmy2+A9NCRE/vxjvXzy0ftSq0YVgncHHs8IIIAAAgjEQuCROvVs8K490OtwrTly5rRN03QTwaatvKY2bZ+U8hUq2mn+QwABBBBAAAHfFoizO/CuDEFBQTJ2zE/2ocPYpEuXTjJkzCiJAxPL6dOnTac7Z5w/LFzXYxoBBBBAAAEEPBfImzefzTxr5nT7XMcE9EmSJJGTJ09IxYfLSv8Bg+TpZ56VqlWry7q1azzfMDkRQAABBBBAIEEKxPkd+MhHqcPYnDlzRnbv2iXbt/9jf1Q47gpEzstrBBBAAAEEEPBcIE2a8A5gT5w4YVcqVbqMfZ4/92dzoTzIBO2r7escOXJ4vlFyIoAAAggggECCFfB6AJ9gj5yCIYAAAggg4OMChw8ftkdQvUZNyWhqutWv38C+3rhxg33OlCm8x/krV6/4+JFSfAQQQAABBBBQAQJ43gcIIIAAAgj4qICO4KKpRcvWsmHzNtHhXC9cOC9Lfl1k5z/2eEP7fGD/fvvMfwgggAACCCDg2wIE8L59/ig9AggggMA9LPDH+nXy46iRTgFttjZk8Mdy7tw5qVmztpQvH9553coVy515mEAAAQQQQAAB3xXwSid2vstByRFAAAEEEPAtgX5vvynjx46RfPkLyIY//7B9zegR7N6zS/r2eVGuX79m+6DxraOitAgggAACCCDgToAA3p0K8xBAAAEEEEigAjrme1hYWITS6RBy+nBNhw4elCkHJ7rOstM6OozeqSchgAACCCCAgO8JeK0KfbFixSVr1my+J0KJEUAAAQQQSKACyZIlk9/X/CllHyp3WyVs3aadTJw87bbWZSUEEEAAAQQQuPsCXgvgX371Dfl97Z8yfMS3Uu7h8nf/SCkBAggggAACPi4QGBgoOXLmlPETp0r7Dp1E76Z7klKlTi393h0knwz+TNJnyOjJKuRBAAEEEEAAgQQo4Nk3/20U/MqVK5I4cWJp1LiJTJsxR+bOXyStWrcRvXtAQgABBBBAAIHYC9y4cUNW/75KUqRIIQMGvi9z5i6wPdCnSpXK7cYyZ84inbt0kyVLqwAf0gAAQABJREFUV0rHTl1s1ftlS39zm5eZCCCAAAIIIJDwBQLSp08fsSFdHJVZ7xLUfqSOPNO+o1SrXkO0zZ6mM2fOyITxY2Ts6B/lyJEjcbQ339pMquYDfKvA90BpL88y5yQk2KtHmjKJyPA6oZIvrVd3w8ZjKVBvciIJjofmwKlrppaUZVPGsnRk96bAlQ1X5NLSS97chde2rcPGvfl2fzv2u+7k6tWrsmXzRjl06JCcP39edPz33LlzS6lSpSWR+T7WtGvnTnnj9Zdl3do19jX/IYAAAr4kEBAYIJlfzOxLRb4nynpiyIl74jgT0kF6LYB3PcgCBQrKU888a+7APyH33RcevYSGhMiCBfNl1PcjZe3a1a7Z/X6aAD7hnWIC+IR3TuKrRATw8SWd8PbjywG8aqZLl076vvK6qenW1E5HJXzk8GEZYy6af/vNVxIcHBRVNuYjgAACCVqAAD5hnh4C+Pg/L/ESwDsOS+8ETJv5syRJYm5FuqTt/2yTUT+MlJkzpsm1a9dclvjnJAF8wjuvBPAJ75zEV4kI4ONLOuHtx9cDeIeo1ngrVbqM5MuX39x5zySpUqU2d+HPyenTp+Sfbdtk584djqw8I4AAAj4rQACfME8dAXz8nxevDyOXOHESebT+Y6Yq/bNSsVIV5xFqG3n9UfHgg6WkWPH75aNPhkjefPnkow/ec+ZhAgEEEEAAAQSiFwgxNdp0/Hd9kBBAAAEEEEDAvwW8FsBny5Zd2j35tLR98inJkiWrU3Hvnt0y+qdRMnXKZLl48YLkz19AOnXuKi1NB3eOdvLOzEwggAACCCCAAAIIIIAAAggggIAV8FoA/94HH0uduvXsTrS9++LFi0zg/oOsXLHc9oLr8N+3b6+89eZrMviTDyU01Cv96Tl2xTMCCCCAAAIIIIAAAggggAACPivgtQA+LCzMtL87LRMnjJWxY34S7UQnunTu3LnoFrMMAQQQQAABBBKwQIeOnaXEAyXlm6+/tD3eO4qqbfOf795Tit9fQs6b7/qVK5fLd6ZDvdDQeBj+wVEInhFAAAEEEPATAa8F8IMG9pMyZcqaTumu3xK865d4oUKFZP/+f82wN5v9hJLDQAABBBBA4N4UaNnqCek/ILwPG+2QVoes06TN6abPmmuHuzt+/JgULlxEqteoaTvce/3VvvcmFkeNAAIIIIDAHQgkuoN1o121QYNGMnTYCPnw408lRYoUEfI2adpMho/4Vr748hvavUeQ4QUCCCCAAAK+JVDu4fL2u95dqZs1b2mD9xnTp0r5h0pJ7RpV5PKlS2ZY2TaSNm06d6swDwEEEEAAAQSiEfBaAF+zVi27288/GyxXr16NUIQvhg2VSxcv2ivwBc2deBICCCCAAAII+J5Arty55duRP8qNGzdk/ryfbzmAWrVr23lfjxhun48ePSKzZs2ww8lWqVrtlvzMQAABBBBAAIHoBbxWhT5Pnnx2zwsX/nJLCfTq+6pVK8zwcg1sD/W7d+26JQ8zEEAAAQQQQMAzgUfq1JVq1WtKrly55eTJE6LV0/PmzWdHgrl27ZoMHTLYsw3FIleq1Knlhx/HSvp06aRTx/am/fsD8liDhhG2oKPQXL9+XXbs2O6cv2nTBjtKTdasN0eoCQgQ/UdCAAEEohcwnV3zURE90V1aGhAQu3vCYWH0gXInp8prAfy1a+F33RNFcUJTpEhpy60/LEgIIIAAAgggcHsCXwz/WhqbpmmOdOHCeRvAa/O1bs91l0SJEsmvZiSYrVvirs8Z3eZw0wyuaNFi8s7bb8iSXxfZAN5RBsdzhowZbY077djWkS5euGgnHb8D0mTMJSnuy+BYzDMCCCDgVuDkwb8kcdKIzXLdZmRm/AqYi7CZ85eM1T5P7I2776NY7dhPMnstgNer7fkLFJRXX39TXuz5ggQHBzvJ9E5B1ZtV52Lqnd65EhMIIIAAAgggEEHg0fqP2eBde3Rfu2a1VKpcxbl8+/Z/ZOGC+VL/scft/LgM4HWbtR+pI1qDbu+e3ebufw3bLE53XrJkKTsKzT/b/pbgIPPdb37cuabAwPA7NYmThP8EuXjqoOiDhAACCEQnEBAYIMHXIzbLjS4/y+JJwFygJSCPJ+ubu/FaAD9m9I/2R0PDRk2k5IOlzNX5xZIqZUqpZnqfzZ49h939smW/ybFjR+P3iG/urVbtOvJ4w0a37DvEjFn/1huvSlBQkF2mP1KaNmtuqyLu3r1bpkyeIMuXLb1lPWYggAACCCAQ3wIVK4UH7LNNu3K9WP7zvIWSN18+ZzH+WL/OfhfnyZ3HOS8uJpIlS2Y3U6hwYRk7fnKETb72xlumidxj0rRxA1udv2ChwpI0aVLbTl4zZsqU2eY/eeJEhPV4gQACCCCAAAIxC3gtgF+5Yrl8/OH70qfvKzb41fFhXdP2f7bJG6+97DorXqd1iDvtBTdy0rsYA959xwbw2nvuZ58PlzAz7+jRo9KwUWNpaIL+Du2fkqVLl0ReldcIIIAAAgjEq0CmjJns/latWul2vxcuXrDzA0yV97hMvy1ZLA0b1IuwyfbPdrTfq4MG9JNffplnl+00w8kVK36/vUOv1fg11TJ37jXt3r3LPvMfAggggAACCHgu4LUAXovw5fDPZeHC+bZTm0LmCnzKlKns2O/b/v5LZs2cHqFavedFjtucT7VrLat/X+XcqLbT07vwmjp17mqHuevSpYMsWrhA2rR9Uj76ZIh06NSZAN4pxgQCCCCAwN0S2H9gv911eTOU2+SJ428pRt269e28f/ftvWXZncw4d+6c6MM17d//r335j7lAf/DAATs9edJ4adykqXwyeKiMHfOTrR1Qo0YtW+1+/bq1rqszjQACCCCAAAIeCHg1gNf97zJX33ftHOJBUe5OFm2b79o+31GKjKbjHa36v8fcIdDgXdMk8+PotTfelmrVakhgYKAz0HeswzMCCCCAAALxKfDHzSC4YeOmsnPXTkmdJo3dfYYMGaRHr/9J3XqP2tdald7b6crly3YXl28+64sVy5fJe4PelZdfeV1e6NHLDh+3b+8e22u9t8vD9hFAAAEEEPBHAa8G8OnTp5cqVavbKvSJEkXsxEYxr5txY7/75itx7Z02vpE7de4mNWrWklMnT9pA3XEHQYe+0bTFpddeLeeWLZtE7x5kyJDRtu2L7/KyPwQQQAABBBwC2pxr7s+zTZ8ujeXNt/o5ZsvGLf84p2fOmCYbN25wvvbWxPcjvxV9RE7ffj1Cfhj5nWn7nsnWatOx4EkIIIAAAgggcHsCXgvgdfzZSVNnODusi6p4c2bNNO3L796Xud6dcNyheOsdc5fgpd6mo7qJktH80NCkw/G4posXwtsT6vA8mtJkyuW6OMbpi6cPS2DipDHmI0P8CugYxKljeS5jW8IkIZclUeB5c/5vvZgV222RPy4FQmL9dxzbvYeGBJtzf10SJU4S21XJ70WBRIFJJFX6bObceP5VGHTtsly7dNaLpYr9pnv36i7a4/vzL/QUHZvdka5evSoaPH8x7DPHrLv2HBwcdNc6rb1rB82OEUAAAQQQ8IKA579aYrnz57v3tMG7VqU7d/as5MyVS7Ttu97R1iro+lrTlStXYrnluMk+8rtvZLLpUf74sWOSKlUqadGytWgA/3a/d20AH3QjvBf6yOPYa9V5TYmThP8QDwm6HrsCmaFw72aNg9gV9t7KHetzGUuexGHBoiMhc/5jCRcP2b197sNCQyRQx8HWBynhCJjzERp8w3RUGt7viScF04sxCS3dMLXZvhg2VIZ/8blkz5HDfveeOHFcDh86JNoxKwkBBBBAAAEE/EfAawF8mbIPWaVePZ6T4qYH2r6m/ds35k6AVuXT1/N+WSyXLl+S69ev3RVNvbPuuLuuHfFotb/mLVpJiQdKSrp06ZzV4x134h2FzJw5i53UKvearpwPf7YvPPwvNCT84oCH2ckWDwJhJrS+nXMZq6KZaz5hIaESi1ghVpsn8+0KJPL+uTdFCwxNbc59wgv+blfNH9YLDQ2Wqxcv+cOh2GPQi4NHDh+2D785KA4EAQQQQAABBCIIeC2Adwxt87sZ2iZr1mx2p3ny5rXP2kPt9u3/yP0lHpBypudcHXIuvpOOS6sd1DmSBu25zDi52qGd1hq4du2afa5QsbLpPT+lrSmgHduVKl1G9M6GI/h3rM8zAggggAACd0OgUuUqZrSXx6W66Z/F8X0buRxazX7BzaHdIi/jNQIIIIAAAgj4joDXAvigoPC7zPfdl1b+/XefFalSpaoMGxreI32im2PSOu5oxzfZ7Dnz5Yhpe7982VK5fOmSNGvR0t55nzZ1sh0DXss/e9YMadvuKRkzbpKsX7/Wdl6XxFSdnzRhfHwXl/0hgAACCCBwi0D+/AVk3PjJpm+N6L/OM2fOfMu6zEAAAQQQQAAB3xOI/hv/Do7n5KmTti2eVqVf+tuv9s52xUpV5J3+A+Xq1StStFhxu/WTJ0/cwV5uf9UNG/6UqtWqS5EiRe1GtOrh9GlTpN/bbzo3OnBAP9OWMLvppb62rSmgbQl1/PphnyfcYfGchWcCAQQQQMDvBTp17mqD96NHjkj/fm+JDtF2/fqtfbOcPn3a7y04QAQQQAABBO4FAa8F8DtMFfkHzTjqVapWk/nzfpYJ48fK0888K/pjw5F0yLb4GJvWsT/X56effMJ2Xqcd/ty4fsO2edcee12T3plv/3Q70VoEWn3+hLnYoPNICCCAAAIIJAQBx7jv48ePkV/mz00IRaIMCCCAAAIIIOBFAa8F8EMGfyyjfxxlho05Yov/rrkzcM0EyDVq1RYdH37Txo0yoP/btq25F48v2k1rW/fdu/5rBx9VZtcO76LKw3wEEEAAAQTiW0D7lGlmdqpV6UkIIIAAAggg4P8Cibx1iG+901/mzFsgrVq3tbvQNuWDBvaXurWrS7kyJaVzx2fkwIH93to920UAAQQQQMDvBRb+Mt9WmW/cpJkULVrM74+XA0QAAQQQQOBeF/DaHXjHeOk3btzaFu9eR+f4EUAAAQQQiAuBffv2yoL586Rx02ayYPFS2wmru+326vG8bc7mbhnzEEAAAQQQQMB3BLx2B16r9WnScdVJCCCAAAIIIBD3Ag+Ve1geb9jIbjggIECSJk3q9qH9uJAQQAABBBBAwPcFvHYHfvKkCdK12wvSsFETGf7FUI/amvs+J0eAAAIIIIBA/AnUqVvP9kJ/6OBB6ffOG7Jv3z5Tpf7aLQU4e/bsLfOYgQACCCCAAAK+J+C1AL5Dh862l3clmTl7nly66L739sYN68uJE8d9T44SI4AAAgggcJcFsmXLbkswceI4Wbxo4V0uDbtHAAEEEEAAAW8LeC2Az1+goLPsadLcJ/pwlxxt5d0tYx4CCCCAAAIIRC2w7e+/pHmLVlKwYKGoM7EEAQQQQAABBPxGwGsB/DtvvSbDh30WI9SpUydjzEMGBBBAAAEEELhVYM7sWdL7f32lceOm8s1XX4qj/5lbczIHAQQQQAABBPxBwGsB/JEjR0QfJAQQQAABBBDwjkCZsg9J6jRp7MbnL1wiYaGhbnf01puvybixo90uYyYCCCCAAAII+I6A1wL4vHnzSfYcOaKV0LHh//xjfbR5WIgAAggggAAC7gXuS/tf8zTthT4gMNBtRl1GQgABBBBAAAHfF/BaAP9O/4GivePGlB4q84CcOkk1+picWI4AAggggEBkgWlTpsjypUsjz77l9fnz526ZxwwEEEAAAQQQ8D0BrwXw+/btlb17drsVyZ4jp6RIkcIuM/cL3OZhJgIIIIAAAghELxAcHCRHj9JcLXolliKAAAIIIOA/Al4L4AcN6Cf6cJdaP9FWPvl0qGz/Z5ucPn3KXRbmIYAAAggggIAbgdKly0jZh8rJxo0b5PChQ1K+QkU3uSLOWrVyuTAWfEQTXiGAAAIIIOCLAl4L4KPDmDJ5ovR95TUpVvx+KVKkqGzf/k902VmGAAIIIIAAAjcFmrVoKc926Cxjfhol27b9LR98NDhGm9df7Svjx42JMR8ZEEAAAQQQQCBhC9yVAD4sLEwuXbwoWbNmk6LFihPAJ+z3CKVDAAEEEEhAAnv27JH9+/81NdhOy4ED+2XdujUxlo4hW2MkIgMCCCCAAAI+IeC1AD7Q9ISbMmWqCAjaC27q1KmkVu06kjdffrvs4MEDEfLwAgEEEEAAAQSiFpgza4b8tXWL/Gv6mjlz5oysXLE86swsQQABBBBAAAG/EvBaAD902Ahp3KRptFhbtmyWDX/+EW0eFiKAAAIIIIDAfwJPPfOs9H35NRk2dIh8Ovij/xYwhQACCCCAAAJ+L5DIW0cYGhoS5aYvX74sq1aukFde6h1lHhYggAACCCCAAAIIIIAAAggggMB/Al67A/+/F3vIqy/3+W9PLlPXrl1zecUkAggggAACCCCAAAIIIIAAAgjEJOC1AD5PnrzyzLMdJSQ4WD768H3RsWod6fGGjeWhcg/LVlOFfsb0qY7ZPCOAAAIIIIAAAggggAACCCCAQBQCXgvgtY1ep85dZZ/pZEcDeNeUKXNmu0w73/l5ziwJCvovuHfNxzQCCCCAAAIIuBdo++RT8kiduu4XRpo7/IvPZd7cOZHm8hIBBBBAAAEEfE3AawF8uYfLW4vBH38Y4e67zhw7+kd5/oUekj17DilStJj8/ddWX3OjvAgggAACCNxVgcyZs4g+PEkZMmTwJBt5EEAAAQQQQCCBC3gtgM+ZM6c99LVrVt9CEBISIn/+sV4aNmpihppLectyZiCAAAIIIIBA9AIrli+TmTOmRZ/p5tING/70KF9sMhUuUkSeaPOkFCtW3FxIyCybNm2URQt/keXLlsqNGzecm8pnho19vntPKX5/CTl/7pysXLlcvvvmKwkNDXXmYQIBBBBAAAEEPBPwWgB/+tQpyZIlq2TLnl1OnjxxS2ly5c5j54WFhd2yjBkIIIAAAgggEL3ARhOUT50yKfpMXlzaomVr6dL1OdsM7sKFC9Km7ZP2MX3aFNGObDVly5Zdps+aKxkzZpTjx49J4cJFpHqNmqJB/euv9vVi6dg0AggggAAC/ingtWHktm3724p9+NFgyZkrl1MvR44c0veV16V06TL26vvuXTudy5hAAAEEEEAAAd8Q2P/vv/Ldt19LqZLFpGyp++WJls1swRs3aSaJE4ffH2jWvKUN3rXD2vIPlZLaNarI5UuXpFXrNpI2bTrfOFBKiQACCCCAQAIS8NodeO0wR3ubf6Dkg7JsxRr5+++/JFXKVKJV7hxp3Jif5JypTkdCAAEEEEAAAd8SmDB+bIQCr1nzuxw7dtTedc+YMZO9416rdm2b5+sRw+3z0aNHZNasGdLuyaelStVqdKwXQZAXCCCAAAIIxCzgtTvwe/fslm5dOsqRw4clSZIk9o67a/A+ZdIE+eCDQTGXkBwIIIAAAggg4BTYuWO7bW+uwXJCSlmzZhN9aPv306dP2aJpU7rr16/LDlNmR9q0aYOdzJo1q2MWzwgggAACCCDgoYDX7sDr/pf+9qvUrllFtEf6ggULS6pUqWT//n9Fq9drgE9CAAEEEEAAgdgJLPhlvugjISWtMv/Jp59JQECATBg/xow+E2yLl8G0fb908aK49ndz8cJFuyxFivBObJOlSitJktGhbUI6n5QFgYQocPnCcUmUOElCLNq9XaYAkdTps8fK4NKZhHUBOlaFTwCZvRbAl3igpLzU91UJDgmWXt2fE+0t15E6duoib73dX/5Yv05GfDnMMZtnBBBAAAEEEPAxAa1lN3zEN1KjZm3RjvXeHzTAeQTBQSaQN0G9awoMDK/8lzjJzZ8gpjNb1wDfNS/TCCCAQEQBOr+O6JEwXvEZHr/nwWsB/FNPt5dH6tS11fy0+pxrOn78uF1WsVJl+XHUSLly5YrrYqYRQAABBBBAwAcE7rsvrXw7cpRUqlxFVv++Sjp3ai/Xrl1zllxHoSlYqLAkTZrUObRcpkyZ7fKTJ8JHqLl+5YLog4QAAghEJxAQGCChN2v3RJePZfEsYK6pXD57LJ53em/vzmtt4B98sJSV/Wzwx7dcWZ/782xbhV6r1BcpUvTePgMcPQIIIIAAAj4oUKBAQZk5e64N3nU8+qeffMJWl3c9lJ07d9p+cKpVr+GcXeuROnZ69+5dznlMIIAAAggggIBnAl67A581WzZbgq1/bXFbEm0HX6BgIUmaLJnb5cxEAAEEEEAAgYQr8Olnw+zddS3h1atXZeB7HzoL++vihbJo4QKZPGm8NG7SVD4ZPFTGmpFn8ubLJzVq1LIX8devW+vMzwQCCCCAAAIIeCbgtQD+yJEjkjlzFilatJj8fmplhNIEBgaa+cXtvOsuVe0iZOIFAggggAACCCRYAdeq8m3bPRWhnNoLvQbw2v/Ne4PelZdfeV1e6NHL3o3ft3ePdOrYPkJ+XiCAAAIIIICAZwJeC+C3bN4kpUqVtlfd/9e7h6xbu0YSm54jyz38sB3/VYeU06FmdtMbvWdnilwIIIAAAggkIIG2T7TwqDTffj1Cfhj5nWTKlMn2Uq9jwZMQQAABBBBA4PYEvBbAf/7Zp9KocVPJlTu3TJk2S86dO2c7sUmZ8r+hYr4c/rlcvnTp9krOWggggAACCCDgEwLBwUGS0Mat9wk4CokAAggggEAkAa91Yqc9z7Zp3dwOKaP7TJcunTiCd61298lH78vwYZ9HKg4vEUAAAQQQQAABBBBAAAEEEEDAnYDX7sDrzv4xHdU1a/K4vQtfsGBh0V7n9+//13Zeo0PHJU7s1d27O17mIYAAAggggAACCCCAAAIIIOCTAl6PoMPCwuTggQP2oULJkyeXuvUelRYtW0vZh8pJtcoV5Pz5cz6JR6ERQAABBBBAAAEEEEAAAQQQiC8BrwfweiABAQFSoWIladGilTR4vJGkTpPGeXxarZ4A3snBBAIIIIAAAggggAACCCCAAAJuBbwawBcsVFiat2gpzZu3khw5czoLoHfl161bI7NmTJdTp0465zOBAAIIIIAAAggggAACCCCAAALuBeI8gM+YMaM0btJMmpsq8g8+WOqWvW7cuEFe6NZJdJx4EgIIIIAAAggggAACCCCAAAIIeCYQpwH8oPc+tGO8B7p0TnfUBOqzZk6XM2fPyBtvviNHDh8iePfs3JALAQQQQAABBBBAAAEEEEAAAadAnAbwD5g77o7gXYP28WPHyNq1q0WrzNeoUcu5UyYQQAABBBBAAAEEEEAAAQQQQCB2AnEawLvuuk7dRyUkJESSJksqq1aucF3ENAIIIIAAAggggAACCCCAAAIIxFIgTgP4/m+/Ia3btJOGjRpL2rTpTAd2rezj5MkTcuokndXF8tyQHQEEEEAAAQQQQAABBBBAAAGnQJwG8Js2bRR99H/nTXmkTj0bvNeq/YhkzpzFPnSvFStWlt59+toe6Pft2+ssCBMIIIAAAggggIBHAgGJRBKZBynhCISGioSZBwkBBBBAwKsCcRrAO0p648YNmT/vZ/tInz69NGrc1AbzZco+JBkzZZL/9XnZPrZs2SxPtW3NOPAOOJ4RQAABBBBAIEaBpA/UkySFK8eYjwzxJxC063e5sfWX+Nshe0IAAQTuUQGvBPCulmfPnpXRP42yj/z5C9hAvpkZGz537jx2mLmUKVMSwLuCMY0AAggggAACCCDgViBtMpGkgW4XMfMuCpy5KhISdhcLwK4RuIcEvB7Au1pqlflPB38kQz79WMo9XF4eb9hYrl694pqFaQQQQAABBBBAAAEE3ApcDhIZ14iq+m5x7tLMA+dF+i5NJFfMuSEhgID3BeI1gHccjg4rt37dWvtwzOMZAQQQQAABBBBAAIGYBFLelV+vMZXq3l2enPNx7558jvyuCNADzF1hZ6cIIIAAAggggAACCCCAAAIIxE6AAD52XuRGAAEEEEAAAQQQQAABBBBA4K4IEMDfFXZ2igACCCCAAAIIIIAAAggggEDsBAjgY+dFbgQQQAABBBBAAAEEEEAAAQTuigAB/F1hZ6cIIIAAAggggAACCCCAAAIIxE6AAD52XuRGAAEEEEAAAQQQQAABBBBA4K4IEMDfFXZ2igACCCCAAAIIIIAAAggggEDsBAjgY+dFbgQQQAABBBBAAIH/s3cf8FEUbQCHX9LovfeOqHQQkCK9KEWadESaSlM/O3bpdkVEOiod6UWliICAIkoH6aDSi5QklCSEb94JdyYhkLsjdyTwn5/H7e3N7sw+h+y+u1MQQAABBBC4LQIE8LeFnUIRQAABBBBAAAEEEEAAAQQQcE+AAN49L3IjgAACCCCAAAIIIIAAAgggcFsECOBvCzuFIoAAAggggAACCCCAAAIIIOCeAAG8e17kRgABBBBAAAEEEEAAAQQQQOC2CBDA3xZ2CkUAAQQQQAABBBBAAAEEEEDAPQECePe8yI0AAggggAACCCCAAAIIIIDAbREIuC2lJqFCGz7cSJo1byH58xeQvXv3yrczpsqqlSuS0BFQVQQQQAABBG6fQIECBaVn775y7333y7mzZ2X16lUyZtSXEhkZefsqRckIIIAAAggkUQEC+Jv8cM1btJJPPhsuV81FxtGjR6Vxk6bSuHET6dK5o6xYsfwmW/IVAggggAACCOTIkVNmz1skmTNnluPHj0nRosXkoRo1RYP6fq+8CBACCCCAAAIIuClAE/qbgHXr/qQkS5ZMnuzRRapULm8vNvz8/aVLt+432YqvEEAAAQQQQEAF9Ea4Bu9zZs+UiuVLS+0aVSU0JEQea91W0qfPABICCCCAAAIIuClAAH8DML3gKFmqtOzbu0eWLllsc02fNkXOnDkj1avXEH8TyJMQQAABBBBA4MYCtWrXtl+OHDHcvh89ekTmzZsjgYGBUrVa9RtvyDcIIIAAAgggEKcATejjZBHJli27/WbLls3OHFevXpUtWzZJjRq1JFOmzHLy5AlJnTGH83tXFkLPHBc//0BXspLHhwLJJJmkcvO3dLd6QZEXzW8fbG7+uLsl+b0rEOn2/8fu1udq5BXz24eLXwD/5Lpr5838fv4Bkip9Vknm5/r/lBFhF+Vy6DlvVuuO2reeSy9fviy7du10HtemTRukfYdOkj171Hk2eer0EhCU0vl9fAv6/1OkOY9yLo1Pyrff6+/h7v9PntTw8rlj5jzKv6We2HlrG/0nNHmqtObfUtf/P/akLheCT3Ae9QTO29skE0mdwd146Ji3a3VH759/AW/w82bOksV+c/58zAu14PPn7fqUKaP+kUqTKecN9hD3apt/w4y4v2TtbRNIVaCET8p+5U+fFEMhbghkLuhG5lvJelDkqnmREo+A/Vc86p96lyt18fwpAniXtUQymdZsIcHBojfAHSn4fLBdTJkylX1PniqdpEzn5g8RfEiEc6mDNPG8Z8nj9brodVTrX71eDAW4KRBk/hcOcnMbd7Prb391lrtbkd/bAtkLRd2Mdaec0DME8O54xc5LAB9b5Nrn8LBwu+SXLGYvA0fT+QDT/E9TyL9H7Tt/IIAAAgjc+QL6BJ7kukBEeISYwWRibODvH3VeDQiMugS5fOG8XImIOufGyMgHBBBAAAEEELhOgAD+OpKoFdo8XpPjSXzUWpGsWbPZxVMnT9p37iA5ZHhHAAEEEEAgpoCeSwsXKSpBQUESFhZmv8ySJat9P3ki6jyrXRLolhDTjU8IIIAAAgjcSCDm4+Ub5boL1x85clhCQ0OlUuUqkipVVDM/HdiudJmycuLEcYndtP4uJOKQEUAAAQQQuKnA7t277YB11R+q4cxXq05du7zXDBJLQgABBBBAAAH3BPxNX+533Nvk7sgdEREhefPlk4qVKktlE8QXKlxYnn/hZdE5bcePHSNr166+OyA4SgQQQAABBDwUCAkJlhYtH5Nq1R6S1KnTSNv2HaRhw0dk/769MnhQfw/3ymYIIIAAAgjcvQLJMmbM+N/IMnevQ5xHnjpNGhnx5WipUbO2nQ8+MjJSFsyfKy8+/6yzKWCcG7ISAQQQQAABBKzAk0/3kpde7mfPozp93IH9+6Rrl8dtEA8RAggggAACCLgnQADvgle6dOlFm8+fMH35QkNCXNiCLAgggAACCCDgEAgICJQsZnaXZGZAO50LnoQAAggggAACngkQwHvmxlYIIIAAAggggAACCCCAAAII+FSAQex8yk1hCCCAAAIIIIAAAggggAACCHgmQADvmRtbIYAAAggggAACCCCAAAIIIOBTAQJ4n3JTGAIIIIAAAggggAACCCCAAAKeCRDAe+bGVggggAACCCCAAAIIIIAAAgj4VIAA3qfcFIYAAggggAACCCCAAAIIIICAZwIE8J65sRUCCCCAAAIIIIAAAggggAACPhUggPcpN4UhgAACCCCAAAIIIIAAAggg4JkAAbxnbmyFAAIIIIAAAggggAACCCCAgE8FCOB9yk1hCCCAAAIIIIAAAggggAACCHgmQADvmRtbIYAAAggggAACCCCAAAIIIOBTAQJ4n3JTGAIIIIAAAggggAACCCCAAAKeCRDAe+bGVggggAACCCCAAAIIIIAAAgj4VIAA3qfcFIYAAggggAACCCCAAAIIIICAZwIE8J65sRUCCCCAAAIIIIAAAggggAACPhUggPcpN4UhgAACCCCAAAIIIIAAAggg4JkAAbxnbmyFAAIIIIAAAggggAACCCCAgE8FCOB9yk1hCCCAAAIIIIAAAggggAACCHgmQADvmRtbIYAAAggggAACCCCAAAIIIOBTAQJ4n3JTGAIIIIAAAggggAACCCCAAAKeCRDAe+bGVggggAACCCCAAAIIIIAAAgj4VIAA3qfcFIYAAggggAACCCCAAAIIIICAZwIE8J65sRUCCCCAAAIIIIAAAggggAACPhUggPcpN4UhgAACCCCAAAIIIIAAAggg4JkAAbxnbmyFAAIIIIAAAggggAACCCCAgE8FCOB9yk1hCCCAAAIIIIAAAggggAACCHgmQADvmRtbIYAAAggggAACCCCAAAIIIOBTAQJ4n3JTGAIIIIAAAggggAACCCCAAAKeCRDAe+bGVggggAACCCCAAAIIIIAAAgj4VIAA3qfcFIYAAggggAACCCCAAAIIIICAZwIE8J65sRUCCCCAAAIIIIAAAggggAACPhUggPcpN4UhgAACCCCAAAIIIIAAAggg4JkAAbxnbmyFAAIIIIAAAggggAACCCCAgE8FCOB9yk1hCCCAAAIIIIAAAggggAACCHgmQADvmRtbIYAAAggggAACCCCAAAIIIOBTAQJ4n3JTGAIIIIAAAggggAACCCCAAAKeCRDAe+bGVggggAACCCCAAAIIIIAAAgj4VIAA3qfcFIYAAggggAACCCCAAAIIIICAZwIE8J65sRUCCCCAAAIIIIAAAggggAACPhUggPcpN4UhgAACCCCAAAIIIIAAAggg4JkAAbxnbmyFAAIIIIAAAggggAACCCCAgE8FCOB9yk1hCCCAAAIIIIAAAggggAACCHgmQADvmRtbIYAAAggggAACCCCAAAIIIOBTAQJ4n3JTGAIIIIAAAggggAACCCCAAAKeCRDAe+bGVggggAACCCCAAAIIIIAAAgj4VIAA3qfcFIYAAggggAACCCCAAAIIIICAZwIE8J65sRUCCCCAAAIIIIAAAggggAACPhUggPcpN4UhgAACCCCAAAIIIIAAAggg4JkAAbxnbmyFAAIIIIAAAggggAACCCCAgE8FCOB9yk1hCCCAAAIIIIAAAggggAACCHgmQADvmRtbIYAAAggggAACCCCAAAIIIOBTAQJ4n3JTGAIIIIAAAggggAACCCCAAAKeCRDAe+bGVggggAACCCCAAAIIIIAAAgj4VIAA3qfcFIYAAggggAACCCCAAAIIIICAZwIE8J65sRUCCCCAAAIIIIAAAggggAACPhUggPcpN4UhgAACCCCAAAIIIIAAAggg4JkAAbxnbmyFAAIIIIAAAggggAACCCCAgE8FCOB9yk1hCCCAAAIIIIAAAggggAACCHgmQADvmRtbIYAAAggggAACCCCAAAIIIOBTAQJ4n3JTGAIIIIAAAggggAACCCCAAAKeCRDAe+bGVggggAACCCCAAAIIIIAAAgj4VIAA3qfcFIYAAggggAACCCCAAAIIIICAZwIE8J65sRUCCCCAAAIIIIAAAggggAACPhUggPcpN4UhgAACCCCAAAIIIIAAAggg4JkAAbxnbmyFAAIIIIAAAggggAACCCCAgE8FCOB9yk1hCCCAAAIIIIAAAggggAACCHgmQADvmRtbIYAAAggggAACCCCAAAIIIOBTAQJ4n3JTGAIIIIAAAggggAACCCCAAAKeCRDAe+bGVggggAACCCCAAAIIIIAAAgj4VIAA3qfcFIYAAggggAACCCCAAAIIIICAZwIBnm3m2lYBAYFSslQpyZkzl6RPn17CwsIkPDxMTpw4IVs2b5ILFy64tiNyIYAAAggggAACCCCAAAIIIHCXC3glgC9QoKC8+HI/qVWrtqRJmzZO4vDwcPn1l7Xy6Scfyu/rf4szDysRQAABBBBAAAEEEEAAAQQQQCBKIFnGjBmvJhRGYGCg9OzdV/r0fU6SJ09udxscfF727tkjhw8fkoiICPM0PqcUKlxEsmbNZr+/evWqTJ82RYYM6i9nz55NqKqwHwQQQAABBBBAAAEEEEAAAQTuKIEEC+A1KB877ispXKSoBVq58ieZOnmS/LhsiW06H10tWbJkUqnyg9K6TTtp3qKV+Pn5yenTp+XZvj3l51Uro2dlGQEEEEAAAQQQQAABBBBAAAEEjECCDWJ3//332+D96NEj0r3r4/J4h7by/XcLrwveVV2fumvz+eef6ytNGzeUbVu3SObMmaVqter8KAgggAACCCCAAAIIIIAAAgggEIdAggXwly9flp07/5SmjRrK0iWL4ygq7lVbt2yWls2byLKlS+TypctxZ2ItAggggAACCCCAAAIIIIAAAne5QII1oVdHHXU+IiLcI1J/f3/7ZD4yMtKj7dkIAQQQQAABBBBAAAEEEEAAgTtZIEFHob9Z8J47Tx6pW6+BnU5u29atsnLFcrly5YrTNvqycyULCCCAAAIIIIAAAggggAACCCBgBRI0gNc9ZsuWXWrWriOZMmWStWt+NvO9b5bnX3hZnv3fCzHIV/+8Sp7s/oSEhobGWM8HBBBAAAEEEEAAAQQQQAABBBC4XiBBm9Br8D5vwfeSK3duZ0lTp0ySlq1aS1BQkOgAdwEBAc4p5D768D0Z9unHzrwsIIAAAggggAACCCCAAAIIIIBA3AIJNoid7r59x042eNdR5o8fPyZXzLzv7dp3tMG7jkj/YMVyUqFsSWfQ3qHj43HXirUIIIAAAggggAACCCCAAAIIIBBDIEED+NKly9qd61P1iuVLS7eunZ2FjR83xg5SpytGjRoh4eHhkj17DjvwnTMTCwgggAACCCCAAAIIIIAAAgggEKdAggbwqdOktoX8tHyZ812fxGs6fizqXZdDgoPl1KmTkixZMjv/u64jIXC7BDJkyCD58xeQvPnyxVkFx/f58uWP83tWIoAAAggggEDiE3Ccv311fteupF98OVr6PvOcWxiZM2e2273S73W3tosrc5GiRaVs2XK29Wtc37MOAQSSvkCCBvBBQcmtSEhoiFPmzJkzdjksLMy5ThdCgqPy+PklaBVilMEHBFwReP+jT2XVmnWyeu16KVuu/HWbjB3/jf3+57W/SbFi91z3PSsQQAABBBBAIPEJ+Pr8ni17dmnc5FGpXaeeWxgpU6Wy2z38cCO3tosr86TJM2SuGY+q8oNV4vqadQggcAcIeCV6vnLlv7ncI6NNFRfdK/Lqf3mir2cZAV8LJJNkziJ79urjXNaF0qXLyAMVKznXaasREgIIIIAAAggkfoG78fy+desW2bF9m5w+fTrx/0DUEAEEPBJI8GnktBZTp8+UiPAIW6E8efPa9znzFsWY992x3n7JHwgkEoF69RtKoUKFZf/+fbZG3Z/sGW/NMmbMaP5uR8r58+fizXsrGXLkyCn//ntaordmCQgIlBw5c8iRw4clMvLGN8V0ZohzZ8/GO22jp2Xo7BI5c+WSo0eOSkRE+K0cple3TZ8+g1y4EGrH4IiroNSpU0uKFClEWw7dzDNduvSSLn06OXzokHNsj7j2p7NvZM8R9ftcucHNzLi2Yx0CCCCAQMIKeHJ+T5M2raRNk9bOonSz2uTMmUtCQv5rfXqjvHq9EBgYJCdOHL9RFpfX67kqIDDQdkuNvlGPbv+NPxV9vavLrl4vuLo/8iGAQMILeOUJvAYBGqBHD9L14t6xLvr6hD8k9oiAZwLbzF1r7dLR46mooF1PYo0aNbYzKpw8eSLGTkuVLi2z5iyQP3cfkE1bd8rWHbtFm9j3ePJpO7aDZtY+cDNnz5cRI8fE6ItWpkxZu16/0/5yN0oDB79n8z3Vs7csW/6zrPt9k2zcvEPeePMdyZI1q7z3wcem7B2y5pffZfO2nfJosxYxdqUn93f6DzLf7ZJf1m2QbX/ulXkLf5D77i/hzHerZWhA/Pnwkeb499guCNt37pWRo8fFGNuieYtW9jiaNH1UHu/cRUaPnSAzZs2V51942a7/+NPPnfVxLPR99n/2uxYtH3Osuu690+NP2DwP1agZ47vXXn/Lrr/nnuJ2vQblL7/6mnXasn2X7NxzUBZ+t0TU1ZHGjPta/ti4TXbs2i8bjPHW7bvl/Q8/dk556cinXSgmTp4um7ZEuetvssDsS49Hg3pH0ptAU6fPsvvTrhnbd+6TDz78RPRikIQAAggg4FsBd87vWjPtQ77o+6X2XPDr+o32/NCr9zPO87uj9k0fbSY/rVwjmkevAyZP/dbxVYx3zbdy9a/2emH9hi2iL52lyZP0aLPmton8DnNe2W7O63oNMOS9D53XE/0HDrbnQL2poOclvda40ctxnnTlesGTurINAgh4RyBBn8C/9cardmR5d6qqTxRJCCQGgXFjR5ug7RNp9Vgb+ejD96Rr1x7ib54sjx09Up7o0j1GFXPnzisVHqhon7pv3bJZUpn+a4WLFJU33nrX5htjtvnhh+/k6Z59bBP8YDNw4ysvPS+Zs2SRkWPGi55YJ37z1U3vwpcz/fHvL1HSbq9Pg0+dPGkDd73B4LjJcPHiRQkOPm9P0gMGDZFFC+ebJ+AR9kbExCnTpWLFyvYJ8e7duyRPnryiNw9mzJwjNR+qYvd3K2Xo0/+Zc+Y7xwXQ5no6EM/DjzSWe++7X+rXqSGXL1+WXLly22OI3hVBkTZu+EO0fF3/zVfjZdOmjdZOBx3q3edZSZkypQwdMtCui+sPPR7dtmjRYrJq5QpnlmL33GPXZ82WTXbt2ikffvyZPNKoia2LXsRlyJBRSpYqbW4o5pNRX35ht6tbr7594q5OanrvvfdJm7YdzLEVl2ZNH7F59EJnobmg06fqmvbu2WNbHehsGpr0RoG2wihYsJAs+mGZ/Ttx4cIFOXBgv61j67btJVPmLNKtSyebnz8QQAABBHwj4M75XW/QzzQ36LVlmZ5PQ0KC7blXB5jTc/iAd9+yle7W/Ul5650Bdvno0SN2bKfCRYpcd0Bdu/WQt9+NOpcdO3bUnpP1GmDo+x/JpUuXZM7smddtc6MV2r9+mLlprtM1HzAtBcPMjE6FCxeR9h06yfx5c+w1RZmy5W33Pz2Xnj17RjJlyiRByaPGqNL95jXnPkfSaxx9cOHK9YJjG94RQOD2CyToE/gtmzfL0iWL3XrpBT4JgcQgoCfWObO+tQHaM+YJcNv2HeTcubMyefLE66q3csVyebRxQyldorg0fqS+1K5ZTd59+w2bzzF4zZ7du6Vvn542MGzbroM8/kRX+XLUWBu8r1z5k7z95mvX7TeuFd/OmCYVypaQ8ub1yccf2CwaGL74/LNyf/HC5ruSooGnPg2vUKGi/V6fXGvwrrNAVH2wgtSr/ZCUK32f/PH7ekmbNp20NcFk9ORJGe2Mjz6R1ub7TRs1sPt/pGFdOXjwgBQoUFA6d+kWvQh7oaJTTDq8Ro4YLosWLbR5uvV42pm3Q8fONnjXgP739b8513uyoBcm2mxS01M9ukqjh+tZjyaN6suYUV86d9ni0UZSqsQ91kmPpXbNqrargg5qqBdBmvTmjAbv635dK7XMDZA6tapJ2VL3Xte0Ui/o9IaOXpSVL3O/3WedWtXt3wO9UaA2JAQQQAAB3wm4c35/7fW3bfC+cME8qfRAGfPv/H3y/HN9bdDctWt30Rlp9Hz7wkuv2gP44L3BUvmBslK3dnVp17pljIPSm9ovvRJ1ru/b+ymb78GK5eT9oYNtvievtfiLsdFNPjRoGHVDeba5VqlVo6o0qFtTKlUoba8N9KZy7KQ3pPX6pNqDD9hXuzYtnX3j9UGD9pV393ohdhl8RgAB3wsE+L5ISkQg8QqMHDlCHmvTTjo/ERV8fj7sUwmNo1+bBtAZMmaSjz4ZZoNYbdKe2Txd1aR93Bxp+Y9L5b2hg6Tfa2/KgIFD7Gp9Ktzr6R4xxoRw5I/rfdTIL5wn3JU/LZf/Pf+S7Nu7RzTo1qR9q9f9stbW49777pNfTYBZqVJl+50+xX7q6V52Wf/QbgGaCpk79tGTJ2U4RuyfMGGsbN68ye5u+7attsWCNs3Xp+vRkz7t/vij96OvknFjRoo2LdSuCkMG5TJPD06awL+rzaPf3WrSlguH/vlbCpom7a++9oZ5El5U9Ebjxo1/2HfH/rX1wHPPvSBlypUT7QKUyfy2jiftGc3yWTN+QFnznabx48Y6x0jQG5Dh5glI9OSw16aLWqYjOWbcUHu9yUFCAAEEEPCdgCvndx2otoxpPq9p8KD+tqWaLs+aOUMea91WHqxSVUqXKWOmQj5lW13pmDTjx43RLDZFn4VJV5QsWdre0NVlbbWnL02O64XY52L75U3++Ouvg/ZbvRmsN5V/W/eLac22QT79+MObbBX1lXbhGv/VJNtSbtnSJTJ4YFSLQcc5y9XrhXgLIgMCCHhdIEEDeO3bWuGB/0bsjq/24eFh5ilW9esG4IhvO75HwFsCGhgvWfKDNGjwsH1iPGHc6DiLevHlfs55XjX427dvjxw7dsw2UY+9gT5pbtmqtQ2w9bt+r7zo8d95vZseV4q9Pu+1Oes1iGz1WNsYm4SG3ngQN80Ye1+OjWOvz33tZoA27Y+eHK1q9El/9KRN/mInfcqurQLKV3jA3jTRmxvaJP3okSPy3bWn87G3cfezXoQNGfqhFC9+r7xuxg/QdNpcfOnNhEkTv7YXVF9/M8X2T9fmjPp3YOeff0oVc6Hm6LOujo7j0QumGyVtqpg6TRr7ddQUPlWcWdVdU1wOzkwsIIAAAgh4RcCV87vegNdAVtPJEydi1CMsLKrFaBozqJ2+NG0xN6/1hv6NUvT55+M6F0cflPZG+4i+fsqkr+25Sc+ZOuaOvq6YZv5z5sySN19/9YZ18ff3t+PxaKu5P3dsl2f6PO0cqPVWrhei141lBBDwnUCCBvDZzIW3NhdyJ+noniGmfzAJgcQi8OXwYTYQnzt7lvPJd/S66Ymw8xNd7Kr+77wpE8aPtSdCvZOug9nETtr/WvtpO5I2sW7d8lHbJ9uxztX3GwV/sdc7Ljy0ftr3z50Ue1+ObWOv16flmvRCQpvzOZJeIGjSYNiVpM34dB/tO3ZyeutTfe176EpKkSLqYutGeZcs/kHWrP7ZPjnRpyENGj5s++hrn0QdM0C7E2ig/tPyZfLcM73t03bd1+JlK2zQr8s6zoDemEiePLkUN/3j165ZrauvS+fOnbNN7/XpfW3TvFGbbZIQQAABBBKHQHznd/03XFtVBZrR3fVpefR/64sWjTq36bnAcX7LnTvPTQ/MMdq83qhu0azxTfO68uURc3Nb91OufAV7nfJglWpmzvm6duyedb/+IjOmT41zN++Y812NGrVEB+Tt+kTHGDPS3Mr1QpyFsRIBBLwu4JeQJVyNNY3VVxPGSsf2raV921Y3fJ0+fSohq8C+ELhlgY0bN0jF8qVt87m4dqZ9ovWJrCbty67NtLV5dB1zEo2ddMR3HWVdm+Xpk2B98qsDyemIsd5MW7dutrvv2buvRH8CoPXUUeFr1qpzy8XrXXxNderUs00JdVkH+Klbv4Eu2rv8diGeP5Ys/t40c//HmuoAcPqkeurkSfFsJbLv2lR/FSv91+pHBx9yXGTpDnRkXW1mqM0VtcmgjiHQ1IxdoE8sNMjW5vL58ue3ZW3bts0ZvOt+iphBCR1Jb15oX0FNzz3/or0ZoLNpPPPc83YfjnzanWH7tXzv9B/obIav3+uTnT59owbnc+TnHQEEEEDAdwLxnd/13/BdO/+0FWrStJmzYjrbiaMLmp4L9u/ba7/TGZYc497ooHcNH27k3EYX9Hyg1wh6k1oHyI2eSpQsJV1Mn3p3kjbj1/P3hj9+t033dcq4H5ctsbsoWKhQnLvS8Wh0DB698dC9y+OiNwGiJ19cL0Qvj2UEELh1gYBb38V/e9C7ek906W4Hr9KLVV3Wu4MjzBPNBfPnutzn9789soRA4hPQJvMacGoAN3f+d7LDBLI6qI2OKhs9aTA7bvw3tjnexK8n2BHPdRT0SVNm2Cb1ehEwdsyo6Jsk2PI3prz2HR+3I6IvX7HGPIFeZW8y6A2FrFmz2UB2xU8/3lJ533wzQXQUXr2A0afVu3ftkuoP1bBBqw7+N26sa8emF0wTxo+RN9/ub+sz89tpdjT3+Cq31AT+keZGiF7M/LBkuSQzNyd0pHi9WeJIOt+uNjHUgYd+//03M+DcUfsEXUfe1Tr+bfrHb9q4USpVriK9evWRGjVrSaD5Tp+yR9+P7k9nJvhm4lQzvsCDMm3GbEcR170P7P+2fDtrnh2Nf9WacraJZZYsWe30fdo0c7Gptw5wSEIAAQQQSHwC2r1K+4rryO6FCxeW5KaVl9541/T9dwtl57UA/7fffrWDxU74epKcOXPGtBoLv27qUb1W0D7y3Xs8ZcfM0UD6mBmxXsdl0ZZ5e/bstq34XFXQ6WL1PKsD1um1h15ra3cvvcm8Yvny63aj1ybvmFZ/mrQF2cuvvh4jj97U9sX1QoxC+YAAArcskKBP4PUfMP3H4MGKZc0I26/bIEcvqD/7fISd/7Jjp84xnkjdcu3ZAQIJIODos+14j2uXly9HNQd39Ffra/qP6Qjp2i9aA7psJij+edVKu6mjaV2/fm/YO/Y6wNu7pim7Jm3K7RjI7fU33r7ptIuO+oRdDrPb6h+O8h3fOb5wfHa8ax3atGpuppWZawP3WrXrmuC0tr240CfnevdekyO/J2Vo15e2bVrYJ9M6LU2duvXs/98anLZ5rIW9oNEydGq1+NIf1+qjTyrGjRkdX3b7vf57o83vNem0ddrHfZfpQ/+PCco1qYH+bhowR5qLGw3SmzVvaaa1y2Wbznfu1N4OUDhs2Cd2xPhw81S+lJleTvelN1o06UXR5Wv9HvX37dihjXnasdROW6ej0etv6ejbrjcENOnfC211tPPPHfamTvWHatqnL/p0RlsB/GtuAJEQQAABBLwv4DjHOd7jKjH2+V3/jddR5/Ucp+cNDd71XKAzi7xgZn9xpGf79nK2NNNAWlt6xT63at4hpvXdIDNgnJ4jSpcuY7pxPWLHxNFzwQ/fLbK708FytWXYzeqpGfXGu7bkK2IGZNUBYDV4/2PD7/LKy8/LumvjsziO57IZYE+Tn7+/fdc/qlarHuOlN5ddvV5w7oQFBBC47QLJzD86148slUDV0gvWRo2b2ibEuqxpsZkb+8nuUf2HE6gYdoPAbRPQJt/p0qWTgwcP2pPzbavITQrW//c0wEPah+cAAEAASURBVNa774cOH/LKmBPZsmW3TdH1aYMn/b51Ptx27TuK9lfXJoHuJJ0BIH/+AnY6O52LN66kc9Zr4K4DzO02Qb4+9Y+dtFuEziGv9dfjiCtpk3y92HEknYd+5uz59oKqnJkyLnbS8lKnSm1HIT506JB9QhM7D58RQAABBBKfgI53U8Cc49Oaf8f3mMFN45qRRmut5x8dwFSnc3Xc0L3R0ei5MnmK5HL50mXbH11vDHiS9LynXcD+MtceOkZLQiVfXC8kVF3ZDwJ3s4BXA/iS5mlW32eek/pmRG9Hc9SpUybJqy+/cDebc+wIIBBNQAe+/OW3jfYGQ+uWzZxPEaJlSRSL2v9x9ZrfZMOGP+SA6X+fImUqOyCe3hjRmQaGDI5qppgoKkslEEAAAQQQQAABBO5IgQTtA+8Q0ibFvZ951o546Ving31pX/hfzXzVJAQQQMAh0MoMyqNBsDZbdzQBdHyXmN51tHvtO69P3fXlSDo/8LDPPnZ85B0BBBBAAAEEEEAAAa8JJOgTeO1b87/nX3Je3Gp/1u8WLZARX3wu27dt9dpBsGMEEEi6AjrYXz7TxP/48WPXjY6b2I5KZyAoYgYe0ub22rf/wIH9tvl8Yqsn9UEAAQQQQAABBBC4MwUSNICfu+B7KVu2nFNq4jdfyUFzgXuzpE3q4+szdLPt+Q4BBBBAAAEEEEAAAQQQQACBu0HAK03oHXCdHn/CsXjD90ULFxDA31CHLxBAAAEEEEAAAQQQQAABBBCIEkjQAF7nx9xnRup0J128eMGd7ORFAAEEEEAAAQQQQAABBBBA4K4USNAm9HelIAeNAAIIIIAAAggggAACCCCAgA8E/HxQhstFOKaac3kDMiKAAAIIIIAAAggggAACCCBwlwgkWABfs1YdmT13oegoze6mADM106fDvpDn/veiu5uSHwEEEEAAAQQQQAABBBBAAIG7QiDBAvi0adNI+QoPyJx5i6Ripcou4xUsWEimTPtWmrdoJclTJHd5OzIigAACCCCAAAIIIIAAAgggcDcJJNggdnt275ajR49IocJFZMbMubJg3lyZMmWirPv1F9H54GOne++9Tx5r0050pPqgoCAJDQmRDX/8HjvbnfnZP8HY70yf23FUkVdErl69HSVTJgIIIICAuwLJzPMHvwR7BuFu6eSPS0Cv9a5ef70XV1bWIYAAAgh4LpCgg9ilTp1aXnjpVenSpZv4+fvbWh07dlT+3LFdDh8+LBER4ZIzZy4pXLioFCla1FnrH75fJO+89Ya9AeBceQcvpG7R/w4+uqR5aKHzzG9yJSJpVp5aI4AAAneZQFDJhhJYtMpddtSJ+3DD96yVsK0/eL2SfslEzH+kRCYQaO6nXTLPQkgIIOB9gQR9FBwaGir933lTZs2cIf1ee1MerFJVcuTIaV+xD+Wqedq5besW+eTjD+THZUtjf81nBBBAAAEEEEAAAQRiCGgAv6Q1T/pjoNzmDwfPifRZZiJ4Avjb/EtQ/N0ikKABvANt+7at0rF9a0mTNq088EAl89Q9p2TOnFn8zWB1/54+LSdOnJA/fl8vJ0+ecGzCOwIIIIAAAggggAACCCCAAAII3ETAKwG8o7yQ4GD5afkyx0feEUAAAQQQQCCBBXLlyiUP1aglOihs5ixZJDw8XHRa1lOnTsnOP3fIqpUr5Px584iMhAACCCCAAAJJXsCrAXyS1+EAEEAAAQQQSKQCxYvfK/0HDZFKlR68aQ0jr1yR+fPnyoD+b8upkydvmpcvEUAAAQQQQCBxCxDAJ+7fh9ohgAACCCAQQyBlypTy3P9elB5PPm27pumXOhPML2tXy6HDh+Tc2bOSNWtWyZM3n9SqXUeyZ88hzZq3lNp16srQwQNlyuSJZtINZt2IgcoHBBBAAAEEkogAAXwS+aGoJgIIIIAAAoGBgfLjT6sld548FmPunFkyZvRIOyhsXDp+Zqq1atUfkmefe0EqPFBRBg/9QGrWqiM9unWOKzvrEEAAAQQQQCCRCxDAJ/IfiOohgAACCCDgENAAXoN3naL1uWd6m6fuaxxfxfkeaebm1j7wP69aKa3btpMBA4dKgYIF48zLSgQQQAABBBBI/AJmzgcSAggggAACCCQFAR2gbsVPP0rzRxvFG7xHPx5tMj996hTp1L6NGdjuz+hfsYwAAggggAACSUiAJ/BJ6MeiqggggAACd7eABvCdO7X3GGHdul9EXyQEEEAAAQQQSJoCXg3gkydPLm3adZASJUrYQXQWLVooM6ZNkTp168kDFSuJzhe/YP68pClHrRFAAAEEEEhEAjp1XKXKD0qTps2kQIGC8tdfB2Xmt9Nlwx+/+6SWXbp2l/tLlJRRI7+wg+o5CtW69OzdV+697347wN7q1atkzKgvRZv3kxBAAAEEEEDAPQGvBfCZM2eWuQu+l3z58jtrdObMGRvAFy12j/Ts1VeOHz8mixYu4CTuFGIBAQQQQACB+AVy5Mgp3c0o9MWKFZPt27fJtCmT7Y3xjz4Z5txYB69r07a99On1lHz/3ULnem8stHqsjbzTf5DdtQ6sp6Pia9J6zp63SPSaQM/5RYsWM3PW17Q3GPq98qLNwx8IIIAAAggg4LqA1/rAv9LvdRu8h4aEyOqfV8Wo0YRxYyQ4+Lx9Kl+wUOEY3/EBAQQQQAABBG4sEBAQKJOmzLDTyNWoWVt69X5GZs1dIP0HDLYb/fH7epk/b64c+ucfCQgIkLfe7i86+J23ko5uP/T9j+LcffMWrWzwPmf2TKlYvrTUrlFV9LrgsdZtJX36DHFuw0oEEEAAAQQQuLGA1wL4yg9WtaW++soLdqTc6FW4fPmymfJmq12V18xTS0IAAQQQQAAB1wQerFJFipon75p0QLuNGzeYed+zSeo0aWTrls3SulVz6dv7KXm06cNy4cIFyZU7t5QqXca1nbuZK0/evDJ67FcSFhYW51P+WrVr2z2OHDHcvh89ekTmzZtjbyhUrVbdzdLIjgACCCCAAAJeC+CzZM5idVf89FOcyufNE3hNOkctCQEEEEAAAQRcE3C0XFuy+Ac7oF2r5k1k586okeWXLl0sERHhdkenTp40U8hFnYNz5szl2s7dyKU3DMZ/NUkyZshgm+lrU/7YKVu27KI37Xft2un8atOmDXY5e/bsznUsIIAAAggggIBrAl7rA//333/ZAWuqVK0m2pwvetJmcxUrVrarDh7YH/0rlhFAAAEEEEDgJgJpUqex327dutm+R0RE2Cnlihe/V86ePRtjyxPHj9vPGUyQnZBJb74P/2KU3HNPcXnrzddk+Y9LzQB2Ja4rIpPp+x4SHCw6jZ0jBZ8PtospU6aKek+XRZKnSuv4Ot73yCsREh6YXPwDkseblwy+E4g0v0m6rHnFz99rl5b2YEJOHJCAwCDfHRglxSvgH3BVUqXPJEEBUf82xbsBGe56gbPHDtz1BrcC4LV/Zdf/ts4G8K+8+pqMN33eNekIucXMAHaDhr4vGTNmlBMnjosG+t5MqVOnln6vv2WfAAx4960YRTV8uJE0a95C8ucvIHv37pVvZ0w1TytWuJ0nxgZ8QAABBBBAwIsC/gH+du+XLl1ylhJi+pVrumKC+egp9EJo9I8Jtqznz9p16srePXtk/769Uv2hGnZgOi2gZMnScvr0aflzx3aJCDf1Mef+6MnfP6rlXUBg1CVI+OVQ0aDc1XT1aqT4XbkiVyOvuLoJ+XwgcNX8JpdCz5mf2/stKyNNWaTEI6ATSoRfDJVLEtX6J/HUjJogcGcKeC2A//CD96R+w4elUOEiMnDwe1avWfOWJmBu6ZTUgFqfHHgr6ROCzz7/UurVbyDnz5+T6AG8DqzzyWfDzQVApBw9elQaN2kqjRs3kS6dO8qKFcttlVzJ4626s18EEEAAAQRuJpA2TVo7yrvmyZYtq82aLl1657qo9d5ppq7TxGoqUrSoHVDPfrj2x6uvvSENzPm/WdNH5OTJE1K4SFEJCgqy/eQ1S5YsUXU9eeKE3SLi8kXRlzspKDLCzGDjvesHd+pC3igB/T3CLkR1j/SmSYC5PxDJzRtvEru9b3NPTcLDLsjl8Atub8sGCCDgvoDXbpOeO3dWmjV5xM7zHvtO6ZHDh+XJ7k/YUXLdr7LrW7za7w0bvMe1RbfuT9oWAU/26CJVKpcXnc7Gz99funTr7szuSh5nZhYQQAABBBDwocAzzz0v637fZF9t2nawJesMMI51+t6yVWuv1Oin5cuk8SP1Y7y+nTHNljWw/9vSt8/Tdnm3mU5OR8DXJ/SOVMs8ude0d+8exyreEUAAAQQQQMBFAa89gdfydbTZPr2elP+Zk3f+AgUkbdp08vdfB23TOhfr53E2naLmqZ69bf977YOnc9A6ki6XLFVa9pmLh6VLFtvV06dNkVdfe1OqV68h/iaQ1/6C8eW5QhMuBynvCCCAAAI+ErgScfubD2tf+9j97f8y53dNf/65Q/75+2+7PGP6FGn6aDP54MNPZdLEr+21QI0atWyze+1qR0IAAQQQQAAB9wS8GsA7qhIeHm77yTk+e/v9gYqVZMh7H9r+9T26dZYp02fFKFJHxdW0xUy340g6wM6WLZtELywyZcpsmvhFjaJ/szzaNNB07nPswsV3HcjH3W1c3DXZblGA3+UWAdkcgbtA4L/B2G7XwY4eNUKmTpnoVvGhod7pCx+9EheulRG9rJ9XrZRBA9+Vl17uJ736PGOfxh/Yv0+6de0cfVOWEUAAAQQQQMBFAa8F8AMGDpG69RrctBrhZqobHQBHm+JNmTxREuKJdt58+eyctBcvXpAnHu8Q59P+zNeCc+0XHz0Fn4/qu5UyZUpxJY9um71w6ei7iHf5+P7NEpg8Zbz5yOBbAR10J1vh60dQ9m0tKA0BBBK7wMXzp+X8yX9uazV17JgzZ87c1jrEVfi4saNFX7HT6JEjZPzYMfbGuA5mq63zSAgggAACCCDgmYDXAvj8BQtKrty5462VjgBfp249ecg8+dan5bea+plm8JkyZZIRXwyTXLly2Zc2h9fparQP3s4//zQDbUSNkukXa6RUbTqvKcA0+Xclj+Y9vm+TvrmVwi8zyIdbYD7IrKMae/Jb+qBqFIEAAgjEENCbzNmz54ixLr4Phw8fEm0Nd7uSzk1/7NjR21U85SKAAAIIIHDHCHgtgNfR3TUN+/RjOz9sdLGPPhlmR6XVAW+OHTsmvU2zuvoNGtoAW5vb3UoKCooaGbdX72dEX9HTpCkz7Ej0y39cZlc7nrI78mTNms0unjp5UsyktfHncWzIOwIIIIAAAj4S0AFWX3rlNbdKe/65vjJr5gy3tiEzAggggAACCCQ+Aa8F8EWKFLNHO3nSN9fddR8yeICMHf+NFCpUWF58/lk7wFz7Dp2kTJmycqsB/FtvvCqfffpRDOnRYyZIlqxZpUWzxvLXwYNmKpvLon30KlWuIqlSpZILFy7YOpQ25evc9Nq03pU8MQrhAwIIIIAAAj4QSGamSHU36VN7EgIIIIAAAggkfQGvBfDabF2TDg4XO+3Ysd2u0vljNW3VweRMAJ8nbz77+Vb+OHLkiOgrejoffF7SpE0TVc61L+bPmyPt2neUiZOny/r16+zgdTrVzfSpU2yOS5cumWnubp4nehksI4AAAggg4AuB48ePm3mwI8XvWiC/4qcf5Yvhw2TL5ht36dJ+8yQEEEAAAQQQSPoC7t/Gd/GY9+7ba3NqU7/YqUKFinaV4+IjQ4aM9rO3+ueFhYVJ2OWwGNUYYOap1Yue8hUekJ69+krxe++TeXNny7DPPnbmcyWPMzMLCCCAAAII+EBghpn2tHaNqnbwVz2/1axVR76dNU/GjPtaypQtJ3oDOvaLAN4HPwxFIIAAAggg4AMBrz2Bnzdnlm0Sr3OxN2naTH78camc+fdfKV22rFQ2Tdc16ZywmsqUK2ffT50yfc+9kJo8Uv+6vYaGhEjnTu0lXbr0tvn8CTMlnK6LnlzJEz0/ywgggAACCPhC4MCB/dLvlRflow/fk67dekinx58wg8HWtK8Nf/xunsh/JsuWLvFFVSgDAQQQQAABBHwo4LUAfsL4sVK2XAVp+mgzOxq9XlxETzoa7efDPrWrUqRIIfv27pHf1/8WPYtPlrW/e+zp5GIX7Eqe2NvwGQEEEEAAAW8L6KCr7w8dbJvQD/v8SzN9a30pV76CjJswUQrkzRFnNzZv14n9I4AAAggggID3BLwWwGvf9769n5LZs76VevUbiPZ3T5EipRwxU9ls2rRRJn7zlfOJ9+Md2nrvCNkzAggggAACd7CANqHv0/dZeaBiJXuUev7Vp+9xjUFzBzNwaAgggAACCNwVAl4L4B16Py1fJvoiIYAAAggggEDCCOgYMg0aPmID9xIlS9mdXjED1c0zg69++cXnsnv3roQpiL0ggAACCCCAQKIS8GoAHxQUJPeXKCn58xdwjpYb/eh18J2FC+ZFX8UyAggggAACCNxEoGKlyjL0vQ+lcJGomVx0wLrp0ybLqJEj5PChQzfZkq8QQAABBBBAIKkLeC2Az5o1m0yaMt2O7n4zpPW/rZPjx4/dLAvfIYAAAggggMA1gUqVH3QG77pq8+aNoufcN95851qO699GmKfydsrW679iDQIIIIAAAggkIQGvBfBP9+pjg3dt0hcSGiLp02eQo0ePyJ7du6V0mTL2szqFh8ec3i0J2VFVBBBAAAEEbrtApUoPxluHNat/JoCPV4kMCCCAAAIIJH4BrwXwVapUtUf/8kvP21HoX3jxFRk88F2ZP2+uaPM/nbP2xInjZgT44MSvRA0RQAABBBBIJALff7dQTp865VZt1q9f51Z+MiOAAAIIIIBA4hTwWgCfJWtWe8Q//PCdNG/e0i7nyZPPvv+27lc7wE6xYvdIhQoPyK+/rk2cOtQKAQQQQACBRCawd88e0RcJAQQQQAABBO4+AT9vHXJkZKTdtc7x/s8//9jl8iZYdyQddEdT9hw5HKt4RwABBBBAAIF4BHLnyRNPjpt/rQPLkhBAAAEEEEAgaQp4LYB3NO8rWbK0/PH7eom8ckXq1qsv3Xs8JR06Pi7333e/FTt//nzSlKPWCCCAAAII+FggVapUsnrteunYqbPbJfv7+8vQ9z+SkaPHub0tGyCAAAIIIIBA4hDwWgC/b+9ee4Q1ataS4ODz8v33i+znN9/uL4OHfiD+AQFy6uRJ+X39b4lDgloggAACCCCQBAR0DvhBQ96Xz4ePtKPPu1Lle81N81lzFki79h0lIDDQlU3IgwACCCCAAAKJUMBrAfyQIQOkRbPG8tX4sfawdTC7RQvnm0Hrzok2r9+xfZt0faKjDe4ToQtVQgABBBBAINEJaPez4Z9/amZwCZemzZrLilVr7U3xBypWkmTJksWob0BAoNSr30C+HDVWFn23RMqWKy9nz56VL82UciQEEEAAAQQQSJoCyTJmzHjVl1XXJwcB5ul7WNjdO31c6hb9fUlOWS4IhM4zv8mVCBdykgUBBBC4/QJFixWzT+GjTyGnQf3hw4fk3LlzkjVLVsmePbtt7eao7cxvp8ugAe/Iv//+61iVZN+DSjaUwKJVkmz978SKh+9ZK2Fbf/D6oQWYR09LWkeNs+T1wijAJYGD50T6LPOTC+EuZScTAgjcooDXRqEvXvxeeaxNO/n39Gn5YvhntpotWj5m++2lTpNGtm/bKm+/+TpP4G/xB2RzBBBAAIG7T2DP7t3SplVzaWZmeWneoqVUfrCqJE+eXAoUKBgDQ5+4r1q5QiZP/JoZX2LI8AEBBBBAAIGkKeC1AL5T5y42WF+37hcbwBcpWlQ++mSY6BN4TRrgZ8iQ0TajT5p01BoBBBBAAIHbJ3D16lWZM3umfWnwniNHTsmcJYukMTfJz5nA/dTpU3Ls6FG5YgaRJSGAAAIIIIDAnSHgtQC+VOkyVmjE8Ki+dl27PWmD94MHD8j8uXOkx1M9pU7depInb145dG2auTuDlKNAAAEEEEDAtwKXL1+Wv/46aF++LZnSEEAAAQQQQMCXAl4L4HPmzGmPY8Mfv9v38uUr2PcJ48bKVxPGSslSpaRW7bpSqFBhAnhf/uKUhQACCCCAQAII5M2Xz45qX6JESclunv5fvHhRfv9tnXz55XBxTCWrxWiz/p69+4qOhK8tA1avXiVjRn1pB7RNgGqwCwQQQAABBO4qAa8F8BcuXLCQ6dKnk5QpU0qxYvfYz2vX/GzfQ0JC7XuqVKntO38ggAACCCCAQNIRePjhRtK7z7MSaZroHzKD5+XLl1/Kli0n1WvUlAZ1a9oD0Wb9s+ctksyZM8vx48ekaNFi8pD5XoP6fq+8mHQOlpoigAACCCCQSASiOqR7oTI6wI6m4SNGy6fDvhA/f385bQa027t3j53qpkTJkvb7Y0eP2Hf+QAABBBBAAIGkI/CP6f42ZfJEKVv6PqlepaJUqVROTp48Yce40e5xmpq3aGWDd+2rX7F8aaldo6qEhoTIY63bSvr0GZLOwVJTBBBAAAEEEomA1wL4cWNH2UPUu/FVqlazy59/9rFtMvdIoyZSsGAhiYiIkH379iUSCqqBAAIIIIAAAq4KfP/dQvsUXUe61xQcHGwHzIuMjDSzcl6x62rVrm3fR44Ybt+Pmpv28+bNkcDAQKlarbpdxx8IIIAAAggg4LqA15rQr12zWp7s/oQZif4JO+f7H7+vl4nffG1rVrnyg3agnXW/rPXKNHLVH6ohjZs8KoUKF7Yj3Z88cUIWLZxvnxToqL2O1NA0/2vWvIXkz1/AtAzYK9/OmGqn23F8r++u5Imen2UEEEAAAQTuJoFMmTLZc27tOnXtSPiLF38vGqhrypYtu+gAe7t27XSSbNq0Qdp36GTnqdeVgSnSSEBQcuf38S1cNTcIzAT3ZmBcr13CxFcFvo9DwM/8JinSZJRk12YbiiNLgqwKDzltW3UmyM7YSYIIJPMXCUqRWq6mdP3/4wQpmJ0kWYGL508n2bonhop79ey3+IfvRV+x05tv9Iu9KkE/v/hyPylTpqyEhoba5nzaAkDv9Ov0OsM+/diWpc36PvlsuOiFwFEzzU7jJk2lceMm0qVzR1mxYrnLeRK04uwMAQQQQACBJCZQv8HDMmDQUGetJ349wbmcyfR9DzFP5qPfPA8+H2y/T5kylX33DwySwOSuj4cTeSVCriTzM4GiiRpIiUYgmflN/INSmuDaq5eWogF8Mo0YSYlGIJlcFf/A5BLo7/r/x4mm8lTktghcFAL4W4H32r+yufPksXfib1a58PAw2bJ5882yePTd3j27ZdqUSTJ92hTbZL9Bw4dl9NivpF79hs4Avlv3J21f/B49usjSJYulbbsO8t4HH0uXbt2dAbwreTyqIBshgAACCCCQQAJp0qaVPn2flerVa5ipWfOZud+PSIN6taScmf3l9TfelkuXLknnTu1st7UEKjLGbpaYJ+67d++S+8wo86+9/paM/2qS1KlZTf7++y+JCI8Qc7KNkd/fP6r3XkBg1CXIpeB/RV/upKDcYeIXcdmdTcjrZYErEWFy8V/vj2sUYP76aFmkxCMQaXrMXAw+LRfCCcoSz69CTe5kAa8F8P0HDJG69erHa1e+bAk5dfJkvPncyfDC/56JkV0Hz9MUZprxadLRcEuWKi37zIB6Grxr0mD/1dfetBdA/mbAvQwZMsSb54oZeZeEAAIIIIDA7RJInjy5zDGjvDtmetF6+PlFBcwaQOvUbalTp5aqVavLypU/eaWa//77r+hLp43V0eV7PNVTKjxQ0QbwOqhd4SJFJSgoyHan0wpkyZLV1kO7t5EQQAABBBBAwD0BrwXw//zzt+grrqR94vSiQ5OfaXLlrVS6dBmpZfrkNWvWwhbxzdfj7buWr2nLlv+e/mvzvi1bNkmNGrUkU6bM5gIjS7x59MJEm/65k66Eh5uHEd47ZnfqQt6YAu7+ljG35hMCCNwNAtrtSptwJ5bUouVjNngPDj4vE8aNle5PPu2smt4cn28GjGvXvqOUKlMmwQN4vTmwf99e28fdUWihwkXsYkhIVDP53WZGmuL3mlHqzdg0Py5bar/T87ImnZWGhAACCCCAAALuCXgtgH/nrddFX3ElvZgY+v5Hsn3bVjl1KmGfvkcv76VXXrMXDbpOB9BZu2aN/Vr7wms6f/6cfXf8EXz+vF3UeetdyaOZM+Yq6tjcpfdTf++w/YRcykwmnwnoTRV3f0ufVY6CEEAg0QhcCj4jIT5oJuzqAZc2471omj5tqnz04XtSq3YdyV+ggF2nf+h5VlPu3Hnse0L+8c67A6RoseKiTeh10LqKFStLteoP2VZ1v/7yiy1qxvQp0vTRZvLBh5/KpIlf27rpjXIN/Nf/ti4hq8O+EEAAAQQQuCsEvBbA30xv2tTJ8vyLL8v9JUpK0aLFYoxOe7Pt3P3ulZefl7ymP2CTps3MaPidZeTocdKyeRMJDwu3u4r99F+bzmsKMNPbuJJH8576a7u+uZUiwi66lZ/M3he4ejXSo9/S+zWjBAQQQODGAo7WbDr2S1wp2bX+5xcvJvx553czu0yp0mXtE/5w07pMp4b7c8d2efml/zlvkP+8aqUMGviuvGQGl+3V5xmb58D+fdKta+e4qss6BBBAAAEEEIhH4LYE8NpcXZ92a1P24vfe67UA/vChQ6KvX810dbVr15XyFR6QFClS2JHp1cXxlN1hlDVrNrto++Rfm27upnkcG/KOAAIIIIDAbRDYuyeqGbqOBD/VDN4aPelNaZ2uTZM+8U7o9MF7Q+TjD9+X7DlyiJalNwniGtNm9MgRMn7sGNs1TW8oOKaYS+j6sD8EEEAAAQTuBgGvdcbWk7QGy9Ff2jQ9S9as0rpNO8ln5l7XdPjwYfueUH9ouffdXyLG7jQIT58+ve2np08Jjhw5bKeYq1S5iqRKFTWNjQ5sp00RT5w4bp8cuJInRiF8QAABBBBAwMcCP/30oxmRO8I2nR8z7ms7+Gq6dOlFZ1+ZNWeBHcRO52F3TI+a0NXTwVyPmPP4P3//HWfw7igvIiJcjh07SvDuAOEdAQQQQAABDwW89gT+02FfSLPmLW9arW1bt8jv63+7aR53v8yYMaN8v/hH2+9v7ZrVcslcuLQwc76nTpNG5syeKXqxoS/HwD4TJ0+X9evX2cHrtPnf9KlTbJE67U58edytG/kRQAABBBBISIEd27fJxx+9LzrmS/0GDZ271qlTHUm/1wCbhAACCCCAAAJJX8BrAbyfX1R/8riIwsLCZNOmDWaQuzfi+vqW1umThj9Mvzyd/1b72GvSJvuzZs6Qt9/8b1C9Af3flpw5c0qNmrXtdDeRZmTheXNny7DPPnaW70oeZ2YWEEAAAQQQuA0Cwz//TLQ/eq/efc2I9MUlhzm3aWuyPWYE+JFfDhfth05CAAEEEEAAgTtDIJl5Yn3VG4ei/eFSpUod5651ehkNqr2ZtLl+LjPqbri5WaAj3V+4cCHO4rSpoTafP2GmhAsNCfE4T5wb3mBl6hb9b/ANq2+XQOg885skoqmhbpcD5SKAwJ0lEBAQIGnTpjVdw87b1md3ytEFlWwogUWr3CmHc0ccR/ietRK29QevH0uA6fy5pHWk18uhANcFDppJnfos85MLUWNEu74hORFAwCMB88+gd5I2U9d5aeN6eTt41yPSwXT2mTlm//77rxsG75pPp5I7cGD/DYN3V/NoPhICCCCAAAK+FGjc5FHZumO3fD1ximTIkOG6oh9r3VY2bd1pZ2O57ktWIIAAAggggECSE/BaAJ/kJKgwAggggAACSUwgXbp0oi3JataqIwu/X3rdIK5pzPgvmhzvSezwqC4CCCCAAAIIxBIggI8FwkcEEEAAAQSSokDevPlkzrxF8Q4gmxSPjTojgAACCCCAQJQAATx/ExBAAAEEEEjiAmNGfSkbN26wU7d+9vkIefvdgaL930kIIIAAAgggcGcJEMDfWb8nR4MAAgggcBcKHD16RB5r0VSmTplkj75rtx4yZdq3kjlLlrtQg0NGAAEEEEDgzhXg9vyd+9tyZAgggAACd5FAeHi4vPryC7J500bpP3CIVKpcxb7uIgIOFQEEEEAAgTtewGtP4HVAnYqVKt/xgBwgAggggAACiUlAn8K3bvmoHDt2NDFVi7oggAACCCCAQAIIeC2A7/T4E/LtrHnyw5Ll0qZde9svLwHqyy4QQAABBBBA4JrAX38dlF27dsqZM2dimGh/+EYP15Nf1q6x06SGRzBBcwwgPiCAAAIIIJBEBbzWhP7gwQOi873fe9/98v4Hn0i/196SaVMnyTdfT5Ajhw8nUS6qjQACCCCAQOIRWLP6Z6lfp0acFTp18qS0bd0izu9YiQACCCCAAAJJU8BrAfyAd9+SyZO+kcc7d5FWj7WWjBkzSs9efeWpp3rJ0qWLZcL4sfbJQNJko9YIIIAAAgjcHoF77iku95coKTu2b7PN5EuULBVvRTaZfvEhwcHx5iMDAggggAACCCRuAa8F8HrY+/ftlXfeel3eHzpImrdoJY8/0VWKF79XGjR8xL602d9XJpCfM3umXLx4MXFLUTsEEEAAAQQSgUD7jp3kiS7dZaJp0bZjx3YZ8t6H8dbqlZeeN63gJsebjwwIIIAAAgggkLgFvBrAOw79woUL9sLh9OnTMnzEKAkMDLRf6VMEvfDo9/qbMn3qFBk/fgzN6x1ovCOAAAIIIBCHwJEjR+TcubP2xvexY8dk9+5dceSKuSo0NCTmCj4hgAACCCCAQJIU8HoAnzVrNmnXoaO079BJcubM5UQ6cGC/bPjjd6lXv4GkS5deejzVUyKuRMjQwQOdeVhAAAEEEEAAgZgCo778QvTlSMt/XOpY5B0BBBBAAAEE7nABrwXwZcuWk+5PPi0NH24kAQFRxURGRsqPy5aagezGy8+rVtpB7lKnTi2PtW4n3Xo8KZcvXb7DuTk8BBBAAAEEElYgc+bMIsmSyelTp5w7LlmqtBQrdo/oQHarVq2w51vnlywggAACCCCAQJIV8FoA3+eZ/0ndevUtzL///ivTp02Wid98JYcPHYqBFRoaKl9NGGuD+hhf8AEBBBBAAAEEbiqQL19++XntbzaPjkavY8sMHvqBdOj4uHO7+XPnSN8+Tzs/s4AAAggggAACSVfAawH8pUsXZcvmTfL1V+Nl/rw5EhYWdlMlfTpPQgABBBBAAAHXBerUrWcz67zvGrxrQN+2bXu7TkedT5M2rTRt1lymmmlc165Z7fqOyYkAAggggAACiVLAz1u1Smaa85UqXUayZM0ab/DurTqwXwQQQAABBO5kgXz5C9jDWzh/rn2vVaeu+Jtua8eOHZVSJe6RsWNG2fVVqlSz7/yBAAIIIIAAAklbwGtP4B393iPCw5O2ELVHAAEEEEAgkQqkTp3K1kxnedFUrlx5+/79d4vkypUrsnnTBvs5R44c9j0h/yharJi0advBTg+b1dys17nmly75QVatXBHjxn2BAgWlZ+++cu9998u5s2dl9epVMmbUl0LLu4T8NdgXAggggMDdIuC1AH73rl12rnedKo6EAAIIIIAAAgkv8M8//9id1qlbX3777Vep3+Bh+3njhj/se7Zs2e17iBlvJqFTy1atpYcZrDbc3Kg/f/68tG3Xwb5mz/pW/vdsH1tcjhw5Zfa8RaID7R0/fkyKFi0mD9WoKRrU93vlxYSuEvtDAAEEEEDgjhfwWhN6PYFrv/cmjzaXvPny3fGQHCACCCCAAAK+Fli14idbZJOmj8raX/+QVKlSyZkzZ2T5j8vs+sZNm9n3f/7+K8Gr9tfBgzJm9EgpXbK4lCt9n7Rp1dyW0dSc9x2t8Jq3aGWD9zmzZ0rF8qWldo2qEhoSYmafaSvp02dI8DqxQwQQQAABBO50Aa89gW9sLiaCgoKs36w5C+xUNnFhPt6p3Q2/iyu/K+saNHzEPIVoKAULFhI/f3/RC5zFi7+X7du2xthcp7hr1ryF5Dd9CPfu3Svfzphqm/5Fz+RKnuj5WUYAAQQQQMBXApvNYLEjvhgmvXo/Y4vUp+HvDx0kwcHnRQe40yldNa1cGRXo2w8J9MfUKZNi7OnXX9favvf61D1z5iz2iXut2rVtnpEjhtv3o0ePyDwzsG37Dp2karXq8t2iBTH2wQcEEEAAAQQQuLmA1wL40qXLOkvOnj2H6CuuFBgQGNfqW1r35tvvSt68+ewFjJ+fv72AefZ/L0i3Lp1k2dIldt/6VOCTz4bLVTP6/dGjR6Vxk6bSuHET6dK5o6xYsdzlPLdUUTZGAAEEEEDgFgXeGzJIpkyeaJulb9q40Z77dJfbt22Tnk91N63hLsvePXtusZT4N3ec67X13enTUXPSaxP+y5cv2xHyHXvYZPrlawCfPXtU8/5k5jytA9+6nq7aee+TiTvbuL53cnooYH5DfWhifhwPd+DiZlcjzN8XF/OSzScC+nvo/8d+/vwwPgG/AwqJvBJxBxzF7TsErwXwQ4cMkEkTv473yP79N2rgnXgzupFhx/Zt8sF7g2Wemfs2wNwgeO2Nt6Rb9ydFg3ZHAK+f9YKhR48uZtCdxbbf3nsffCxdunV3BvCu5HGjWmRFAAEEEEDAKwL//P236Ct60pHoffWEW5vMf/DRJ/a8OnXKRImIiLo4y2T6vut0dlevmqD7Wgo+H2yXUqaMGoAvTcYckiJtJsfX8b5fiQiTS4EpxD8oZbx5yeA7gQDzm6TJWcTMghDV+tJbJZ/5e6sEBPLbe8vXk/36B1yVNJmySarkGT3ZnG3uQoGTB2O2ir4LCW7pkL0WwO/ZvVv0dTvSk927OIuNiAiXhQvm2QA+Z85cdr0OplOyVGnZt3ePDd515fRpU+TV196U6tVriL+5g5whQ4Z48+gIvyQEEEAAAQTuZoHAwEAZPmKU1KhZW3TwvMED+zs5IsJNIB/rcam/f9TwOwGBUZcgwacPi77cSUEZC0qysAvubEJeLwtEhF2Ufw/t8nIpIgHmr0+4KYuUeATMpbYEnzokF8IPJZ5KURME7mABrwXwDjPti6590nXEWe2bF2zuxG/btkUmjBtrRq0958jm1fdSpcrY/R8+HHWB4BiVd8uWzc5y9enAli2bpEaNWpIpU2bJkiWL/e5meU6ePCFBKdM49+HKQtjFUHMto03MSIlNwN3fMrHVn/oggID3Ba6YK9Ur4Ze9X1ASKSFduvQyeuwEebBKVfll7Rrp3q2zXLp0yVl7PU8WLlLUjomjTes1ZcmS1b6fPHHCvvMHAggggAACCLgu4LUAXpvTjR77lR1EJ3Z1NKjv0rWHPN6xjWzZ/F8QHTtfQnzWGwfPPf+ibb43+VqT/szXgvPYNxCCzTQ4mlKmTCmu5NG8qTPm1DeXU9ilvaZ5WcL3+3e5AmSMU0D7Urr7W8a5I1YigMAdLXD5wjm5cJbAU3/kQoUKy9jxX9sAfe6cWfLi88/aG/XR/wLsNi3xit97n1R/qIb8uGyp/apWnbr2fa9pBUdCAAEEEEAAAfcEvBbAP92ztw3e9cn2kiU/yJrVP9ua5c6VW9q06yAZM2aUz78YJXVrVb/uhO/eIdw4t45CP3XGLFvWh+8PER0hV1N4mGnrY5JfsqhmfPaD+UObzmsKMM0BXcmjec8ccf8CJCL8v6cTug/S7Re4Klc9+i1vf82pAQIIIHB7BD76ZJgN3rX0ixcvyoBBQ50V+XHZEttFbcb0KdL00WbywYef2nFx8hcoYFu67d+3V9b/ts6ZnwUEEEAAAQQQcE3AawH8I42a2Br0f+dNGT9uTIzaTBg/Vr5b/KNtVl/snuLXTe8WI7OHH8qWKy/jJky088/qCL06zY4jaZM+TY6n7I71WbNms4unTp4U88jeLt80j2ND3hFAAAEEELjLBKI3lW/XvmOMo9dR6HWA2J9XrZRBA9+Vl17uJ736PCPaX/7A/n3SrWvnGPn5gAACCCCAAAKuCXgtgC9gnn5rij1PrK7TeWBXmqnadFT4IqZvXOz52TXPrSTdr44o7+fnJ88901vmzJ4ZY3dHjhyW0NBQqVS5iqRKlUouXLhgA/3SZcrKiRPHbd98nXYnvjwxdsoHBBBAAAEE7iKBdm1aunS0o0eOkPFjx9ixZXT2F70GICGAAAIIIICAZwJeC+D1KXfq1AWloOkjp9O6RU96As+fv4BddelSwo4kmiNHTvl02Bd237t37zJB+oP25Sj/k48+kOPHj8n8eXNEnxhMnDxd1q9fZ5v06ZOB6VOnXKvXpXjzOPbJOwIIIIAAAr4Q0KlRJ06eZgeFc6e894YOkt/W/erOJgmaV2eE0WntSAgggAACCCBwawJeC+B1cDodQO4LM7XM66+9Iut+/UV02rVcuXLZQeXKla8gkZGRCX5BofvUfvd6k6BYsXvsKzrRN19PsAH8gP5vS86cOe20NxUeqGjrMm/ubBn22cfO7K7kcWZmAQEEEEAAAS8LBAUFSpWq1dwuRc+HtzOAd7vCbIAAAggggAACcQp4LYB//71BUrt2HSlUuIhMnT5LIk3wHmamkUuRIoWzIl8MHyZnzpxxfk6IBW0CXyBvjnh3FRoSIp07tRedAkfnhT9hWgzouujJlTzR87OMAAIIIICANwV0sLjuXR83fcmD3Cpm29YtbuUnMwIIIIAAAggkTgGvBfD//P23tGr5qLz51rtStVp18TMjvKe4Nsr76dOn5dOPP7Aj0t5uFp1KLvZ0crHr5Eqe2NvwGQEEEEAAgYQW0BZmOjgcCQEEEEAAAQTuTgGvBfDK+eeO7dK+bStJkzatbU6vA8Yd+udvM4DNUdvM/e4k56gRQAABBBBIOAGdAlXHdNG51vPkyWu6iR2Xrk90lHvN/OtP9+ojOlr8qy+/wHk34cjZEwIIIIAAArdNwKsBvOOoQoKDheZ7Dg3eEUAAAQQQSBgBnW1l8tRv5cEqVZ07zJf/nF3WmVQaNW5qp26bNXMGfeCdQiwggAACCCCQdAW8FsAHBATII40a20HiqlSpJinN0/fYKTw8TGrVqCoa4JMQQAABBBBAwD2BJk2b2eD98uXLsmjhfGnR8jHnDv7++y9ZuGCenbK1QoWKBPBOGRYQQAABBBBIugJeC+DbtG0vg4d+EK9M2jRpCeDjVSIDAggggAAC1ws8YGZR0TR71re2mXzRosUkf4ECdp3+sWnjRhvA58mb17mOBQQQQAABBBBIugJeC+B79u5rVdas/llGj/pSdHT4KxER10mdPHnyunWsQAABBBBAAIH4BdKmS2czbdjwR5yZw8Iu2/VxnX/j3ICVCCCAAAIIIJCoBbwWwKdPn94e+OBB/en/nqj/ClA5BBBAAIGkKnDgwH5b9Ro1asqMaVOuO4xmzVvYdfv377vuO1YggAACCCCAQNIT8PNWlXft3Gl3nTdvPm8VwX4RQAABBBC4qwXWrlltj7/hw43k7XcHSm4zCn1QUHK57/4SMmLkGKlUuYpERkbKL2vX3NVOHDwCCCCAAAJ3ioDXAviFC+Zbo+f+94LogHYkBBBAAAEEEEhYgd/W/SoTv55gz7Ndu/WQTJkySYoUKeT7xT/aEei1tK8mjJOdO/9M2ILZGwIIIIAAAgjcFgGvRdbffD1eXnjpZSlu5qHdumOPXLlyff/3sLBweahaJQaxuy0/PYUigAACCNwJAm++0U82bdoovczYMwULFhI/My+8PnXXUehHjhgu06ZOvhMOk2NAAAEEEEAAASPgtQC+zzPPSbp0Uf3gU8UxhZxDn1HoHRK8I4AAAggg4L7A1atXZea30+0rICBQsmXPJqdPnRKdWo6EAAIIIIAAAneWgNcC+EaNmliplSt/ktEjR8jJEyck4sqV6/ROnjxx3TpWIIAAAggggID7AhER4XLk8GH3N2QLBBBAAAEEEEgSAl4L4HPlzm0B3hsySLZv25okMKgkAggggAACiVkgefLktltaYGCgW9Xs0+spWbQwamwatzYkMwIIIIAAAggkKgGvDWL3547t9kDz5y+QqA6YyiCAAAIIIJBUBZIlSyb+po+7n5+fW6+MGTMm1UOm3ggggAACCCAQTcBrAfz0aVNtMc89/6IZHde9JwXR6sciAggggAACCFwTuHTpkpQtdZ9UqlDGvj75+AP7zZLFPzjXOb7r2L61RF7rurZm9c8YIoAAAggggMAdIOC1JvTlKzxgee65p7hs37nXjogbl1eth6rIsWNH4/qKdQgggAACCCAQS+D8+XOiL01Zs2az7z8tX3bduVTPrTqla9NmzaVe/QYyetSXNi9/IIAAAggggEDSFfBaAO+4qFAanZP2RkmbA5IQQAABBBBAwH2B1KlT243SpE0b58a7dun8783l3vvuj/N7ViKAAAIIIIBA0hLwWgD/0gvPyqAB8fe5YxT6pPUXhtoigAACCCQegZ07NUAX6dq1hx2k7vChQ87KBQUFSd16DeznKxERzvUsIIAAAklSwDzzS1kmZZKs+p1c6YsbL97Jh5coj81rAfzZs2dFX46kI+ZeMX3xIiMjHat4RwABBBBAAIFbEFgwf6706fus5MyVS9b++ofs2L5NNm7cIHny5JGy5cpLunTpRYP38ePH3kIp8W/as1dfyWXq8OYb/a7LXKBAQenZu69tBXDOXBesXr1Kxpjm/FwPXEfFCgQQuIlAMr9kkrZW3K2NbrIZX3lZgADey8Bx7N5rg9hpWeXKV5DJU7+VTVt3yt4Dh+Sd/gNtFXRgu59WrpGBg9+Lo0qsQgABBBBAAAFXBPSJe5+eT4mjNdt995eQDh0flxo1a9vg/erVq/Lppx/ZwN6V/bmbp1r1h+TZ/70gL778qtRr0PC6zXPkyCmz5y2Stu06SI4cOaTCAxXltdffkkFD3r8uLysQQAABBBBAIH4Brz2B1+B91uz54memu3EkfRKgacvmzfK/51+SXLnzyOCB78qFCxccWRL0XefL/fCjz2Tx4u/NQD7zrtt3w4cbSbPmLUSnutu7d698O2OqrFq5IkY+V/LE2IAPCCCAAAII+FBgxYrlUqP6g9K8eUspds89kjt3XtMC7owc+ucfWbBgruzds8drtZk4adp/5/mr1xfTvEUryZw5s8yZPVOee6a35MyZS3786Wd5rHVbGTp4oJw7919Lveu3Zg0CCCCAAAIIxBbwWgD/nLkjr8H7xg1/yNw5s+XdAYOcZS//cakcOXzYBPC5pXCRorJ1y2bndwmxkClTJnmgYiVp2aq1NGj4iBw/cfy6AF4vKj75bLhcNU36jx49Ko2bNJXGjZtIl84dRS+GNLmSJyHqyz4QQAABBBC4FYHQkBCZNPFruwvtshYeHn4ru3N527ffel3EDEb79jsD4tymVu3adv3IEcPt+9GjR2TevDnSvkMnqVqtuny3aEGc27ESAQQQQAABBOIW8FoT+hIlStkSBw54xw6sE7v4HTu221XaZy6hU8VKD8rosV/Z4P1G++7W/UlzzZFMnuzRRapULi/9XnnR3nDo0q27cxNX8jgzs4AAAggggMBtENBzWavH2sii75fKjl37ZeuOPfLn7gPy3Q/LpHWbduLn57VTvXzz9QT55qvx5kb4kTiPPFu27HL58mXZtWun8/tNmzbY5ezZszvXsYAAAggggAACrgl47Qm8o+n8gQP7baAcuzravF3T+fPnY391y583b9poB9LRgXM0CI+dtDlfyVKlZd/ePbJ0yWL79fRpU+TV196U6tVriL9pOZAhQ4Z48+igfCQEEEAAAQRup8Cnw74w3cFaXleF+0uUlA8++lSqVK1mm69fl8EHKzKZ821IcLBoX3xHCj4fbBdTpkxl31NnzCHJU0d1sXPkudl7ZES4XA5MLgGBN56i9mbb8513BCLNb5IhRyHxCwj0TgHX9nr+yC4JCIq6hvRqQezcZQH/wKuSOmMWSRHk+v/HLu88WsYzx/aI///buxPwKKpsgeMnGxC2KAkEByHsOgvEsItCAvgcGRRcEQTBiCiiiOOCyHNGn+KKs4iAiAMuKMgisuhDRtlkDUGEuCHD7ggkgTCEBJPuLFP3xo7pJG3SsSupSv3r+0JXV92qOvd3bbtPLffS9iVELDJrnERu0qKjX8Fk/Ptbv8pT2FvAtAR+37690tO4En7ttdfLyhXLvY6qflRcZvygUNPBAwe81gXijboSoK4IqCS9vAReXRFQU0qJW/fVj4uUlN0SH99PmjSJlKioqArLqE6DwhtF6nKV/eeHsxnG1RDT2CsbBuVKCQRJkNTzsy1L7YK3CCDgAIE8d464c7ItU9MEo7M6T/K+cMHb8t7SxZJ55oxEGCehb7xpqNw8bIR+HGzF8vdl/bpPqj3uPLcxfJ3x467kFBJSdEdAaFjRd2GO8b3oOlf5k/nq+zok+mKjd31Xyd0yX8MCBfluyco4Xu5Fm0CHll9Nj4gEOu7aur8C42OuPsc5BZX/HFfNolDUCTwmqwkUytn076wWVK2Ox7RM8v8/+EAn8FMee1wS+g3QiF27dZcJ990vargZdYV+x47tkpp6otqBI39MzjMzz3gd++yPdwOEh4dLZcqojcPCG3jto6I3P2RlSFDwTx37VVSe9dUn4G9bVl9kHAkBBKwjUGipBD6+X9Ez5vPfekMem/KIF9OOpO3icrnl1lG3Sc9evWokgVcnulVfN2pMeperKOGOimqq40xPS9OvKhH3NxkPNvqvKSxkWFqvBq/hN6pPoTyX+eNBhxrnf2j7Gm7sUodXN9ioz7Dbbe5JtaCQIN13VanD87amBYz2d+ea0yF5TVfNqsc3LYF/8425uoOaK41hZfrGJ+j6t2oVYww1UzRGbEZGhjz2qPePjepCchs/aNQUHOT9XKC6dV5NoaoDoEqUUWUz046qF7+m/Lxcv8pT2HyBQimsUluaHxlHQAABBHwLREUW3S2WtH1ruYW2bd2iE/iWLVuVu97shfv27ZOLf/0b6dM3XtZ+8rE+XL8BV+jX/cZjbEwIIIAAAggg4J+AaQm8usVt7JjRMnjItTLk2hukXbt20qhRYzly5LC+dX26MS6tSuJrYvKMl+u5yu6JoWnTZnr2ZHq6Or2r53+2jGdDXhFAAAEEEKgBgSNHj+ijXnZ5X1m1suxwqSpxVlPaj1e79ZsA/jM6cYw0atjQGHO+se4s794JE/XQsPPmvqaPsnjRAv07YNqLf9e95Me0bq0fVTt4YL8k70gKYCTsCgEEEEAAAWcImJbAe/jU8++ln4H3rKup12PHvpfs7GzjlsLeUr9+ff1jQ3VsF3tJnPEjJ9XoWO+McatfboVlaip+josAAggggIAS2L5ti340bfgtI/Vt6uoZ+IxTp/RjYGqsdc/z8Rs3rDcF7Alj+DhPp7XqAA8/MkXOns0UTwK/6dON8vTU/5OHjbvvxt97n6gh7g4dPCBjbh9tSjzsFAEEEEAAgdouYHoCH2r0Rto5NlYnyqUx1W3qSUnbSi/+xe9btmolQ4ZcJy2NW/bV1KNnL1FXBb5ISZGNG9dLTk6OcVLhfVE/eOa/s0iSk5P0FQH1w2LRwgV6m8qU0QX5BwEEEEAAgRoS2LzpU3l34TsybPgIueHGofqvdCjL3lsiG9avLb04IO/bxFQ8FOyc2bNk3j9e053DqiHvfA05F5CA2AkCCCCAAAK1XMC0BF7djv7Mc9N0b/MNjNvrfE3d4jqJ55Z2X2X8Xd6hw0X6KoBnu9jYS0T9qR85KoFX01NPPi4XXHCBxBs9+Hbr3kMKjM5XVixfJtNf+qtns0qVKS7MDAIIIIAAAjUgMHnSg7Jl86eSePtYaduuvYQa/bnkF+TrUV7eeH2u/m6rgbC8Dpln9Bx94sRxr2W8QQABBBBAAAH/BUxL4O9/4CFRHdipSd2Srp4rzytn3HTVeVigp3VrP5aYC4uGivO17+ysLBnGCpqfAAAUAElEQVR96y3Gc3sRom6fTzN6ylXLSk6VKVOyPPMIIIAAAghUt4Dqc6bk42rBwcH6pHR1x8HxEEAAAQQQQMB8AdMSeNV5nZqee2aqzH5lhtEnXOAT9UDwqJMLpYeTK73fypQpvQ3vEUAAAQQQqAkBdUcZEwIIIIAAAgjUTgHTEvhz587pq9ubjdv6rJq8184mpVYIIIAAArVZIPH2O2TylD/5VcWJE8bLR6s/9GsbCiOAAAIIIICA9QRMS+BT9uyR5s0v0GPBf5Gyx3o1JyIEEEAAAQRsKNCwUSOpV6+eX5FHRRWNF+/XRhRGAAEEEEAAAcsJmJbAvzLrZbnif66U+yY+YAwZc1ByjZ7fS08ut0u2btlcejHvEUAAAQQQQMCHQJ47z2uN6mH+9Xlz5cx/TnstL/nm6HdHS75lHgEEEEAAAQRsKmBaAn/06BH5wbiNXvVAP+cfr/vkMaMXep8HYwUCNSgQbnzaBsQUynl1azAIDl1GYME3QVJgzS46ysTKAgSUwKuzZ8rBg/vl7vETJK5LV0noN0C69+gl78x/U16bM1vS0lKBQgABBBBAAIFaKmBaAv/4E1N18q7cMjIy5OTJdMnP875qoNaZ0Qu92i8TAlYTMIY/lus7FkrrCKtF5ux43t1LAu/s/wLsV3vVSd2aj1brv549L5Vx4++Vfv0HyJ3jxsttxvPxSxa/K7NnzRB1Ip0JAQQQQAABBGqXgGkJfI+ePbXU0089IXNefaV2qVEbBBBAAAEELCCQlLRN1N9FF10sf3r8SenTN15GjBwlw4ePkLatW9CJrAXaiBAQQAABBBAIpEBwIHdWcl+enue3bdtacjHzCCCAAAIIIBBAgRYXXii3jrpNevTsVbzX7/79XfE8MwgggAACCCBQewRMS+B3fbZTK11+ed/ao0VNEEAAAQQQsIhAu/Yd5C9/my6bNifJraMTpW7duvL1V1/KhHvukn59e3P13SLtRBgIIIAAAggEUsC0W+jfX7ZUBl09WCZM/KMcPnxIXK7ccuPevOlTyc0tf125G7AQAQQQQAABBwu0bddeHp40Wa4aOEiCg4vOw6vb6GfNeFlUj/RMCCCAAAIIIFB7BUxL4IcNH6nVGjRoILPnzPUp2Kt7nBw/fsznelYggAACCCCAwE8Cg66+Rv4w6JriBRs3rJOdO5Olc2ys/iteUWJm/bq18kXKnhJLmEUAAQQQQAABOwqYlsDv3fu1REdHV2jiznNXWIYCCCCAAAIIIFC+QHxCf1F/PzdlnDpFAv9zQKxDAAEEEEDAJgKmJfDTnn9W1B8TAggggAACCAROIDkpSd56Y55fO9y371u/ylMYAQQQQAABBKwpYFoCb83qEhUCCCCAAAL2Fti+fauoPyYEEEAAAQQQcJ4ACbzz2pwaI4BADQjUiakjoc35X24N0Ps8ZN6JPHEdcflczwoEEEAAAQQQQMBqAvyatFqLEA8CCNRKgTpt6kj9LvVrZd3sWqlzu86RwNu18YgbAQQQQAABhwqYNg68Qz2pNgIIIIAAAggggAACCCCAAAKmCJDAm8LKThFAAAEEEEAAAQQQQAABBBAIrAAJfGA92RsCCCCAAAIIIIAAAggggAACpgiYlsCPThwjXbp28xl0gwYN5IEHJ0mdOnV8lrHCiqsGDpLZc+bK6jVr5eWZr0rf+AQrhEUMCCCAAAII2EKgdes28vy0v8rKD9fI/HcWyV133yPBwab9/LCFCUEigAACCCBQVQHTvkH79k2QxUuXyy0jbi0TW4eOHWWV8UU+8Y8PSmRkVJn1Vllw3fU36uT9978fKBER58nV1wyWN99aIAkJ/a0SInEggAACCCBgWYHmzS+QZSs+lGHDR0jz5s2lW/ceMuV//yxPP/uCZWMmMAQQQAABBKwsYFoCf+pUuoSFhcmzz78oz73wFz2vIAYPuVZWrPpI2rXvIAX5+eLOc1vWZ8wdd0pQUJDcOTZRevfqKo8+8pAEh4RI4pg7LBszgSGAAAIIIGAVAXUiPDIyUt5ftlR6dI2V/vGXSXZWltw0dJg+MW6VOIkDAQQQQAABuwiYlsBPmTxJXpn1shQWFsrwW0bKkmUr5W8vzdC3oavb50+cOC7Dht4gJ9PTLWmlfnB06hwrB/b/Sz7+5xod46J3F8jp06elT594CTESeSYEEEAAAQQQ8C3Qr3/RHWuzZ83QhY4fPyYrVryvT+pfdnkf3xuyBgEEEEAAAQTKFTAtgc/Ly5PnnpkqiaNHitvtlri4LnL9DTfpINat/UQGXtlfkpK2lRuUFRY2axatw0hJ2VMcjjoZkZKyW0JCQ6VJk8ji5cwggAACCCCAQFkB9V2am5sr3367t3jl7t279Hx0dNH3bPEKZhBAAAEEEECgQoHQCkv8wgIhIWXPEWzYsE4yMjJ+4Z7N3TwyqujZ/MzMM14HOpuZqd+Hh4fr1+h2cV7rK3qTenC3BJ05XlEx1lezQJBxvGZ+tqW/IQbnZMi/Mr+XrAJ1NCarCBSKW/z9HPsbe77bJTlZ30t+Km3vr52p5bNCJarVbyUkrPKdqf6QeVIy078zNazatPMmxt1sWWfP6rvxPPU6m3lWz4aH19evjZu2lPDGle8PR32eslzZfJd6QC3yGmy0ib+fp6qEfvLQ5/Ll6bpV2ZRtTBI4nlUoEc1aSKN6TUw6QtFu047s4XvUVOEq7tz4aRPd1s986MDnVTwYmykB0xL40NAwmTzlMRl75zgtferUKTly+JDumf7Jp56RSy/tLZMeekBKJ8hWaRa3q+jZ/OAg7xMQnlvnQ43n+6syRbe9ROTw9qpsyjYmCjRo3cnEvRftusD4Ypt3wtwvN9MrUQsPENXG/EqpBLHBaeNAfPTNx/bjCPoLsGr/K/fjKM4umufOE6MzGS8Ez4n90LCq/QRRn6eIvCy+S71ULfLGj5NhVY04qk2cPL2/qluznWkC9Uzbc/GOm8XE8j1arGGdmei2v7JOMA6JpGrfnpXAee75aXLTzcN1yc92Jsv4cWMlNfWE3D1+gjw8abIM/MPV8rtOneUq41Z6dXbealN6epoOyXMl3hNf06bN9Kzn2f1UziB5aHhFAAEEEEDAS0B9l6pOa9WQsS6XS6+LimqqX9PTir5n1R0N3NXgxcYbBBBAAAEEfAp4X172Wcz/Fef/+Iz4vLmvydAbr9Od1qlnyGfNnC4jR9ysb6Fv2bKVNGrYyP+dV8MWx459L9nZ2dKzV2+pX7/oNj/VsV3sJXGSlpZq2TsHqoGGQyCAAAIIIFApgX379ukO6/r0jS8u32/AFXp+v9FJLBMCCCCAAAII+Cdg2hX4r778Qg8b88GqFWUi2rJ5kwy6aoDulT7fGErOilNOTo6sNHrKVT3oz39nkSQnJ0l8fD/9Q2TRwgVWDJmYEEAAAQQQsJTA4kUL9PCx0178u7w9/02Jad1af5cePLBfknckWSpWgkEAAQQQQMAOAkHnn39+oR0CrYkYGzRsKLNemSPxCf31ePAFBQWyauVyeeiBicW3AtZEXBwTAQQQQAABuwjcOW688ejco/p7NMzoP+bQwQNye+IoUUk8EwIIIIAAAgj4J2BqAt85NlYGD75OWhln3Et3BqfCdLly5f777rF8Mty4cYSo2+fTjGf5srOMjnOYEEAAAQQQQKDSAqpj2yhjdJcgo0M7NRY8EwIIIIAAAghUTcC0BL5b9x6ycNF7uuOanwutV/c4vsx/Doh1CCCAAAIIIIAAAggggAACCBgCpnVip4aPU73OHjp0UHZ9tlNjq+fhJ096ULZv26Lfq07izpz5Dw2BAAIIIIAAAggggAACCCCAAAIVCJiWwHfo0FEfesI942TNmtV6fsP6dbJwwdty7/hxojqJq1u3rtSrVw0DR1aAwGoEEEAAAQQQQAABBBBAAAEErC5gWgJ/3vlNdN0PGMPEZGRk6Pk2bdvqVzUu7DdffyWhoaFySVxXqxsRHwIIIIAAAggggAACCCCAAAI1LmBaAp+dXdTZW9OmzWTf3m90Ra+8cqCEhITo+SZGp3BqioiI0K/8gwACCCCAAAIIIIAAAggggAACvgVMGwc+LTVVWrWKkUt7XyZLlyzSvbd36NhR3l2yTFy5LomJaa2jOnr0iO/oWIMAAggggAACCCCAAAIIIIAAAlrAtCvwyclJkpaWKu2NZ+Hz8vJk2gvP6gP26NFLLu/TV88nbd9a3MEd7YEAAggggAACCCCAAAIIIIAAAr4FTBtGrrxDXn3NEElI6Cfq+fg9u3fJa3Nm687syivLMgQQQAABBBBAAAEEEEAAAQQQ+EmgWhP4nw7LHAIIIIAAAggggAACCCCAAAII+CMQ0Gfgf/u7TtKsWXSlj+92u2Tzpk8rXZ6CCCCAAAIIIIAAAggggAACCDhVIKBX4JevWi1xcV38suwW10nUsHJMCCCAAAIIIIAAAggggAACCCDgWyCgV+BLH+b48WOlF5V5HxQUVGYZCxBAAAEEEEAAAQQQQAABBBBAwFsgoAn8ZzuTJbZzrAQbY70XFhZKyp7dMvPll2SP8cqEAAIIIIAAAggggAACCCCAAAJVFwjoLfQqDDW++9i77pahNw+XunXr6sjUc+4zZ7wkW7dsrnqkbIkAAggggAACCCCAAAIIIICAgwUCnsB7LCOjoiQx8Q4ZdVuiREScpxd//vkuedEYD56O6zxKvCKAAAIIIIAAAggggAACCCBQOQHTEnjP4dUV+bUbNktYWJhetH7dJ3LbqBGe1bwigAACCCCAAAIIIIAAAggggEAlBIIrUaZKRX7VooU8OfUZ+efajcXJ+5Ejh2XpksVV2h8bIYAAAggggAACCCCAAAIIIOBkgYB2Yqcg27ZtJ+PvmSDX3XCThIYW7f6br7+SWTOny4cfrJL8/Hwne1N3BBBAAAEEEEAAAQQQQAABBKokENAE/s9PPCWJt98hwcFFF/Z37Nhu9EI/XTasX1ul4NgIAQQQQAABBBBAAAEEEEAAAQSKBAL6DPzyVaslLq5Lse3eb74unvc1M+KWoXIyPd3XapYjgAACCCCAAAIIIIAAAggggIAhENAr8KVFL/71b0ovKvM+LLSoc7syK1iAAAIIIIAAAggggAACCCCAAALFAgG9At++Qwdp2rRZ8c4rM/PZzmRxuVyVKUoZBBBAAAEEEEAAAQQQQAABBBwrENAE3rGKVBwBBBBAAAEEEEAAAQQQQAABkwVMG0bO5LjZPQIIIIAAAggggAACCCCAAAKOEiCBd1RzU1kEEEAAAQQQQAABBBBAAAG7CpDA27XliBsBBBBAAAEEEEAAAQQQQMBRAiTwjmpuKosAAggggAACCCCAAAIIIGBXARJ4u7YccSOAAAIIIIAAAggggAACCDhKgATeUc1NZRFAAAEEEEAAAQQQQAABBOwqQAJv15YjbgQQQAABBBBAAAEEEEAAAUcJkMA7qrmpLAIIIIAAAggggAACCCCAgF0FSODt2nLEjQACCCCAAAIIIIAAAggg4CgBEnhHNTeVRQABBBBAAAEEEEAAAQQQsKsACbxdW464EUAAAQQQQAABBBBAAAEEHCVAAu+o5qayCCCAAAIIIIAAAggggAACdhUggbdryxE3AggggAACCCCAAAIIIICAowRI4B3V3FQWAQQQQAABBBBAAAEEEEDArgIk8HZtOeJGAAEEEEAAAQQQQAABBBBwlAAJvKOam8oigAACCCCAAAIIIIAAAgjYVYAE3q4tR9wIIIAAAggggAACCCCAAAKOEiCBd1RzU1kEEEAAAQQQQAABBBBAAAG7CpDA27XliBsBBBBAAAEEEEAAAQQQQMBRAiTwjmpuKosAAggggAACCCCAAAIIIGBXARJ4u7YccSOAAAIIIIAAAggggAACCDhKgATeUc1NZRFAAAEEEEAAAQQQQAABBOwqQAJv15YjbgQQQAABBBBAAAEEEEAAAUcJkMA7qrmpLAIIIIAAAggggAACCCCAgF0FSODt2nLEjQACCCCAAAIIIIAAAggg4CgBEnhHNTeVRQABBBBAAAEEEEAAAQQQsKsACbxdW464EUAAAQQQQAABBBBAAAEEHCVAAu+o5qayCCCAAAIIIIAAAggggAACdhUggbdryxE3AggggAACCCCAAAIIIICAowRI4B3V3FQWAQQQQAABBBBAAAEEEEDArgIk8HZtOeJGAAEEEEAAAQQQQAABBBBwlAAJvKOam8oigAACCCCAAAIIIIAAAgjYVYAE3q4tR9wIIIAAAggggAACCCCAAAKOEiCBd1RzU1kEEEAAAQQQQAABBBBAAAG7CpDA27XliBsBBBBAAAEEEEAAAQQQQMBRAiTwjmpuKosAAggggAACCCCAAAIIIGBXARJ4u7YccSOAAAIIIIAAAggggAACCDhKgATeUc1NZRFAAAEEEEAAAQQQQAABBOwqQAJv15YjbgQQQAABBBBAAAEEEEAAAUcJkMA7qrmpLAIIIIAAAggggAACCCCAgF0FSODt2nLEjQACCCCAAAIIIIAAAggg4CgBEnhHNTeVRQABBBBAAAEEEEAAAQQQsKsACbxdW464EUAAAQQQQAABBBBAAAEEHCVAAu+o5qayCCCAAAIIIIAAAggggAACdhUggbdryxE3AggggAACCCCAAAIIIICAowRI4B3V3FQWAQQQQAABBBBAAAEEEEDArgIk8HZtOeJGAAEEEEAAAQQQQAABBBBwlAAJvKOam8oigAACCCCAAAIIIIAAAgjYVYAE3q4tR9wIIIAAAggggAACCCCAAAKOEiCBd1RzU1kEEEAAAQQQQAABBBBAAAG7CpDA27XliBsBBBBAAAEEEEAAAQQQQMBRAv8FCeGpRsqb/jQAAAAASUVORK5CYII=",
+      "text/html": [
+       "<div>                            <div id=\"8cd2e5e1-3a69-452f-b49a-99626f7f1b5f\" class=\"plotly-graph-div\" style=\"height:600px; width:900px;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"8cd2e5e1-3a69-452f-b49a-99626f7f1b5f\")) {                    Plotly.newPlot(                        \"8cd2e5e1-3a69-452f-b49a-99626f7f1b5f\",                        [{\"marker\":{\"color\":\"rgba(31, 119, 180, 0.8)\"},\"name\":\"PyTorch\",\"showlegend\":true,\"x\":[\"PyTorch\"],\"y\":[99.0],\"type\":\"bar\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"marker\":{\"color\":\"rgba(255, 127, 14, 0.8)\"},\"name\":\"tinyRuntime (no quant)\",\"showlegend\":true,\"x\":[\"tinyRuntime (no quant)\"],\"y\":[99.0],\"type\":\"bar\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"marker\":{\"color\":\"rgba(44, 160, 44, 0.8)\"},\"name\":\"tinyRuntime (quant)\",\"showlegend\":true,\"x\":[\"tinyRuntime (quant)\"],\"y\":[99.0],\"type\":\"bar\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"marker\":{\"color\":\"rgba(31, 119, 180, 0.8)\"},\"name\":\"PyTorch\",\"showlegend\":false,\"x\":[\"PyTorch\"],\"y\":[11.552532196044922],\"type\":\"bar\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"marker\":{\"color\":\"rgba(255, 127, 14, 0.8)\"},\"name\":\"tinyRuntime (no quant)\",\"showlegend\":false,\"x\":[\"tinyRuntime (no quant)\"],\"y\":[10.451820135116575],\"type\":\"bar\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"marker\":{\"color\":\"rgba(44, 160, 44, 0.8)\"},\"name\":\"tinyRuntime (quant)\",\"showlegend\":false,\"x\":[\"tinyRuntime (quant)\"],\"y\":[72.08225703239441],\"type\":\"bar\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"marker\":{\"color\":\"rgba(31, 119, 180, 0.8)\"},\"name\":\"PyTorch\",\"showlegend\":false,\"x\":[\"PyTorch\"],\"y\":[469.3828125],\"type\":\"bar\",\"xaxis\":\"x3\",\"yaxis\":\"y3\"},{\"marker\":{\"color\":\"rgba(255, 127, 14, 0.8)\"},\"name\":\"tinyRuntime (no quant)\",\"showlegend\":false,\"x\":[\"tinyRuntime (no quant)\"],\"y\":[65.33984375],\"type\":\"bar\",\"xaxis\":\"x3\",\"yaxis\":\"y3\"},{\"marker\":{\"color\":\"rgba(44, 160, 44, 0.8)\"},\"name\":\"tinyRuntime (quant)\",\"showlegend\":false,\"x\":[\"tinyRuntime (quant)\"],\"y\":[33.9765625],\"type\":\"bar\",\"xaxis\":\"x3\",\"yaxis\":\"y3\"},{\"marker\":{\"color\":\"rgba(31, 119, 180, 0.8)\"},\"name\":\"PyTorch\",\"showlegend\":false,\"x\":[\"PyTorch\"],\"y\":[44.93835258483887],\"type\":\"bar\",\"xaxis\":\"x4\",\"yaxis\":\"y4\"},{\"marker\":{\"color\":\"rgba(255, 127, 14, 0.8)\"},\"name\":\"tinyRuntime (no quant)\",\"showlegend\":false,\"x\":[\"tinyRuntime (no quant)\"],\"y\":[44.66026306152344],\"type\":\"bar\",\"xaxis\":\"x4\",\"yaxis\":\"y4\"},{\"marker\":{\"color\":\"rgba(44, 160, 44, 0.8)\"},\"name\":\"tinyRuntime (quant)\",\"showlegend\":false,\"x\":[\"tinyRuntime (quant)\"],\"y\":[11.949405670166016],\"type\":\"bar\",\"xaxis\":\"x4\",\"yaxis\":\"y4\"}],                        {\"template\":{\"data\":{\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"rgb(17,17,17)\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"bar\":[{\"error_x\":{\"color\":\"#f2f5fa\"},\"error_y\":{\"color\":\"#f2f5fa\"},\"marker\":{\"line\":{\"color\":\"rgb(17,17,17)\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#A2B1C6\",\"gridcolor\":\"#506784\",\"linecolor\":\"#506784\",\"minorgridcolor\":\"#506784\",\"startlinecolor\":\"#A2B1C6\"},\"baxis\":{\"endlinecolor\":\"#A2B1C6\",\"gridcolor\":\"#506784\",\"linecolor\":\"#506784\",\"minorgridcolor\":\"#506784\",\"startlinecolor\":\"#A2B1C6\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"line\":{\"color\":\"#283442\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatter\":[{\"marker\":{\"line\":{\"color\":\"#283442\"}},\"type\":\"scatter\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#506784\"},\"line\":{\"color\":\"rgb(17,17,17)\"}},\"header\":{\"fill\":{\"color\":\"#2a3f5f\"},\"line\":{\"color\":\"rgb(17,17,17)\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#f2f5fa\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#f2f5fa\"},\"geo\":{\"bgcolor\":\"rgb(17,17,17)\",\"lakecolor\":\"rgb(17,17,17)\",\"landcolor\":\"rgb(17,17,17)\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"#506784\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"dark\"},\"paper_bgcolor\":\"rgb(17,17,17)\",\"plot_bgcolor\":\"rgb(17,17,17)\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"#506784\",\"linecolor\":\"#506784\",\"ticks\":\"\"},\"bgcolor\":\"rgb(17,17,17)\",\"radialaxis\":{\"gridcolor\":\"#506784\",\"linecolor\":\"#506784\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"rgb(17,17,17)\",\"gridcolor\":\"#506784\",\"gridwidth\":2,\"linecolor\":\"#506784\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#C8D4E3\"},\"yaxis\":{\"backgroundcolor\":\"rgb(17,17,17)\",\"gridcolor\":\"#506784\",\"gridwidth\":2,\"linecolor\":\"#506784\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#C8D4E3\"},\"zaxis\":{\"backgroundcolor\":\"rgb(17,17,17)\",\"gridcolor\":\"#506784\",\"gridwidth\":2,\"linecolor\":\"#506784\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#C8D4E3\"}},\"shapedefaults\":{\"line\":{\"color\":\"#f2f5fa\"}},\"sliderdefaults\":{\"bgcolor\":\"#C8D4E3\",\"bordercolor\":\"rgb(17,17,17)\",\"borderwidth\":1,\"tickwidth\":0},\"ternary\":{\"aaxis\":{\"gridcolor\":\"#506784\",\"linecolor\":\"#506784\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"#506784\",\"linecolor\":\"#506784\",\"ticks\":\"\"},\"bgcolor\":\"rgb(17,17,17)\",\"caxis\":{\"gridcolor\":\"#506784\",\"linecolor\":\"#506784\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"updatemenudefaults\":{\"bgcolor\":\"#506784\",\"borderwidth\":0},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"#283442\",\"linecolor\":\"#506784\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#283442\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"#283442\",\"linecolor\":\"#506784\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#283442\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,0.45],\"showticklabels\":false},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.625,1.0],\"title\":{\"text\":\"Accuracy (%)\"}},\"xaxis2\":{\"anchor\":\"y2\",\"domain\":[0.55,1.0],\"showticklabels\":false},\"yaxis2\":{\"anchor\":\"x2\",\"domain\":[0.625,1.0],\"title\":{\"text\":\"Time (s)\"}},\"xaxis3\":{\"anchor\":\"y3\",\"domain\":[0.0,0.45],\"showticklabels\":false},\"yaxis3\":{\"anchor\":\"x3\",\"domain\":[0.0,0.375],\"title\":{\"text\":\"Max memory usage (MB)\"}},\"xaxis4\":{\"anchor\":\"y4\",\"domain\":[0.55,1.0],\"showticklabels\":false},\"yaxis4\":{\"anchor\":\"x4\",\"domain\":[0.0,0.375],\"title\":{\"text\":\"Model size (MB)\"}},\"annotations\":[{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"Accuracy\",\"x\":0.225,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":1.0,\"yanchor\":\"bottom\",\"yref\":\"paper\"},{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"Time\",\"x\":0.775,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":1.0,\"yanchor\":\"bottom\",\"yref\":\"paper\"},{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"Max memory usage\",\"x\":0.225,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":0.375,\"yanchor\":\"bottom\",\"yref\":\"paper\"},{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"Model size\",\"x\":0.775,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":0.375,\"yanchor\":\"bottom\",\"yref\":\"paper\"}],\"legend\":{\"orientation\":\"h\",\"yanchor\":\"bottom\",\"y\":1.1,\"xanchor\":\"right\",\"x\":1,\"itemclick\":false,\"itemdoubleclick\":false},\"font\":{\"size\":14},\"height\":600,\"width\":900},                        {\"displayModeBar\": false, \"responsive\": true}                    ).then(function(){\n",
+       "                            \n",
+       "var gd = document.getElementById('8cd2e5e1-3a69-452f-b49a-99626f7f1b5f');\n",
+       "var x = new MutationObserver(function (mutations, observer) {{\n",
+       "        var display = window.getComputedStyle(gd).display;\n",
+       "        if (!display || display === 'none') {{\n",
+       "            console.log([gd, 'removed!']);\n",
+       "            Plotly.purge(gd);\n",
+       "            observer.disconnect();\n",
+       "        }}\n",
+       "}});\n",
+       "\n",
+       "// Listen for the removal of the full notebook cells\n",
+       "var notebookContainer = gd.closest('#notebook-container');\n",
+       "if (notebookContainer) {{\n",
+       "    x.observe(notebookContainer, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "// Listen for the clearing of the current output cell\n",
+       "var outputEl = gd.closest('.output');\n",
+       "if (outputEl) {{\n",
+       "    x.observe(outputEl, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "                        })                };                });            </script>        </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Accuracy (%)</th>\n",
+       "      <th>Time (s)</th>\n",
+       "      <th>Max memory usage (MB)</th>\n",
+       "      <th>Model size (MB)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>PyTorch</th>\n",
+       "      <td>99.0</td>\n",
+       "      <td>11.552532</td>\n",
+       "      <td>469.382812</td>\n",
+       "      <td>44.938353</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>tinyRuntime (no quant)</th>\n",
+       "      <td>99.0</td>\n",
+       "      <td>10.451820</td>\n",
+       "      <td>65.339844</td>\n",
+       "      <td>44.660263</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>tinyRuntime (quant)</th>\n",
+       "      <td>99.0</td>\n",
+       "      <td>72.082257</td>\n",
+       "      <td>33.976562</td>\n",
+       "      <td>11.949406</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                        Accuracy (%)   Time (s)  Max memory usage (MB)  \\\n",
+       "PyTorch                         99.0  11.552532             469.382812   \n",
+       "tinyRuntime (no quant)          99.0  10.451820              65.339844   \n",
+       "tinyRuntime (quant)             99.0  72.082257              33.976562   \n",
+       "\n",
+       "                        Model size (MB)  \n",
+       "PyTorch                       44.938353  \n",
+       "tinyRuntime (no quant)        44.660263  \n",
+       "tinyRuntime (quant)           11.949406  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#| label: fig-x8\n",
+    "#| fig-cap: \"Performance comparison on x86\"\n",
+    "\n",
+    "import pandas as pd\n",
+    "import plotly.graph_objects as go\n",
+    "from plotly.subplots import make_subplots\n",
+    "from IPython.display import display\n",
+    "\n",
+    "def split_dataframe(df):\n",
+    "    '''Split dataframe based on Runtime (Pytorch, tinyRuntime (no quant) and tinyRuntime (quant).'''\n",
+    "    df_pytorch = df[df[\"Runtime\"] == \"PyTorch\"]\n",
+    "    df_trv = df[(df[\"Runtime\"] == \"tinyRuntime\") & (df[\"Quantization\"] == False)]\n",
+    "    df_trq = df[(df[\"Runtime\"] == \"tinyRuntime\") & (df[\"Quantization\"] == True)]\n",
+    "    return df_pytorch, df_trv, df_trq\n",
+    "\n",
+    "def plot_perf_comp(df, theme):\n",
+    "    '''Plot latest performance comparisons using Plotly.'''\n",
+    "    dfs = split_dataframe(df)\n",
+    "    \n",
+    "    # Create subplots using Plotly Figure Factory\n",
+    "    fig = make_subplots(rows=2, cols=2, subplot_titles=(\"Accuracy\", \"Time\", \"Max memory usage\", \"Model size\"))\n",
+    "\n",
+    "    metrics = [\"Accuracy\", \"Time\", \"Max memory\", \"Model size\"]\n",
+    "    colors = ['rgba(31, 119, 180, 0.8)', 'rgba(255, 127, 14, 0.8)', 'rgba(44, 160, 44, 0.8)']\n",
+    "    names = [\"PyTorch\", \"tinyRuntime (no quant)\", \"tinyRuntime (quant)\"]\n",
+    "\n",
+    "    for i, metric in enumerate(metrics):\n",
+    "        # Retrieve values for each metric\n",
+    "        y_values = [df[metric].values[-1] for df in dfs]\n",
+    "        \n",
+    "        # Add trace for each runtime\n",
+    "        for j, name in enumerate(names):\n",
+    "            trace = go.Bar(x=[name], y=[y_values[j]], marker_color=colors[j], showlegend=(i == 0), name=name)\n",
+    "            fig.add_trace(trace, row=i // 2 + 1, col=i % 2 + 1)\n",
+    "\n",
+    "    # Set layout, background color and font size, and disable legend click feature\n",
+    "    fig.update_layout(\n",
+    "        legend=dict(orientation=\"h\", yanchor=\"bottom\", y=1.1, xanchor=\"right\", x=1),height=600, width=900,\n",
+    "        template=theme, legend_itemclick=False, legend_itemdoubleclick=False, font=dict(size=14))\n",
+    "\n",
+    "    # Update axis labels\n",
+    "    fig.update_yaxes(title_text=\"Accuracy (%)\", row=1, col=1)\n",
+    "    fig.update_yaxes(title_text=\"Time (s)\", row=1, col=2)\n",
+    "    fig.update_yaxes(title_text=\"Max memory usage (MB)\", row=2, col=1)\n",
+    "    fig.update_yaxes(title_text=\"Model size (MB)\", row=2, col=2)\n",
+    "    fig.update_xaxes(showticklabels=False)\n",
+    "    # Show the plot with modebar hidden\n",
+    "    fig.show(config={'displayModeBar': False})\n",
+    "\n",
+    "    # Create DataFrame\n",
+    "    data = {\n",
+    "        \"Accuracy (%)\": [df[\"Accuracy\"].values[-1] for df in dfs],\n",
+    "        \"Time (s)\": [df[\"Time\"].values[-1] for df in dfs],\n",
+    "        \"Max memory usage (MB)\": [df[\"Max memory\"].values[-1] for df in dfs],\n",
+    "        \"Model size (MB)\": [df[\"Model size\"].values[-1] for df in dfs]\n",
+    "    }\n",
+    "    df_results = pd.DataFrame(data, index=[\"PyTorch\", \"tinyRuntime (no quant)\", \"tinyRuntime (quant)\"])\n",
+    "    display(df_results)\n",
+    "\n",
+    "df = pd.read_csv('benchmark.csv')\n",
+    "df_x86 = df[df[\"Architecture\"] == \"x86_64\"]\n",
+    "plot_perf_comp(df_x86, \"plotly_dark\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b356cf25-b1d6-4b66-88b2-aa10e56b4390",
+   "metadata": {},
+   "source": [
+    "## ARM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "4838c4b5-afbe-4891-b58a-55f0e137287a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "displayModeBar": false,
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": "rgba(31, 119, 180, 0.8)"
+         },
+         "name": "PyTorch",
+         "showlegend": true,
+         "type": "bar",
+         "x": [
+          "PyTorch"
+         ],
+         "xaxis": "x",
+         "y": [
+          99
+         ],
+         "yaxis": "y"
+        },
+        {
+         "marker": {
+          "color": "rgba(255, 127, 14, 0.8)"
+         },
+         "name": "tinyRuntime (no quant)",
+         "showlegend": true,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (no quant)"
+         ],
+         "xaxis": "x",
+         "y": [
+          99
+         ],
+         "yaxis": "y"
+        },
+        {
+         "marker": {
+          "color": "rgba(44, 160, 44, 0.8)"
+         },
+         "name": "tinyRuntime (quant)",
+         "showlegend": true,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (quant)"
+         ],
+         "xaxis": "x",
+         "y": [
+          99
+         ],
+         "yaxis": "y"
+        },
+        {
+         "marker": {
+          "color": "rgba(31, 119, 180, 0.8)"
+         },
+         "name": "PyTorch",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "PyTorch"
+         ],
+         "xaxis": "x2",
+         "y": [
+          7.563920259475708
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "marker": {
+          "color": "rgba(255, 127, 14, 0.8)"
+         },
+         "name": "tinyRuntime (no quant)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (no quant)"
+         ],
+         "xaxis": "x2",
+         "y": [
+          6.604063987731934
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "marker": {
+          "color": "rgba(44, 160, 44, 0.8)"
+         },
+         "name": "tinyRuntime (quant)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (quant)"
+         ],
+         "xaxis": "x2",
+         "y": [
+          12.067646026611328
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "marker": {
+          "color": "rgba(31, 119, 180, 0.8)"
+         },
+         "name": "PyTorch",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "PyTorch"
+         ],
+         "xaxis": "x3",
+         "y": [
+          462.953125
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "marker": {
+          "color": "rgba(255, 127, 14, 0.8)"
+         },
+         "name": "tinyRuntime (no quant)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (no quant)"
+         ],
+         "xaxis": "x3",
+         "y": [
+          78.375
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "marker": {
+          "color": "rgba(44, 160, 44, 0.8)"
+         },
+         "name": "tinyRuntime (quant)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (quant)"
+         ],
+         "xaxis": "x3",
+         "y": [
+          39.828125
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "marker": {
+          "color": "rgba(31, 119, 180, 0.8)"
+         },
+         "name": "PyTorch",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "PyTorch"
+         ],
+         "xaxis": "x4",
+         "y": [
+          44.93835258483887
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "marker": {
+          "color": "rgba(255, 127, 14, 0.8)"
+         },
+         "name": "tinyRuntime (no quant)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (no quant)"
+         ],
+         "xaxis": "x4",
+         "y": [
+          44.66026306152344
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "marker": {
+          "color": "rgba(44, 160, 44, 0.8)"
+         },
+         "name": "tinyRuntime (quant)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "tinyRuntime (quant)"
+         ],
+         "xaxis": "x4",
+         "y": [
+          11.949405670166016
+         ],
+         "yaxis": "y4"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "Accuracy",
+          "x": 0.225,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "Time",
+          "x": 0.775,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "Max memory usage",
+          "x": 0.225,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 0.375,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "Model size",
+          "x": 0.775,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 0.375,
+          "yanchor": "bottom",
+          "yref": "paper"
+         }
+        ],
+        "font": {
+         "size": 14
+        },
+        "height": 600,
+        "legend": {
+         "itemclick": false,
+         "itemdoubleclick": false,
+         "orientation": "h",
+         "x": 1,
+         "xanchor": "right",
+         "y": 1.1,
+         "yanchor": "bottom"
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "width": 900,
+        "xaxis": {
+         "anchor": "y",
+         "autorange": true,
+         "domain": [
+          0,
+          0.45
+         ],
+         "range": [
+          -0.5,
+          2.5
+         ],
+         "showticklabels": false,
+         "type": "category"
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "autorange": true,
+         "domain": [
+          0.55,
+          1
+         ],
+         "range": [
+          -0.5,
+          2.5
+         ],
+         "showticklabels": false,
+         "type": "category"
+        },
+        "xaxis3": {
+         "anchor": "y3",
+         "autorange": true,
+         "domain": [
+          0,
+          0.45
+         ],
+         "range": [
+          -0.5,
+          2.5
+         ],
+         "showticklabels": false,
+         "type": "category"
+        },
+        "xaxis4": {
+         "anchor": "y4",
+         "autorange": true,
+         "domain": [
+          0.55,
+          1
+         ],
+         "range": [
+          -0.5,
+          2.5
+         ],
+         "showticklabels": false,
+         "type": "category"
+        },
+        "yaxis": {
+         "anchor": "x",
+         "autorange": true,
+         "domain": [
+          0.625,
+          1
+         ],
+         "range": [
+          0,
+          104.21052631578948
+         ],
+         "title": {
+          "text": "Accuracy (%)"
+         },
+         "type": "linear"
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "autorange": true,
+         "domain": [
+          0.625,
+          1
+         ],
+         "range": [
+          0,
+          12.70278529116982
+         ],
+         "title": {
+          "text": "Time (s)"
+         },
+         "type": "linear"
+        },
+        "yaxis3": {
+         "anchor": "x3",
+         "autorange": true,
+         "domain": [
+          0,
+          0.375
+         ],
+         "range": [
+          0,
+          487.31907894736844
+         ],
+         "title": {
+          "text": "Max memory usage (MB)"
+         },
+         "type": "linear"
+        },
+        "yaxis4": {
+         "anchor": "x4",
+         "autorange": true,
+         "domain": [
+          0,
+          0.375
+         ],
+         "range": [
+          0,
+          47.303529036672494
+         ],
+         "title": {
+          "text": "Model size (MB)"
+         },
+         "type": "linear"
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA/AAAAJYCAYAAADFZw05AAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAD8KADAAQAAAABAAACWAAAAAAy8YL1AABAAElEQVR4AezdB3wUxdvA8SeN0HvvvVelIygdlK6IigVRsbwiil1RRFFBFBUL4l8QRRDERlU6UqUpUlR6772XFN55Bu68Sy7JXciRu+Q3fEJud2d3Z7+7ubtnZ3Ym5JJJQkIAAQQQQAABBBBAAAEEEEAAgYAWCA3o0lE4BBBAAAEEEEAAAQQQQAABBBCwAgTwXAgIIIAAAggggAACCCCAAAIIBIEAAXwQnCSKiAACCCCAAAIIIIAAAggggAABPNcAAggggAACCCCAAAIIIIAAAkEgQAAfBCeJIiKAAAIIIIAAAggggAACCCBAAM81gAACCCCAAAIIIIAAAggggEAQCBDAB8FJoogIIIAAAggggAACCCCAAAIIEMBzDSCAAAIIIIAAAggggAACCCAQBAIE8EFwkigiAggggAACCCCAAAIIIIAAAgTwXAMIIIAAAggggAACCCCAAAIIBIEAAXwQnCSKiAACCCCAAAIIIIAAAggggAABPNcAAggggAACCCCAAAIIIIAAAkEgQAAfBCeJIiKAAAIIIIAAAggggAACCCBAAM81gAACCCCAAAIIIIAAAggggEAQCBDAB8FJoogIIIAAAggggAACCCCAAAIIEMBzDSCAAAIIIIAAAggggAACCCAQBAIE8EFwkigiAggggAACCCCAAAIIIIAAAgTwXAMIIIAAAggggAACCCCAAAIIBIEAAXwQnCSKiAACCCCAAAIIIIAAAggggAABPNcAAggggAACCCCAAAIIIIAAAkEgQAAfBCeJIiKAAAIIIIAAAggggAACCCBAAM81gAACCCCAAAIIIIAAAggggEAQCBDAB8FJoogIIIAAAggggAACCCCAAAIIEMBzDSCAAAIIIIAAAggggAACCCAQBAIE8EFwkigiAggggAACCCCAAAIIIIAAAgTwXAMIIIAAAggggAACCCCAAAIIBIEAAXwQnCSKiAACCCCAAAIIIIAAAggggAABPNcAAggggAACCCCAAAIIIIAAAkEgQAAfBCeJIiKAAAIIIIAAAggggAACCCBAAM81gAACCCCAAAIIIIAAAggggEAQCBDAB8FJoogIIIAAAggggAACCCCAAAIIEMBzDSCAAAIIIIAAAggggAACCCAQBAIE8EFwkigiAggggAACCCCAAAIIIIAAAgTwXAMIIIAAAggggAACCCCAAAIIBIFAeBCUkSIigAACCCCQbIGY2Etyycu1Q0y+sFD9n+Q3gUvmbFyKNZv38qyEmPMREua34rBhBIJZIOZSjNfFDw0JlRDzj4QAAsEtQAAf3OeP0iOAAAIIJCHwys/rZO2eE0nkury4WpEc8laXal7lJVNyBUzgPrWPyP613m2gaB2Rm9/1Li+5EEhHAlGxUXL39Lu9PuIxN4+RDKEZvM5PRgQQCEwBAvjAPC+UCgEEEEAgCAVWrdkoB48csyUPCw2VAvlyS7VKpSVUa5GTSDv3HJD1G7cnmqtG5bJSuECeRPP4uvDH6Qvkp18WyZiPXvJ11aDNv3r9ZtmwZZfcenMTCQ9Pmdr93fsOydp/t1oTreXMlClSKpUtIfnz5rxmTlNmLZHs2bLIjfVrXLN9uu4oNjZWnnz1Y4mOiZVhb/ROMVvXfQTL643m+nplyChp27Se9OjWJliK7XM5U/qaizHXzswFK5zliAgPlyIF80qlciWc8/z94ujxUzJrwUqpW7OilCpeyN+787j9Ldv3yotvfS6tb6ojD9x1i8c8gTRTz9uTr34k2uLto4FPSFgYT2n78/wQwPtTl20jgAACCKQrgf+NnSoLl62xX170C42mYoXzy/BBTyX5RXDpqr/l9aFfJer11osPSsfWNySax9eFh46cSPLGga/bDJT8+w8elRbdnpYPBjwuLZpc7yyWfjkfPeFXuaV5fckansk5/2perFj9r/QbPFJCzY0bMY8JxJoffX1f19byzKPdrmbT8dZN6Lg++N/3UtoEHKkVwI/7aY4sWrFOxn/6SroK3vVaev9/E+Wv2SOd56p8mWIm+KorH37xvdzUsKaULFbQuSwYX3g6Rj2OlL7mLlyMkmcGDLdEGgQ63kf1Rqi+j+bKkS1F+e567A0pUiifDHnlEed29WacvhcPePb+JN+3nSul4ItL5r1jwNDR9nPk7ttapeCWU2ZTnt5/9Fz1eeg2ueOR1+Xr72fI/d3apszO2IpHAQJ4jyzMRAABBBBAIHkClcuXkImfD5CLUdGyYvU/0ve1T+Vp84X0x5GvJ7rBru1vki43N3bmubf3W5IxY6R8PuRp57zwsJSpLXZuMI2/0CBavwzH7QWhd88u8sAdN0vWLCkTvLsy/vLNYClaOJ8cOnJcBn08Tr6c8Is0u6GWXFetvGu2q3qd0HH9OPIN04dD6tR8HTx8XIaN/EF63d1ONHhNT0mvr9grN+xcj1tr3mf+tkJef/8rGTX0eddFQfc6oWP01zXXt1dXW/N84cJFmTJrqbz23mj57OvJ8mLv7ilqF2NajVwytcauqUr5krLwp2GSNWtm19nX7PVPvywUbSWktpEZIq7Zfr3dUULvP2VLFpFH7+son3z5s7QxN68KpXBrMW/Llx7yEcCnh7PMMSKAAAIIXHOBDBHh0qhONenctrF888MsWffvNhn44Rh5+O720rRRLWd55i7+Qz7/Zqq8++qjUtTUBDlSiGl2r03vtQmpI2kz+7eGjbVf7i5vv6q8YL7Q5jDNpjXpF7+ff10krz/bU0aNny6bt++RHre3keY3XCdfTZwhU80XYa1dKpQ/jy1DnwdvvbxpE+Tqel9PnCl7zPKWN9aWB02zzWCvNXyi3zB7fENHTJSR3063lvqowIz5K2TilPnyzccv2+UONz1XngzGfD9Tfp23XEaYmylZM/8X9L817Bs5euyUvNv/0cuOLv/ny5NTHrjzFrvepm17bAC/fdd+ecE0i+3f9z5nk+DjJ0/LI88PFT0XDa6vIgcOHZU+phl6x1aNZP7S1bJ63WapZG4K3du1lTRrdJ3dQ0LHNdjcMChsmhs/fn9nm+/5gSMkd67sctHUas5euEr0mtLHBm7v2FTe/XS8aKuPAvlySfcuLczNoybO0i//8x9Tc/yDfcwguwlimje+Xvo+3FUymRtKCaUxptZNtx+35s1RBm1eP2vBKgk3NXVdbmli8zmCE73ZpTW5s0ywe+zEaalYtrhttVCzStmEdmfnz1v8p3w06ifZumOvDRZKFitgz/Ew04RXkzrpjRPXJuz93/1ScmbPKk+ZAFHTZ2Mmy+QZi+Xw0RO2g7cKZYtJ7we6SJ0aFe3ypK6NFX/9a/++Nai549HLN+ka1akqepNI/371XDz83Hvy57pNUqtqObvNYPsvsWN0veaSunY3bdstr7wzKtH3wNw5s7vxREZmkNva3ShfjJsmur4jjftptiz4fY18NrivY5ZMn7vM/P3OkG9NCxC9FpM6dx+N/FE2m7/NnXsOOs/ds4/eIcWL5Jfe5tp55pFuUrtGBbsd3VYH8zep7wV79h+289984UH5fupvMmnGIjl1+qx9r9fm7o73Y73mtdx6fek6xcx2H+reTtq3bOgss6cXw7+aZB+90IDYNe09cEQGfjBGVpprTj8Xapi/j6PHT8rbLz5kWwp4Y6KPeQ36eKzsO3BUzp6/IAXN3/9t7W6SnndcrjFP6hxqeRJ6/9Fl+j41yrzXjv7u1xS/2aLbJ10W+O9bASIIIIAAAgggkOIC+sVOa84rmFrJk6fO2BpZ1wB+1Le/mGaiMW7Bu6dCnD57Tro//qbtQ1qbZZ8w2/ph2m+ydec+GT/8VfuFVWtBV/61QTo/8IqULVHYBHN5bBPUtz8aJ/rlrmHtKtKtQ1PZsHWXDegdAbw2W33vswnSqc0Nks0EbKPG/yJRJqga3O9hT0UJmnnalPyfTTukRuUyNigMuTLCgNaOO55X14NxuGkg6MlAv8RrbfqkXxfbYFfX0Wak3/48V5503ATRmXHS9t377ZxaVwLRM+Ycrv1nq5w5e96Z8+LFaDtPA3lN585ftNN6w6dts3q2RuvX+ctFA+ElUz6xX9wTOi4NcPT5c0faaKY3zt4lGgjfa5rirtuw3QasenOnpgkm7zdf2rXpvwZVjetVF73poNdPz77vmOlq0v/p+2TT1t3m2pljWzH063OPY9Pxfv+9cYe0vrFOvBpDRxmqViwld3ZqJrtMsKSBU/nSRZ03JPqbZ8U1+NLnxSuVKy4TJs+T+/q8LZO+fDPBm0gaVD7+8oe2tcOTpumuntvx5nzo35Ij/bt5p+2HwjGtv/WmVr7cOZyz9O/zxgY17d9ntFlXt/F/L34gc74bav8Wkro28ufJZY/lwKFjttZRN1y21H+Bl/7N5TX7U59gDeATO0bXay6pa1cD0qTeA8+eu+A8N44Xeo6OHDshNzev55hl//7+3rjdOa0v9CaM/n1pfbr2OpLUuatepYzkMDdz9IaO1hhr0j4rLlyIsts5efqMnafb0cB3x+4DNkjX5uIapLa4va/kMedWb7ZFRUeb9/Zfzfq55O5bW9r1Bn/yrWgfI3pjUP8G9SbgC29+LgXz53beILIZXf7T93UN1F97xj3I15YI9z3xlr3B1antDVLZ9AkwZ9Eftpxnz11+P9H3pKRM9HOkZNGC9oad3pxbvGK9fe/XMt1s3m+SOod64yCh9x89DF3epmld+77rcli8TGEBAvgUBmVzCCCAAALpWyAqKkYOHD4mx0+csjVEk2cusc9aR5ga+Ts6NRetsdpogiINYDZs2Wlr5rQmJ6n0w7QFprb3pHw97CW5vvrl5tglihawNTJLV66XhqbWT5M+dz3inb7OL4halmdfH26enW8kb5maGkd66K52jpf2S9e0MYNsB2g6U7/Ajvt5jmgNkn2m25kzuF7camrutIa1eePrpGWT2okWXr94JmSgHWjVrFpWxk+a6wzgv5syz7iFie7DNf32+18mIMhib6yM/XG21K1VKVlNygc+/4C9maDb1nPbuWc/0ZpxbdXhy3FpcPrJW33sDR4NMn4ztfptTKCs/Slo6mrK36D9/5kv8uvs/j4e9aNooDV80H81m1orrq03EgvgN5qbQu1aNrDbjPuffuH/5O0nbRl02R9rN8r8xattAL/PBCvaRPpO87fxcp/LPaprDWWTLn3kS3MjSZ9D9pQ++2qyCb6yyPQxg50dZu3ee8gen6f8Cc3TGldN+qz1YRMk6jl96e0v7N+o4+8ssWtD/wb1HC9attatpt+xP/370RtI2qldsKakjjHucSV27Xr7HrjBvEdqwKs1zN9PXWBuDGWQdi08X19x9+86ndi50+syX54cUqxQfrdzp9dR3KTbmfr12/amji7bseuALPvzb5ny1VvOlil6k2bR8rU2gNebhHrj69F7O8hjPTrZzWmfCI0795Zps393vj/H3Y/jOqlV1f2Rm0mmFl8De32kSt8DNJUwgfj8JavjbiLRaT1m/dGkNw0rm8cF9D1htWkhogG8IyV2DpN6/7muWjmZOnupY1P89oMAAbwfUNkkAggggED6FdAaqWa3PWUBtAmt1r489/iddrqzqeH+0DQVHm+C41dNM2r9gpc7ZzZTs1Q/STBt6qlNmDUYcCRtcq1pk6lVdATweqPA0fzXLjNfhLV5b5MrX9rsCuY/rXFxpFBTo6S9lzuSPruoNWVaU6w18ukhJWVwlwkwnzO14BpE1zJfUCeaprO3mIBCa+9c03sjvrOTWmNWx/RiPXLoc66LvX6dM8d/2y105Vxps1dfk95M0ObEmjQI0fOcI9t/51Sn9XEMrb3T9O+VQLPT/f3stP53xARRWguqtXeujxA4Mmiwoj13Fy6Q1zHL7bcei6MMuqCgeYRDgxFNW0yrB+2noP71le20/qfN/suZG1yuTaadC6+80FEE9Pq/2t6utaXDkOHj7WMp0dH/1d6fv/BfTXBS10bcssWd1r+nv/7eEnd2mp1O7Nr19j3w13nLZI557EMf/9CRIqaZviWSMwLH1Z47x0nS7bi+F+Y1gb/+Pbk+VqI3A7TVhyZ9bEZvgGrT+5m/rXRsRs6ZFgbanD6hpNe13pjKbEaxcE06Xx8nqH3l0Q7XZb68Pn3mnGjLAO3IU/+mHem8afnjmhI7h675PL3W6133ozfneA7ek9DVzyOAv3pDtoAAAggggIBToJTpbXrQyw9LlswZbfNe/ZLnSPoFUGspdeglfRZSazXvNc3hNYBKKukXWX1m2DVg0X1oijbN3RNK2jxekzaX9DaFXmlq7m3+tJgvrkErM5yTfvHVlgk2YDWtIfTZ8bhpsmn2XaRQXtPq4TPRpu+zzJd3HQrKNcXtVM91mafXYSnYeaGnFhWOeRpI642HG+pWk47mZlPclNHUgnpKZjWbrtwn8JTFbZ5ew47exS9GXb4+HdeyI2Nmc7NKH+NIKOnjCK4BVUL5Yi/990hB3DzHTCuZe3q/KeVKFZUPzbB35UsXkxOmVvK2h/rHzeo2Hffa0IVXCNzyOSb05oXaBntKzhHEvXa9fQ/s88CtthM77a/i6QGfytDPvpMhrz7idiMoOaaezl1yzovjb8Z13ZCQ/zqQdNwA0hYH2oLBNeUxN6gSSnpMOgxl3KQ3UzNGRsR7RCVuvqRM1FJvJqlvnVoV7Y3c7o8NjLsZt+m459BtoYcJx8265FwvHjbHLA8CSX9j8LASsxBAAAEEEEDAs4CO/63P+yaU7urc3HZ8pB2XaZPmO0yHYt4k/RKozRK1hscxJvLvf/xtV9XOkRJKekNBkw5v56il1+lgbx6vx5BUynilB2fHTYyk8ie2XG/EODrT2mxaNWjzau1szVPSL7Bvmibqu/cfsmM5a0dx+gxsjmyXa9VPnLj8bK2ueymRANPTtnVeSh6X6z603CXNMHRHTWCrHR86vohrHhtYmOWekj43rMN77Tt4uVbdU56E5pUocvn6/N10qFf/usu18Poc9LoN26SF6TwvoaRjg/9leup2TXGDdW0d4WqteV17HNeO5bQDvWcfu8O2ltDl503HXr4mvbGhPvr37HrDzrEdrYmsYG4OBHNK6hh9OTZf3gP15te2XZ1tvwk6uoP2d6BJO4rTWl69EeS4qXnJ1Hj7mjKZWu3zF91rn33dhqf8pYsXtrO1RVTc6zixIFv7StGm7efNjbSMpmyOpNf7iZNnZJvp88QxNr1rfw+aLykTbYmlfV5oq7A7zedQclNS7z96vWtLneS0mEhumdLbev/dKkpvR87xIoAAAgggkAoCFcoUtz1ja2dazW+4Pl4nWwkVqZP50qU18Do+sfa+rLX4n46eZGtQHM80elq3tOnMTp/R/cF0pvT+5xPtc/fTzI2ATuaZ6rSetCm29jXw8y+LbCdi6nY1STsA1IrUbaY3+e5dLndUldD29Fx9/GYfyWUekehtOlvT52o1ANHz8eV3v9jO4rT36gefeTehTSQ4P6WPy3VHPW5vbXu+f3nQF3bkBG1irj1vJ1UrXb5MUbOe783Ey5QsbHv01t68vzb70c7pnhv4mWhz9js6NnMtmttrfXxB+5LQHrH1Wek3P/zGjizgmqlJgxqyYNlfdig3vYHlqH105KleqYxtnq19G2gnZfp3oXl8TQ1MR3WadKx07TRxjelIzZE0aFrzz5Zk9YPg2EYg/E7sGH0tn6/vgY/c08E+//6/sVNtp3C6Pz23evPlQzN0oXa8+Onon+XjL3/ytSjm0Y0qdv0lph8RvQYcj5L4vKE4K+gIHk3qV5dhZjQH7QtD3+91HzpyxTumJU9CyTEEow4j55r0MSu9oaa9439vOi/9yvTyro/0uKakTPSRLu25Xvu70Gfnl5jfL5pRMbRsvqSk3n+07I7j8GW75PVegBp4763IiQACCCAQhAKvd6wqZqRfr0oe6qHpolcrumTy1PzRZbF92coM06YdeTl6K4673NO01mYMHfB/8srgkfLoC0NtFq1d1yBRn43UlEAFqQw2TfoHDB1te07WYY30i1wj00w6oXUczUNda2Bt5hT5z9Titntfq3S925pLs1TvVnDPpcM6ab8DXXv1tzdA/pj5P/tF2PU8eXLzZFAgX26pXrm07Nt/JF6tmqemudr7+Kem87a7zegBjzz/nnz3+QDbq/wH5kaK9rKuQX7H1jfYYdBcy6NHEOrpuF0qwD0eV5zGt5e36bKS2a491jgHbM/zlWxaHm2uq2M5a8dZmvQRD+2AK7GkrUJ+nL5QXnyiu9sjIZ7LYOa6FEuvz2ff+Mx28Kj70JrHfk/e46wV97Rf7UFfA4+Zpom19sZd2Qy1p60cXAMw7bhxpalxfKr/J3YTGlAVL2KaM1/ZuZ4fHbdaO8vTmwD6d9SsYS17Y8BxPlzL6ShH3GtDgzUdnm/EmCl2OLwOrRpK9Uq9bHZtWaC9mDtazTi2kRK/w0PC5Zubv/F6U2EhYV7njZsxoWNUJ5dTaVdL6trVTAm9Bzr/juLAv2E6ddQhMAeYG5ja4kj7+bi9fVMZa4boHGne07SGWm9UunbqFmcTl8tmOhXU5Hhv057tNaDt9ey7thWFdrZYtsTlUQQcR+ZpOzrPMaqF3aDjP5fMb7/UywTr482jN+Ocj4zoSA9P9brcisCxiutvbTWi/ZNMnrHE2SJFl+uNLh1+UkfD6D/kS/ucvA4rqc/YO5I+CpKUyWM9OsqAd0fL/730gV1NH5fx1KQ/qXPo6f1HN6g33n7RESVcOsRzlI/fKScQYppxePkJmnI7ZUsIIIAAAgikZ4EeTw4yncSdlR9Hvu4zg9bo6VBcGlT52kGQPt+83wx3pU26XZtn+lyIIFtBv+rsM5205TG14Y6bHck5BA3EWt7xtDx2Xyd5+J72ydmEXUfP4XbTFLZo4fxuwa6vG0yp40pov/qsv34h16GxHM2UE8qrgXP7+16UXne3t/07JJQvsfk6yoI2H9YgWzsu8yZpx3paRg18tBZee9SeOd69VYM26dVHW+J2OOjYvv5d7Nx70A7l6NopmWO5t7+12fNx02N/fvP3pTfJ9PzozRvt2X70hy96u5mAzhf3GJNb2Kt5D3Tdp55/bVquAfzVpCPm2tNrPKFr5Gq2rc38Hdegp2A57rYnTpkvAz8cIz+NfMO22HFdbkdLOHrc/k3+sXaT3GuGlvtuRH+pUqGUM5s3Jlu277U3AfQmVnKTp/cfbRkwzAwTOdn0zn+15yS55UoP69GEPj2cZY4RAQQQQCBgBHSoIX0OsfutLZJVJg0M9Hl4X4N33ZkGr7puegre9bi1tk1bMFxN8K7bGfvjLBuYdW1/k04mO+k51Kb03nRemNhOUuq4EtqH1hbqdZZU8K7ra63h4z27yPCvJyfae3xC+9L52jRXXbwN3nUdfdY2qaBLjyGxPHpdaO3l1QTvWhb9u1IHPb+a9JGA9Ru2S/+ne9jptPBf3GNMzjFd7Xug6z71/KdEoKiBdWLXiOs+fX2tfz/6+Iw3wbtuW/va0H5UXnlnlH1MwHV/ui1tCeRoQeC6zPHaGxOt0b+a4F33Fff9R5/P18cYtFVLSpwTx/HwO74AAXx8E+YggAACCCDgN4FFy9fYoeDaeTF0nN8KwYZ9FtDaJn22WZ9916H/SPEF7rm1pdQ3zZjfMz2Ga4du1zpp8KyBSSCkDVt2ypSZS6R3z87OTscCoVyBUAbeAxM/CxoY9+/bQ86dvyhjJs5IMLPecNL+BDJGug85l+AKflygLQOGDJ9g+3fpcXsbP+6JTasATei5DhBAAAEEEEAAAQQQQAABBBAIAgFq4IPgJFFEBBBAAAEEEEAAAQQQQAABBAjguQYQQAABBBBAAAEEEEAAAQQQCAIBAvggOEkUEQEEEEAAAQQQQAABBBBAAAECeK4BBBBAAAEEEEAAAQQQQAABBIJAgAA+CE4SRUQAAQQQQAABBBBAAAEEEECAAJ5rAAEEEEAAAQQQQAABBBBAAIEgECCAD4KTRBERQAABBBBAAAEEEEAAAQQQIIDnGkAAAQQQQAABBBBAAAEEEEAgCAQI4IPgJFFEBBBAAAEEEEAAAQQQQAABBAjguQYQQAABBBBAAAEEEEAAAQQQCAIBAvggOEkUEQEEEEAAAQQQQAABBBBAAAECeK4BBBBAAAEEEEAAAQQQQAABBIJAgAA+CE4SRUQAAQQQQAABBBBAAAEEEECAAJ5rAAEEEEAAAQQQQAABBBBAAIEgECCAD4KTRBERQAABBBBAAAEEEEAAAQQQIIDnGkAAAQQQQAABBBBAAAEEEEAgCAQI4IPgJFFEBBBAAAEEEEAAAQQQQAABBAjguQYQQAABBBBAAAEEEEAAAQQQCAIBAvggOEkUEQEEEEAAAQQQQAABBBBAAAECeK4BBBBAAAEEEEAAAQQQQAABBIJAgAA+CE4SRUQAAQQQQAABBBBAAAEEEECAAJ5rAAEEEEAAAQQQQAABBBBAAIEgECCAD4KTRBERQAABBBBAAAEEEEAAAQQQIIDnGkAAAQQQQAABBBBAAAEEEEAgCAQI4IPgJFFEBBBAAAEEEEAAAQQQQAABBAjguQYQQAABBBBAAAEEEEAAAQQQCAIBAvggOEkUEQEEEEAAAQQQQAABBBBAAAECeK4BBBBAAAEEEEAAAQQQQAABBIJAgAA+CE4SRUQAAQQQQAABBBBAAAEEEECAAJ5rAAEEEEAAAQQQQAABBBBAAIEgECCAD4KTRBERQAABBBBAAAEEEEAAAQQQIIDnGkAAAQQQQAABBBBAAAEEEEAgCATCg6CMFBEBBDwIPDNguGzZuVeqVywtA56930MOZiGAAAIIIIBASgmcOHVGejw5KMnNZc4YKZ8PeUba3fuCVC5fUj5568kk1yEDAggg4K0AAby3UuRDIIAEdu09KL/MW2ZLtGX7Hunz4K2SO1f2ACohRUEAAQQQQCBtCYSGhEiuHFndDmrF6g2SMTJCqlUq7ZyfMTJSwsJCTd7skj1rZud8XiCAAAIpIRByyaSU2BDbQACBayfwyeif5VPz07F1I5k0Y7E8//hdcu9tra5dAdgTAggggAACCEj9do9J8SIF5LsR/dFAAAEErokANfDXhJmdIJCyAlNmLpGC+XPLCyZw/2XuMpkyc7HHAP7nXxfJD9MWyJYdeyRLpoxSpUJJufvWVlK7RgVboI1bdslHo36UfzbvlPPnL0qp4oWk9U11TJ6WsnDZGvnf2Kny/P/dadYr5TyAb3+eY/c5bOATkjP75ZoIbVJ4fbXyckuL+jJ+0lzZbFoFNKpTTUqYLzUjv50m+w4elZOm6WE2UxNRt2ZFeaxHJ7sv50bNi4TKumPPAZlkjqP3A12kTo2KrqvIq++MMts+IiPeeVpCQ+nSww2HCQQQQACBVBV4oO87Ur1yGdtKTgvy2deTZemq9fL4/Z3l068myZq/t0gh81ne3Xzmdrm5iYwYM1lm/rZSdu89JGVLFZFX+94n1V1q9nUb302eJxOnzpct2/dK9mxZpF6tSvLsY3dI3tw5dDEJAQTSgQDfeNPBSeYQ05bA6nWbRZvQ39K8vv3wblK/hvy9cYf9MHc90reGfSMvD/pCzpw9L13aNpFaJsBeuupvGf/zXJtt2R//SNeHX5OVazbKjWYbbZrVlWPHT8rgj8fZ5UeOnZRVZtnxk6ddNyu79x2y8y9cjHLO/2PtRplgvlR0eeBV8+Vivuzac9CW598tO+Xk6bN2+/d3aysNa1eRmQtWyoPPDJHzFy4610+srLWqlLX7Gz3hV2d+faE3H36YvkAK5MtN8O4mwwQCCCCAQCAI/Lluk2zetttZlK0798nKvzbY5+jPn79gbpjXlTPnzsvAD8ZI27uek68nzpSSxQrKTY1qyr/mxrrj89ixgbc/GisDhn4lUVEx0vPOm+3z9b/OXy4PPj1EYmNjHdn4jQACaVyAGvg0foI5vLQnMNnUtmtq16KB/a213rMXrhKd/1SvrnaeBvTjfpojVSuWknGfvGKfxdMFR4+fkjX/bLF5BgwdLTExsTJ++KtSomgBO0+/AEyZtcS+9vW/6JgYeaXvvdK+ZUPJEHH5rSU6OsbWNLhuq0TRgrbW/99NO6Vm1bL25kNiZS1dorAN/Bcs/cvePChaKJ/d3NifZtvf2lqAhAACCCCAQLAIfDa4rzSuV90W9y9TC3/XY2/Yfmy+/exVKZA3l53/ugnUJ079TbTjvBympl1vWo/7cbZtJTf0tf9zHuqwkT+YmvspsnD5Wnuz3LmAFwggkGYFCODT7KnlwNKiQFR0tOjd9nKlikr5MsXsId7YoKZkzZxJps5eKk8+dJuEmE52Vvz1r2j3Fq1urOMM3jVz7pzZ5CaT/8Cho7Jj9wGpYnrHdQTvulyboXdsfYO+9DnVv76y3GqaALqm8PAwWb1+s8xd9IdozcORoyfMvo/ZLIePnbC/kyqrZurepaUsWbleJpjm+U8/0s02x586a6l9FKBi2eJ2O/yHAAIIIIBAMAjcULeas5jlSxe1r8uWLOIM3nWGfsbrTfV/Nu2Q+tdVluWr/5VY87meyfRw//X3M53r6415TVt37CWAd6rwAoG0LUAAn7bPL0eXxgR+M7XQJ06eMT3eRkrvlz90Hl1IaIjsN8+ZrzAf8HXN83D6/Jwmfd7cU9rlWG7y+jO9//lE+WLcNMmaJZPUMM8BVjbP4OtzegcOXw7idd9JlVXzNGlQQ7TmXZvM67OD+lub4N9jnucnIYAAAgggEKwCkRkiPBbdMT829nJf0/ronKblf/4jf5kb466plGl2nyHC83Zc8/EaAQTShgABfNo4jxxFOhHQzuu0hv1yEHzcedSFCuSRU+ZZ88lmuQbw+fJc7sxmw9ZdbkPbOFbIlyenfanLk0pRphl8cpI2+xv17XTbAd4X7z5jn9fX7cwyz8DPXfync5NJlVUz6tA9d3ZqLkOGjzdN/JfKt+bxgMLmmJvdUMu5HV4ggAACCCCQVgUcndQNeeVR+/hZWj1OjgsBBJIWoBO7pI3IgUBACGhArDXw11cvb4er0SFrHD8/fPG67cxt5m8r5IKpma5wpVn5PJdA2XEQ20xT9mKF80mWzBllxZ//yumz5xyL7G9thqdJm/Np2mk6pHMkbb534OB/teeO+Z5+b9q62zb3q165tDN413yHTTN615RUWR15u9zc2LQ8yCDa4d2e/Yflzs4t6LzOgcNvBBBAAIE0LVC5fAl7fDoSTNykN/APHfnvpn7c5UwjgEDaEqAGPm2dT44mDQvocHH6DLyj8zrXQ9Ua6lua15NR43+ROeZ587bN6kmtquVk/pLVtid67an+hOlNXseML5Q/j7zb/1F5vGcX28Ntjz6DzDPmLexzdQt+XyPT5/wuq2d/YYec0850Rphhb2JNZ3e671/mLpcNpmd5b1KZkoVFmwBqq4EcWbNIvrw5bRP/GfNXuK3exHTkk1RZdQUdLqd9q4Yyccp8G8jfdov78/ZuG2UCAQQQQACBNCSgQ7M2qlPV9ndz8vQZadO0nm2Rt37DNtv6rr8Zcq5N07pp6Ig5FAQQSEiAAD4hGeYjEGACGlhHhIfbHmg9Fa1dywY2gJ9m8t1shpgb9kZvGfzJt7ZXeR1jXZMG5LdeCXy19/YQM0/Hou03eKRdrgG3jgOvSZvqP3pfRxn44RjbdF3n1buukjRrVMs2gQ+xa+tckTDT+Z3eRHBNuXJkk8H9HrY9zn9mxrbVpM+xdzBBuN5I0O1r0t9JldVmNP81NfvWAL5Dq0ZutfqO5fxGAAEEEEDgWgroZ1icjz/n7rVjWMdnnc50/5R0ZrMv4m7DsZ7r/PcHPC4fj/pRJpjPQb3hrknzXVetnOiILSQEEEgfAiGmp+rLvWOkj+PlKBFIdwJac64dxWU2Tebzm2ffHV8KXCG0AzztFK5Iobz2JoHrMm2apz3W6zINypOTdPibDObmgPZ472n/jm0mVdYX3/rc1jRMGv2ms4m/Y11+I4AAAgggkB4E9HG2fQeO2EfmihTMK5Hm8TISAgikHwEC+PRzrjlSBIJa4ODh49LyjqelTo2K8sV7zwb1sVB4BBBAAAEEEEAAAQSSI0AndslRYx0EELjmAuN+mi3Rpkd8bfpPQgABBBBAAAEEEEAgPQpQA58ezzrHjEAQCmjv+afOnJOqFUvFe94+CA+HIiOAAAIIIIAAAggg4LMAAbzPZKyAAAIIIIAAAggggAACCCCAwLUXSPO90M9asFLKlSoqJYsVjKd73Ayrpb147ti9X8qYMa+b1K8uWTNncsvnTR63FZhAAAEEEEAAAQQQQAABBBBAwA8CabYGXp+Vnb90tTz16sfy8pP3yB0dm7nx7TW9d97/1CA5eOiYFC9SQLabIF6H4Bg19DlnT9ve5HHbKBMIIIAAAggggAACCCCAAAII+EkgTdbAb9q2Wzr3fEUSGyFv1PjpcvzEadHhqDSAX79xu3R/bKCM/3muHftavb3J46fzwmYRQAABBBBAAAEEEEAAAQQQcBNIk73Qa3P5qV+/Ld+N6O92sK4TM+Ytlxsb1LTBu86vUr6k1K5RQWbMX+HM5k0eZ2ZeIIAAAggggAACCCCAAAIIIOBHgTRZAx8RHm6feT9teqz2lC5cjJKjx0+ZZ+OLuC3W6bX/bLXzvMmjGWNiL7ltgwkEEEAAgbQrEBISYkZBSLvHx5EhgAACCCCAQGALpMkAPinyo8dO2iyZM2V0y6rTp8+ek6joaPEmj94oOHkmym0bTCCAAAIIpF2ByIhQyZwxXX50pt2TypEhgAACCCAQRALp8ltIhgwR9hTFxsa6naromBg7vnRYaKh4k0dXzpUtg9s2kpqIiomV81Hu+01qHZb7XyBDeKhEmh+/pkvmvF885dddsPFkCISa94OIzMlY0bdVzkSdkVi9BkgBIxAaEipZIrIETHkoCAIIIIBAwgIXYi7IxZiLCWdgSaoIZAzPKBH6XYp0zQTSZQCfK0dWG6ifPH3WDfrkqbOSU5eZAN6bPG4rezkRHhYqT33zh5e5yXatBIbffZ3/dxV9XmTOQJETu/y/L/bgvUC3sd7nvYqcM7fPlLm75l7FFlg1pQWaFWsmnct1TunNsj0EEEAAAT8IhIWEyUuLXvLDltnk1QgMazbsalZn3WQIpMsAXgP0UiUKyep1m9zIVq/fZMeD15ne5HFb2YeJAydNIEdKnwJnDomc2pc+jz1gj/ra9GNxOuq0HDx7MGAV0mPB9JyQEEAAAQSCQ+CSXOJzNDhOFaX0s4Cf2wz7ufQJbF47oNNh4f42P5p0PHedPnz0hJ3W/zq1aSxLVq6XrybOkM3b98hHo36UjVvN8HNtG/uUx5mZFwgggAACCCCAAAIIIIAAAgj4USBN1sDv2H1Abu/1mpNt5Lhpoj+9e3aRR+7tYOff17W1bN+5T94dPkHe+eRbCTNN23ve0VY6tGroXM+bPM7MvEAAAQQQQAABBBBAAAEEEEDAjwJpMoAvX7qorJ8/OlE2Ddhff66nvPhEd9mz/7AUK5xfIq90budY0Zs8jrz8RgABBBBAAAEEEEAAAQQQQMCfAmkygPcFLFPGSClb0n08+Ljre5Mn7jpMI4AAAggggAACCCCAAAIIIJCSAmnyGfiUBGJbCCCAAAIIIIAAAggggAACCASCAAF8IJwFyoAAAggggAACCCCAAAIIIIBAEgIE8EkAsRgBBBBAAAEEEEAAAQQQQACBQBAggA+Es0AZEEAAAQQQQAABBBBAAAEEEEhCgAA+CSAWI4AAAggggAACCCCAAAIIIBAIAgTwgXAWKAMCCCCAAAIIIIAAAggggAACSQgQwCcBxGIEEEAAAQQQQAABBBBAAAEEAkGAAD4QzgJlQAABBBBAAAEEEEAAAQQQQCAJgfAklid78aVLl2T9hu2yeMU62bv/sBw5flJ0Xs7sWaVAvlxSt1Ylub56eYkI91sRkl12VkQAAQQQQAABBBBAAAEEEEAg0AT8Ej3PX7pa3h42VnbvO+Q83tCQEAkNC5Xo6Bg7b8SYKZIta2bp8+Ct0q1jM9HlJAQQQAABBBBAAAEEEEAAAQQQ8CyQogH8gcPHTOD+jcxasEoyZ4qUjq0bSdtm9aRMySJSIG8uCQ0NkcNHT8iuvQdtnmmzl8rAD8bIpBmL5bWne0jFssU9l5K5CCCAAAIIIIAAAggggAACCKRzgRQL4PcdOCId739Zzp2/KHff2lJ6P9BFsmbOFI83X56coj/XVSsvzzzSTcZ8P1M+Gf2TdO31mox452lpWLtKvHWYgQACCCCAAAIIIIAAAggggEB6F0ixAP7MufMSFhYmXw97UWpVLeeVa5hpUt+jWxtpeWNtefjZd+XIsRNerUcmBBBAAAEEEEAAAQQQQAABBNKbQIoF8PlNrfo3H71smssX9tmwSMG8Mubjl+XEyTM+r8sKCCCAAAIIIIAAAggggAACCKQHgRQL4LNnyyL6k9yUK0c20R8SAggggAACCASXwPqN2+X4iVPSqE61eAXXEWgWLltrRqbZJjlzZDWPylWVEkULxMvHDAQQQAABBBBIWiDFAvikdnXhwkXZsfuAHDtxWooWzida605CAAEEEEAAgeAW2L5rv7z41ueSO2f2eAG8Bu/PDRwh0+f8LiWLFZSjx0/Ju8MnyEdv9qHPm+A+7ZQeAQQQQCCVBK5JAD9j/goZMHS0WxN5fU6+78NdbWd2qXTs7BYBBBBAAAEErkKgQ4+XZMv2vXYLuWtmj7ellWs22OC935P3yJ2dmsuFi1Fy9+MD5Z1PvpWfvxwYLz8zEEAAAQQQQCBxgdDEF1/90qjoaBn88TjJmzuH7Zn+hcfvkkfu6SB79x+Wpwd8Knp3noQAAggggAACwScwfFBfmTZmkNSsUtZj4X+dt1wyRmaQru1usssjM0TI7e2byqZtu2XrjsuBv8cVmYkAAggggAACHgX8XgO/ePk60fHhhw9+SiqU+W+cd+3s7tk3PpM9JpAvWiifx8IxEwEEEEAAAQQCV8DxOFzmTJESFR0Tr6D7Dx61TefDw8Ocy8qVKmpf7zt4REqX8L3jW+eGeIEAAggggEA6FEjRAF6D8cIF8khISIiTMkvmjPb1PvMh7hrA7z90zM7PlDHSmZcXCCCAAAIIIJB2BI4eOymO7wGOo9JgX5M+D6/p9LloOX8xfvBvF/IfAgggcEUge9ZQiY6h5W4gXhCHT1zwqVh5cxD/+QQWJ3OKBvCffT1Z/tm0Q5544FZpUr+63VWVCqWkQL7c8tSrH0tN89x79qyZ5bAZ733N31uleqXSkidX/Gfm4pSRSQQQQAABBBAIQoGIiHCJiY11K7ljOiL88leQrJnCRX9ICCCAQGICUbFREh72XyVhYnlZdm0FCMivrXeKPgN/c/N6ct70Nv/oC0Plnt5vycq/NojeaR/53rNye4emsnn7Hpmz6A/Zs++wtGtRXz54o/e1PVr2hgACCCCAAALXTCBPrhxy6vRZt/2dOHXGTufJzQ18NxgmEEAAAQQQ8EIgRW95N7i+ikwe/aZMmrFYPh39s9zX520zpExV6fPQbfJi7+72J9Z0Whfq0sTeizKSBQEEEEAAAQSCUKBsqSIye8FK0aA9R7Ys9ghWr98soaGhUqpYoSA8IoqMAAIIIIBA6gqkaA28Hop+KHdu21imjx0sLz1xt/y7ead0e3iAPNX/E9m2cx/Be+qeb/aOAAIIIIBAignoEHLrN26X02fOydmz5+1r197lO7ZuZPf1yuCRsmHLTpm/ZLV8Of4XaVyvuh2dJsUKwoYQQAABBBBIJwIpWgPvaqbPtnXv0kK63NxYvvlhloz8drrMXrhKOrRqKI/16CSOnmtd1+E1AggggAACCASPQJ9Xhsm2XfudBb6912tSvnRR+WnUQDtPR5kZ8uqj8uqQUfYROp1Zs2pZeeO5ns51eIEAAggggAAC3gukeAB/0jSTm2may+07cMSO8d6kXg15qHs7uaNjMxvEazA/bfbv0rX9TfLwPe25A+/9uSInAggggAACASUw1YwBn1Rq07SutLqpjuzac1CymY5sc+fMltQqLEcAAQQQQACBBARSNIA/ePi4dOjxkluHNSPGTJFSxQvJ2E/6yZPmWfh7bmslI8ZMlu8mz5df5y+XhT8NS6BozEYAAQQQQACBtCCgfd+UKFogLRwKx4AAAggggECqCqRoAP/l+OkSa4aL+fD13jZovySX5I81G2XA0K9krKl516bzOmycPhvfo1tbGTNxRqoePDtHAAEEEEAAAQQQQAABBBBAIFgEUjSAX7xynbRoXFtaNLneefxlSxaRH6YvkK079jnn6YvCBfLI84/f5TaPCQQQQAABBBBAAAEEEEAAAQQQ8CyQor3QFy2YT5aYIH7X3oPOva35Z6vtib5C2WLOebxAAAEEEEAAAQQQQAABBBBAAAHfBFK0Bv6erq2k1zPvSpu7nhPthT72UqzExMRK1iyZ5M5OzX0rGbkRQAABBBBAIFEBHb5t7uI/ZeGyNbJ52245cuyknDHDuemY63lyZ5dqFUtLk/o17LBtYWEpes8+0XKxEAEEEEAAAQT8I5CiAXyD66vIrAnvmV7ml8qKvzZIZIYI22lNN9MDvQbxJAQQQAABBBBIGQH9rB38ybc2aNctau/uhfLnkRw5ssrhI8dlp+n1/e+NO2TC5Hl2aLf+fXvYIdxSZu9sBQEEEEAAAQRSQyBFA3g9gIL5c8sDd91if1LjgNgnAggggAACaVlgx+4D8sb7X8vSVettfzKP399Z2rVsIMUK54932Os3bJNJMxbbn7t7vym3tbtR+vbqKtlNDT0JAQQQQAABBIJPIMUD+OAjoMQIIIAAAggEj8DDz70n+w8elUfu7SC97m5vW7slVPoqFUqJ/jx8TwcZ8ul4mThlvpw9d0He6fdwQqswHwEEEEAAAQQCWCDFHojbumOvvPDm5/aZ9+Qc7xfjptmm98lZl3UQQAABBBBILwKZM2WU/733jPTu2SXR4N3VQ4dwHfRyL3nlqXvl0qVLrot4jQACCCCAAAJBJJBiAXys+UIwZdYSefCZIea5uwNeExw/eVpeevsLef/ziabTO75UeA1HRgQQQACBdCkw6v3npE6Nisk69jtMnzQv97k7WeuyEgIIIIAAAgikvkCKBfAlihaQR0wTvT/XbpJO9/eTIcPHyybTI25C6cDhYzLS1Lq3u+dF82zeIunYupHtJTeh/MxHAAEEEEAAAZGc2bN6xRAdHeMxn7fre1yZmQgggAACCCCQqgIp9gy8DhvX+4EutiOdAe+NltETfrU/ZUoWljIlikjhgnns0HL7Dhyx48SvNePDa417qWIFZehrj0ndWpVSFYKdI4AAAgggEIwC/QaPFG3N9l7/x2yT+n827ZDBH4+TVWs2SqkShczz7o9IxbLFg/HQKDMCCCCAAAIIxBFIsQDesd1SxQvJ6A9flBnzV5if5bJk5XrZsn2vY7H9rcPLNahdRZo2qmV7xNXgn4QAAggggAACvgno5+tPvyyU9i0bOp+HH2SC95VmKFcdFUaXP/7yh/Lr2HckPDzMt42TGwEEEEAAAQQCTsBvkXPrm+qI/mg6dfqsHac2JiZWcufKJjlM87/QkJCAw6BACCCAAAIIBJPAhq27bHF1GDlNm7fvscF77RoV5CtzM/3bn+bIwA/H2CHnGterbvPwHwIIIIAAAggEr4DfAnhXkmxZM4v+kBBAAAEEEEAg5QSOHjtpN1ayaEH7Wx9P09S2WT37u2Gdqvb37r2H7G/+QwABBBBAAIHgFkixTuyCm4HSI4AAAgggEHwCBfLlsoXeunOf/T1/yWr7u3qlMvb36bPn7O+wMD7uLQT/IYAAAgggEOQC16QGPsiNKD4CCCCAAAIBKVCrajmJjMwgLw/6nzSqU03mLv5TypYsIhXLXe60Tp+F11S0UL6ALD+FQgABBBBAAAHfBLgl75sXuRFAAAEEEAgYgby5c8izj3YzvdCfkSmzlki4qWl/9rE7bD8z5y9clFHfTpeMJsCvUaVswJSZgiCAAAIIIIBA8gWogU++HWsigAACCCCQ6gJ3dmou2kHdNtOMvla1cpI1cyZbpjNnz8tTvbqKBvlZMmdM9XJSAAQQQAABBBC4egEC+Ks3ZAsIIIAAAgikqoA2kY/bTD5PruzSqc0NqVoudo4AAggggAACKStAE/qU9WRrCCCAAAII+FXgmx9mSeylS8nahw7rquPGkxBAAAEEEEAgOAX8FsB//OVP8lT/T+x4tMFJQ6kRQAABBBAIPIGvJ86Qp179WE6eOuNT4XbsPiD3PvGWLF6+zqf1yIwAAggggAACgSPgtyb0EeHhMvO3FfanfJli0r1LC2nfooHtLTdwDp+SIIAAAgggEFwC2tv8d1PmyR/rNklf84z7LeazNUNEwh/nGuiPMbX2X4ydKlpxr8/MkxBAAAEEEEAgOAUS/sS/yuN5+J72UqdmBfn2pzkyc8FK6T/kSxk64ju59eYmcmfnFlK4QJ6r3AOrI4AAAgggkP4E+j99n7RuWkdeH/qV9Bs8UgZ9PE5a31hHqlcpYz5b80rO7Fnl0NHjsu/AEfl91XqZv+QviYqONp/JFeW1p3tIyWIF0wRa8h4iSBOHHpAHERKQpaJQCCCAQNoT8FsAr1TXVStvf54/ekK+n/qbfDd5nowa/4uMnvCrNG1Uy9TKt5R611VKe6ocEQIIIIAAAn4UqH9dZfn5yzdtrfr30xbID9Mv/3japY4L3/POm6Vj60aeFgflvJELt8nPq/cEZdnTaqE71iwiDzYulVYPj+NCAAEEAkbArwG84yh1CJtH7u0gD3VvJ59/M0X0+fg5i/6wP/rF4i7TvL5Dq4aSKWOkYxV+I4AAAggggEAiAtps/rEenezPxi27ZNO23XLk+Ck5a4aPy5Eti+TJnV2qVSwthWjxlogiixBAAAEEEAgugWsSwEdHx8jshatk/M9zZMVfG6xQ7pzZpGaVsrJo+VrbDPD9zyfKRwOfsE38gouQ0iKAAAIIIJC6AtrXjP6QEEAAAQQQQCBtC/g1gD9w6KjpaGe+bT5/2DSj11SjchnzDHxzaX1TXdvpzpFjJ2XcT7NlwqR5st/kJyGAAAIIIIAAAggggAACCCCAQHwBvwXw4yfNlTc//EZiY2Ntz/Od2zaWu0zndZXLl3ArRZ5c2aV3zy7SyzSvP3fhotsyJhBAAAEEEEAAAQQQQAABBBBA4LKA3wL4/QePSuGCeeSOjs2ki+l5Xp/HSyxFRmZgiLnEgFiGAAIIIIAAAggggAACCCCQrgX8FsDf27W1PPHgrRIawsAi6foK4+ARQAABBBBAAAEEEEAAAQRSRCA0RbbiYSPHTE+41ZreL1179Y+3dPLMJVLlph4y2IxdS0IAAQQQQAABBBBAAAEEEEAAgaQF/BbAT5/zu9370490i1eK9i0b2N5yp85eGm8ZMxBAAAEEEEAAAQQQQAABBBBAIL6A3wL4LTv3SpbMGaVurUrx9hpimtW3aHy9HDW19PpDQgABBBBAAIHkC+hwres3bJNf5i2TxSvW2g1duBgl/2zaIbv2Hkz+hlkTAQQQQAABBAJKwG/PwF+KvSSZM2VM8Bn4sFC/3TsIKGAKgwACCCCAgD8FVq/bLC8P/kK279pvd1OrajlpVKeaXDQBfM++79ghW+f98EGCn8f+LBvbRgABBBBAAIGUFfBbFF22VBE5dOS4rPjr33gljoqOllkLVkq2rJkld85s8ZYzAwEEEEAAAQSSFjh56ow88cow2XfgiDRrVMs+nuZYSz9ju3dpIYePnpA1f29xzOY3AsEtcOmSSGwMP4FkcEnPR1RwX1eUHoEgEvBbDXynNjfIV9/NkCf6fSQPmTHe69WqKNExsbJo+VqZvXCVbNyyS3p0a5NqVHvNl52//t4cb/+RGSLMl6Dr8Z3mOQAAQABJREFUnPOPnzwtC35fIzt275cyJYtIk/rVJWvmTM7lvEAAAQQQQCC1BJb/+a8cOXZSnnzoNvtZ+9LbX7g1mb+uWnlbNP0Mq1mlbGoVk/0ikHICGix+0TzltseWrl4gVymRTp+KhEZc/bbYAgIIJCngtwC+WOH88sbzPeW1IaPlvc8mxCtIw9pV5PH7O8ebf61mrPxrg7z41ufxdpcrRzZpNulyAK9B/v1PDZKDh45J8SIF5Itx06R0icIyauhzovlICCCAAAIIpKbAdhOYa2p9Ux2PxcifN6edf/bsBY/LmYkAAggggAACwSXgtwBeGdo2rSe1q1cQHTZu2859cvrMWSlRtKCtBWhqmvoFQpoxbogUKpDHWRTXYetHjZ8ux0+clkmj37QB/PqN26X7YwNl/M9z5dH7OjrX4QUCCCCAAAKpIVC4YF67241bdtvPqbhlWL9hu51VvGj+uIuYRgABBBBAAIEgFPBrAK8e+fLklAfuvDlgacLDwyQszHNXADPmLZcbG9R0fimqUr6k1K5RQWbMX0EAH7BnlIIhgAAC6UegeqXS9jPsmx9mSu2aFdwOfOeeA/LxqB8lY2QGqVSupNsyJhBAAAEEEEAgOAX8HsDHms5G9h88KtGm47q4KTw8XAq71H7HXX4tpsf9NNt2pqe18E0b1rJD3+l+dfgdHeKunOmMzzXp9Np/trrO4jUCCCCAAAKpIlC0UD555J4O8snon6V5175m9JdIiYmNlcdeeF+W/fmPnL9w0T4fT4exqXJ62CkCCCCAAAIpLuC3AP6SCdw//WqSjPp2uv0C4ank2hncsunDPS26JvP0i86sBatM+S7IwcPHbSA/aujzUrl8CTlqOgXSpEPhuSadPn32nGhP+hHmBsSZ8/FvTLjmj/s6c8Zw0ZsapMAS0DPi67n09QjCY2Ikwvaey/n31c6f+bX9jb/Pfah5NifmUqzEmuE1SYEjoOfk3IUYn96Tw02LrcgIz622UuvI9JEuvQn94Rc/2NFftBy//f6X7avlxd7d5dZbmqRW0dgvAggggAACCKSwgN8CeO1t/lNTI5AnV3YpV7qorbVu07Su7cF907bdpgf4LdKwTtUUPhzvN3dL8/rSoVVD5wrr/t0mvZ57V97+aKyM+eglyWB6o9cUa2oyXFO0CcL0y7hjHPvQ0BDXxbwOYgF/n8vQS3qtOH6CGCoNFt3f51771gjRc+/ayUYadAy2Q9JzEmJi8ct/m96VPhDf8kPMddW5bWP7oz3S791/WArkyy2ODuy8OzJyIYAAAggggEAwCPgtgJ/120rzXTVExn7STzRg7/3yMNvrfKniheSEGbf25u7PS0SE33afpH3c596rViwlN5nn3ecs/MOumytHVhuonzx91m1bJ0+dlZy6LPRyDUymDGFuy5Oa0Po3vQFACiwBPSO+nkufjyDKXDO6o8CqvPP5MNLiCn4/93razd99IAZ/afF8entMek4yRvj2Hu7ttlMrn9401x8SAggggAACCKRNAb9F0AePHJcipndcHU7u8NETVm//oaOiAXyObFnseOrT5y6T157uYZ/ZCwTePabWIm+eHLYoGqCXKlFIVq/b5Fa01es32fHg3WYygQACCCCAQCoJ6CNrG7fukkXL1sr23Qc8lqLX3e3s57HHhcxEAAEEEEAAgaAR8FsArwIXo6IshAbxmjZs3iUNrq9iX+c046hHR8fI3gOHpWxJ947ibAY//9fr2XelWsXSUrdWJcmaNZNMMUPd6djwvR/o4txzpzaN7Rj2X02cIY1Mc/9fzA2HjVt3y1svPuTMwwsEEEAAAQRSU+D+JwfJCvP5lVjq1OYGAvjEgFiGAAIIIIBAkAj4LYDXJnyHj5yQk6a5fN7cOaRUsYLy9fczpdVNdczz4yGy0HSwo0lr41Mj6di5I00He5+NmWx3r8PJ3d+trTx45y3O4tzXtbVsN+PXvzt8grzzybd2qJ6ed7R1e3bemZkXCCCAAAIIXGOB+UtX2+BdHwN7wtyALpgvj3k8Lf5jAfpMPAkBBBBAAAEEgl/AbwF8WTPcmva2vnDZGrmlRQPp3qWlDPxwjLS64xn7GLAua1i7ih0nPjUYtem+9s6rQ9zFmI7pihXJb3uVdy2LPif/+nM95cUnuos2r9eWBJFXOrdzzcdrBBBAAAEEUkNgy/a9drf/16OzaSlWLTWKwD4RQAABBBBA4BoK+C2Av6tTc7m5WT3JmiWzPZw7Ozc3w/VclJm/rbDPxNe/rrI8+9gd1/BQ4+9Kg/ESRQvEXxBnTqaMkanSzD9OMZhEAAEEEEDATaBcqaJ2+tiJU27zmUAAAQQQQACBtCngtwD+1/krZOKU+bZJnz5nrkmbn+sPCQEEEEAAAQSuXqB2jQpSIG8u+X7qb/bxLh39hYQAAggggAACaVfAbwH8rr0H5U/Tg3sI4yal3auHI0MAAQQQSFWBzJki5aU+d0ufVz6Sx1/+MMF+ZR65t4MUL5J0i7OUPhjtIX+GuaF/yfyLm7QlXi7ToS0JAQQQQAABBLwX8FsAX6FMMVuK3XsPSZ0aFb0vETkRQAABBBBAwCuBCxej5BvTQaym+UtWJ7jOrbfcmCoB/MWoaHl6wKcey/Xl+8/bkWA8LmQmAggggAACCHgU8FsA37heddvp26RfF0nnto097pyZCCCAAAIIIJB8gVVm+DgdQq5mlbJ2GNSCprf5iIj4H+358uRM/k5SYM2nH+kmOrKLawqlhZ4rB68RQAABBBDwSiD+p7xXqyWd6Y81GyVP7uz2i8XzA0d47G1eO5FzHXc96a2SAwEEEEAAAQQcAhu37rYvtYm8NkkP1BRqns3XkV1ICCCAAAIIIHB1An4L4Jev/ldWr9tsSzd19lKPpcyaORMBvEcZZiKAAAIIIJC0QLnSRWymo8cDuxf6pavWy8WoKMmWNbM0uL6KlCxWMOmDIwcCCCCAAAIIxBPwWwCvw8Y1v+G6eDt0nRHK3XhXDl4jgAACCCDgk0Bt08eMBsPfTZ4XsL3Qa8371h17Zfvu/XLg4DGJjomRJx+6TR686xZ7rKfPRcv5izFeH3eYaXofHRtrthO/YzyvN0LGFBeIMefk2KmLEhPr3/OSN1sY5z7Fz97VbTDEnPOzZ6Pkgvnnz5Q9ayjn3p/AV7Htwyd8O/d5c0Rexd5Y1W8BvA5roz8kBBBAAAEEEPCPwMHDx2zT9NXrN8sjzw+VHNmzetzRY/d1TJVab31UbtWMzyUi/PLXDR2v/jnzWN37n0+Ujq0b2cfrsmYKF/3xJYWHhkp4GEPm+WLm77xh5pzkypbB37sRiY3m3Ptf2bc9mJtq2TJHSLYI/wZlUbFRnHvfzsw1y01Afs2o7Y58+8S8tmVjbwgggAACCCCQiMCRoydly/a9Nsei5WsTzNmtQ9NUCeC1QI7gXV/rsHHdu7SQJSvWySbz/H5qd66nZSIhgAACCCAQTAJ+C+D/N3aqfH1laJuEQLKbZ+GmjRmU0GLmI4AAAggggEAiAlUrlpK5E4cmkuPyoty5sieZ51pl2Lf/iN2VdnRLQgABBBBAAAHfBPwWwEdGZpAcJkD3lI6YznZOnjoj+VN5WBtPZWMeAggggAACwSIQHh4mBczQcYGavpzwi6z/d7u0aVbXDC2bT9Zv2C7DRv0olcqVkHKligZqsSkXAggggAACASvgtwD+3ttaif54Smv+2Sp3PfaGtG/Z0NNi5iGAAAIIIIBAAgIXLkbJqdNnJVuWTKI3ywM5FS2UT0Z9O11+mbfMWcw6NSvKwOcekFDzzDQJAQQQQAABBHwT8FsAn1gxqlcqbcer/XzsFLnv9tYSYsaHJSGAAAIIIIBA0gKTZyyW194bLf2evMfWZHf/v4FJrjT2435Ss2rZJPOldIaWTWpL88bXyyHT2d5Jc9NBO7fNni1LSu+G7SGAAAIIIJBuBFIlgFfdcqWKiI4Lu2vvQSlepEC6AedAEUAAAQQQuBoBDYCLFc5vx1TPamrhr69ePsnNZc7k396hEytAqLlJr838A7mpf2LlZxkCCCCAAAKBJJAqAfyFCxdl1ZqNkiHCDB2TxfNz8oGERFkQQAABBBAIFIHWN9UR/XGkr4e95HjJbwQQQAABBBBI4wJ+C+AnmSZ+02Yvjcd33gTvG7bsktNnzpkxYG+Q3DmzxcvDDAQQQAABBBDwLKBDsL0yZJS82vc+ubF+Dc+ZmIsAAggggAACaVLAbwH89l37ZbH5kuEpafM/rT3o89CtnhYzDwEEEEAAAQQSEDh7/oLsP3hUzp47n0AOZiOAAAIIIIBAWhXwWwDfu2dneeSe9vHdzLNwkRki4s9nDgIIIIAAAggggAACCCCAAAIIJCjgtwBee5b/1zSVDw8LlSoVSrkVQGsODpgeaXV4mTy5srstYwIBBBBAAAEEEEAAAQQQQAABBOIL+C2AX/nXBunx5CD7fN6ng55y2/POPQfk/qcGyy0tGsg7/R52W8YEAggggAACCCQtMHfRn7J33+GkM5oc7Vo2oBd4r6TIhAACCCCAQGAL+C2An7voD3vkTz/SLZ5A3VqVpMH1VWTOwlVy6dIlxoGPJ8QMBBBAAAEEEheYPud30R9vUs2q5QjgvYEiDwIIIIAAAgEu4LcAfseeg7aH+TIlC3skqH99ZTsO/OGjJyRfnpwe8zATAQQQQAABBDwLdOvQVGpUKeN5YZy5pYoVjDOHSQQQQAABBBAIRgG/BfBZs2SSqOiYBE1OnT5rl2XKGJlgHhYggAACCCCAgGeBOrUqStum9TwvZC4CCCCAAAIIpEmBUH8dVcWyxUWD9IlT5sfbxZFjJ2XyzMVSIG8u0UCfhAACCCCAAAIIIIAAAggggAACiQv4rQb+9vY3yTc/zJIBQ78y48GvFX3uPTomVhYtWyMrVv8rF6Oi5ZWn7k28dCxFAAEEEEAAAQQQQAABBBBAAAEr4LcAXmvWP3mrj/QbPFJmLVhlfxzmEeHhZoz4DnK7eX6PhAACCCCAAALeC+TKkU2qVSotObNn9X4lciKAAAIIIIBAmhDwWwCvOpXKlZCJn78mf6zdJNt27pNTZ85JyWIFpEr5kvSGmyYuHw4CAQQQQOBaC1xfvbyMH/7qtd4t+0MAAQQQQACBABDwWwAfY5rLT5/7u2hte5umdaV2jQrOw/13805ZbprRV61QSkoVL+SczwsEEEAAAQQQQAABBBBAAAEEEPAs4LdO7Bb8/pe88ObnstA88x43hYaEyEtvfyFDhk+Iu4hpBBBAAAEEEEAAAQQQQAABBBDwIOC3AH6R6bhOU++eXeLttnyZYtL8hlq2c7vY2Nh4y5mBAAIIIIAAAggggAACCCCAAALuAn4L4PfsOyz58+aUgvlzu+/xylT1ymUl2owTf+jIcY/LmYkAAggggAACCCCAAAIIIIAAAv8J+C2Az5MruxkH/pwkVMOugXuIaUqfPVuW/0rDKwQQQAABBBBAAAEEEEAAAQQQ8CjgtwC+asVScu78BRk28ke5dOmS287Xb9wuP05bICWKFpBMGSPdljGBAAIIIIAAAggggAACCCCAAALxBfzWC/1t7W6UCZPmyf/GTpUFv6+RurUqSnRMjCxatlZ27T1oSzLwhQfil4g5CCCAAAIIIIAAAggggAACCCAQT8BvAbwOHzfinb7y1rCxMnvhKtmwZadz57lyZJNnH+smLZvUds7jBQIIIIAAAggggAACCCCAAAIIJCzgtwBed1kgX2758I3ecvDwcdm2c5+cOnNWShYrKMWLFJAMEX7ddcJHzBIEEEAAAQQQQAABBBBAAAEEglDgmkTR2hu9/jiS9j4/b/Gftml9/6fvc8zmNwIIIIAAAggggAACCCCAAAIIJCBwTQJ4x77X/rNVJs9cIr/MXSbHTpySrJkzCQG8Q4ffCCCAAAIIIIAAAggggAACCCQs4PcAfs/+wzJl1hKZYgL37bv225KEh4fJTQ1rSodWjRIuGUsQQAABBBBAAAEEEEAAAQQQQMAp4JcA/vSZc/Lr/OU2aF+1ZqPbMHI3N6sn/Z66V3Iw/rvzJPACAQQQQAABBBBAAAEEEEAAgaQEUjSAX71us3z9/QyZv2S1XLgYZfddtmQRadeygdSuUUHufvxNKVW8EMF7UmeF5QgggAACCCCAAAIIIIAAAgjEEUjRAP6H6QtkxvwVkjtnNrmrcwsbuFcsW9zu8sCho3F2zSQCCCCAAAIIIIAAAggggAACCHgrEOptRl/yRZle5s+eOy/nzl/wZTXyIoAAAggggAACCCCAAAIIIIBAAgIpWgP/4F23SC5T+z511lKZMHme/SlaKJ/c0qK+1KlZMYEiMBsBBBBAAAEEEEAAAQQQQAABBJISSNEAvkTRAtK3V1d58qHbZPmf/8jkGUtk1oIVMmLMFPujhdm4dZccOHxMCuTNlVTZWI4AAggggAACCCCAAAIIIIAAAlcEUjSAd6iGhoRI/esq259X+94rcxausuO/L1m53gT0q8z0H1Lb1Mh3aNVQOrdt7FiN3wgggAACCCCAAAIIIIAAAgggkICAXwJ4131ljMxgmtA3sD+Hj56QabOX2mBea+j/3rCdAN4Vi9cIIIAAAggggAACCCCAAAIIJCDg9wDedb95c+eQ+25vY382bdtta+Jdl/MaAQQQQAABBBBAAAEEEEAAAQQ8C1zTAN61COVKFRX9ISGAAAIIIIAAAggggAACCCCAQNICfhlGLundkgMBBBBAAAEEEEAAAQQQQAABBHwRIID3RYu8CCCAAAIIIIAAAggggAACCKSSAAF8KsGzWwQQQAABBBBAAAEEEEAAAQR8ESCA90WLvAgggAACCCCAAAIIIIAAAgikkgABfCrBs1sEEEAAAQQQQAABBBBAAAEEfBEggPdFi7wIIIAAAggggAACCCCAAAIIpJIAAXwqwbNbBBBAAAEEEEAAAQQQQAABBHwRIID3RYu8CCCAAAIIIIAAAggggAACCKSSAAF8KsGzWwQQQAABBBBAAAEEEEAAAQR8ESCA90WLvAgggAACCCCAAAIIIIAAAgikkgABfCrBs1sEEEAAAQQQQAABBBBAAAEEfBEggPdFi7wIIIAAAggggAACCCCAAAIIpJIAAXwqwbNbBBBAAAEEEEAAAQQQQAABBHwRIID3RYu8CCCAAAIIIIAAAggggAACCKSSQHgq7Tdodnv85GlZ8Psa2bF7v5QpWUSa1K8uWTNnCpryU1AEEEAAAQRSU+DSpUuycNlaWb9hm+TMkVUa1q4qJYoWSM0isW8EEEAAAQSCVoAAPpFTt/fAEbn/qUFy8NAxKV6kgHwxbpqULlFYRg19TnLlyJbImixCAAEEEEAAAQ3enxs4QqbP+V1KFisoR4+fkneHT5CP3uxjAvkqACGAAAIIIICAjwI0oU8EbNT46XL8xGmZNPpN+zPu01dk2459Mv7nuYmsxSIEEEAAAQQQUIGVazbY4L3fk/fItDGDZP4PH5gb4YXknU++BQgBBBBAAAEEkiFAAJ8I2ox5y+XGBjVt7btmq1K+pNSuUUFmzF+RyFosQgABBBBAAAEV+NV8jmaMzCBd291kQSIzRMjt7ZvKpm27ZeuOvXYe/yGAAAIIIICA9wI0oU/A6sLFKNvUr1ypIm45dHrtP1ud885eiHG+9uZFpsgwiTVNCkmBJaBnxNdz6esRhMfESrjuKNbXNcnvTwG9i+nvcx8SYk67+buP5U/fn6fS523rOTl3MUZ8eUsODwuRDOHc+/YWe//Bo7bpfHh4mHOVcqWK2tf7Dh6xj6VdjI6V6Bjv/zj++3vyfh3nznnhNwF9XMLXv6fkFCZzhHk/5XM0OXT+W8f8KUZHmb/jWN++E/taoAg99/zZ+8p2TfL7+j0qs4mHSMkXIIBPwO7osZN2SeZMGd1y6PTps+ckKjpaIsLD5ez5aLflSU1o/q/uq5tUNpZfY4GTp6OuwR7NJ0/rEddgP+zCJ4FT/v3C4SjLLUW7if6QAkvgzDnf3sMzZggjgPfhFOpnaZbMcT9HI+0W9Hl4TRfNF//z5kaKL6lzjSKiP6TAEvD17yk5pT973qx158zkrMo6/hTQr1FRvr2f+lwcc+6HN/na59VYwb8CR05c9HkHBPA+k7mtQADvxvHfRAbTzE9TbJzbvNExMRJqbv+HhV6ugcmcEcL/1HiFAAIIpG0BrYEneS8QEREuMXE+Rx3TehNcU4aIUAkNxdV7VXIigAACCKRnAaLPBM5+LjPUjQbqJ0+fdctx8tRZOwxOqCOApwmImw8TCCCAAAIIOATy5MohW3bscUza3ydOnbG/8+TObn/rIwkZ+DbiZsQEAggggAACCQnwIF8CMhqglzI95a5et8ktx+r1m+x48G4zmUAAAQQQQACBeAJlTb8xOnqLI2jXDKvXbzY17uYztlihePmZgQACCCCAAAKJCxDAJ+LTqU1jWbJyvXw1cYZs3r5HPhr1o2zculs6t22cyFosQgABBBBAAAEV6Ni6kYV4ZfBI2bBlp8xfslq+HP+LNK5XXfLmzgESAggggAACCPgoEGJ6DaU/xwTQYkyv4QPeGy0//brIPgsfFhYq93VtLX0fvl1CtBtcEgIIIIAAAggkKqBDyb06ZJScsb2PidSsWlaGvfGE5Ml1uQl9oiuzEAEEEEAAAQTcBAjg3Tg8T5w7f0H27D8sxQrnFx3DloQAAggggAAC3gvokH279hyUbFkzS+6c2bxfkZwIIIAAAggg4CZAAO/GwQQCCCCAAAIIIIAAAggggAACgSnAM/CBeV4oFQIIIIAAAggggAACCCCAAAJuAgTwbhxMIIAAAggggAACCCCAAAIIIBCYAgTwgXleKBUCCCCAAAIIIIAAAggggAACbgIE8G4cTCCAAAIIIIAAAggggAACCCAQmAIE8IF5XigVAggggAACCCCAAAIIIIAAAm4CBPBuHEwggAACCCCAAAIIIIAAAgggEJgCBPCBeV4oFQIIIIAAAggggAACCCCAAAJuAgTwbhxMIIAAAggggAACCCCAAAIIIBCYAgTwgXleKBUCCCCAAAIIIIAAAggggAACbgIE8G4cTCCAAAIIIIAAAggggAACCCAQmAIE8IF5XigVAggggAACCCCAAAIIIIAAAm4CBPBuHEwggAACCCCAAAIIIIAAAgggEJgCBPCBeV4oFQIIIIAAAggggAACCCCAAAJuAgTwbhxMIIAAAggggAACCCCAAAIIIBCYAgTwgXleKBUCCCCAAAIIIIAAAggggAACbgIE8G4cTCCAAAIIIIAAAggggAACCCAQmAIE8IF5XigVAggggAACCCCAAAIIIIAAAm4CBPBuHEwggAACCCCAAAIIIIAAAgggEJgCBPCBeV4oFQIIIIAAAggggAACCCCAAAJuAgTwbhxMIIAAAggggAACCCCAAAIIIBCYAgTwgXleKBUCCCCAAAIIIIAAAggggAACbgIE8G4cTCCAAAIIIIAAAggggAACCCAQmAIE8IF5XigVAggggAACCCCAAAIIIIAAAm4CBPBuHEwggAACCCCAAAIIIIAAAgggEJgCBPCBeV4oFQIIIIAAAggggAACCCCAAAJuAgTwbhxMIIAAAggggAACCCCAAAIIIBCYAgTwgXleKBUCCCCAAAIIIIAAAggggAACbgIE8G4cTCCAAAIIIIAAAggggAACCCAQmAIE8IF5XigVAggggAACCCCAAAIIIIAAAm4CBPBuHEwggAACCCCAAAIIIIAAAgggEJgCBPCBeV4oFQIIIIAAAggggAACCCCAAAJuAgTwbhxMIIAAAggggAACCCCAAAIIIBCYAgTwgXleKBUCCCCAAAIIIIAAAggggAACbgIE8G4cTCCAAAIIIIAAAggggAACCCAQmAIE8IF5XigVAggggAACCCCAAAIIIIAAAm4CBPBuHEwggAACCCCAAAIIIIAAAgggEJgCBPCBeV4oFQIIIIAAAggggAACCCCAAAJuAgTwbhxMIIAAAggggAACCCCAAAIIIBCYAgTwgXleKBUCCCCAAAIIIIAAAggggAACbgIE8G4cTCCAAAIIIIAAAggggAACCCAQmAIE8IF5XigVAggggAACCCCAAAIIIIAAAm4CBPBuHEwggAACCCCAAAIIIIAAAgggEJgCBPCBeV4oFQIIIIAAAggggMD/s3cf8FEUbRjAH1JIIaTQe+9dFBCQqlKUqoIgUlWkKcVPEKUIgiIdAQGloxRRehHpIE2QHpDeA6ETQgkpfPMO3HGXhOQObpNL8oy/5O52Z3dn/4fZfXcaBShAAQpQwEqAAbwVBz9QgAIUoAAFKEABClCAAhSgAAWcU4ABvHN+LywVBShAAQpQgAIUoAAFKEABClDASoABvBUHP1CAAhSgAAUoQAEKUIACFKAABZxTgAG8c34vLBUFKEABClCAAhSgAAUoQAEKUMBKgAG8FQc/UIACFKAABShAAQpQgAIUoAAFnFOAAbxzfi8sFQUoQAEKUIACFKAABShAAQpQwEqAAbwVBz9QgAIUoAAFKEABClCAAhSgAAWcU4ABvHN+LywVBShAAQpQgAIUoAAFKEABClDASoABvBUHP1CAAhSgAAUoQAEKUIACFKAABZxTgAG8c34vLBUFKEABClCAAhSgAAUoQAEKUMBKgAG8FQc/UIACFKAABShAAQpQgAIUoAAFnFOAAbxzfi8sFQUoQAEKUIACFKAABShAAQpQwEqAAbwVBz9QgAIUoAAFKEABClCAAhSgAAWcU4ABvHN+LywVBShAAQpQgAIUoAAFKEABClDASoABvBUHP1CAAhSgAAUoQAEKUIACFKAABZxTgAG8c34vLBUFKEABClCAAhSgAAUoQAEKUMBKgAG8FQc/UIACFKAABShAAQpQgAIUoAAFnFOAAbxzfi8sFQUoQAEKUIACFKAABShAAQpQwEqAAbwVBz9QgAIUoAAFKEABClCAAhSgAAWcU4ABvHN+LywVBShAAQpQgAIUoAAFKEABClDASoABvBUHP1CAAhSgAAUoQAEKUIACFKAABZxTgAG8c34vLBUFKEABClCAAhSgAAUoQAEKUMBKgAG8FQc/UIACFKAABShAAQpQgAIUoAAFnFOAAbxzfi8sFQUoQAEKUIACFKAABShAAQpQwEqAAbwVBz9QgAIUoAAFKEABClCAAhSgAAWcU4ABvHN+LywVBShAAQpQgAIUoAAFKEABClDASiDBAvjQO/dwO/QuHj58aFUAfqAABShAAQpQgAIUoAAFKEABClAgfgG3+LM8W45d+45g1Yad2LrrIIIuXcWD8Ai9I1dXF2RM748KLxRFjcov4LUqLyJVqlTPdhBuRQEKUIACFKAABShAAQpQgAIUSCECqVSNuEOrxK9cu4kh42bjz/X/aMJ0Ab7IlysrsmZKDzc3V1y6fB3ngi7j/MUren2Z4gXQv0drFMqfM4WQ8zQpQAEKUIACFKAABShAAQpQgAL2CzgsgI9SzwHmLlqLMT//gbv37uPN1yqiUd1XUF7VtLvEUsP+3/GzWLxqC35bsh7hERFo3aQ2OrVpBC9PD/vPgltQgAIUoAAFKEABClCAAhSgAAWSuYDDAvjjpy+gYZuvUDh/Lgz8vC1KFMlrE11Q8DUMGjUTG7fvw5Cv2qP+65Vs2o6ZKEABClCAAhSgAAUoQAEKUIACKUnAoX3gq1QohdEDu8DTI7XNhtkyp8f477ph6I9zbd6GGSlAAQpQgAIUoAAFKEABClCAAilNwGE18NKVXn5cXJ59YPuIiEjdTz6lfQk8XwpQgAIUoAAFKEABClCAAhSgQHwCzx5tR9uzjCQfX/B+MyQUF9SI9E9LMsgdEwUoQAEKUIACFKAABShAAQpQgAIxBRzahN60+7AH4ZB539OrEeglnTwTpEem3777ECIjo/Q0coN6fYBXypc0bcJXClCAAhSgAAUoQAEKUIACFKAABeIQcFgTetMxJsxYjEmzluqR5YsVyo0fvvkUfb6fAgneC+TJrpvIHz1xDmrydyyZPhh51RRzTBSgAAUoQAEKUIACFKAABShAAQrELeDQAP7A4ZNo1nEg3N3cVGCeBWcvXEZaH2/I3PAdWjXAJ+3e0qVZuX4H/jdgAhrVeQWDv/gw7hJyLQUoQAEKUIACFKAABShAAQpQgAJwWB94sfz7nwOaVKaDWzh1EP6YPBAht+/oZa3UPO+mVLdGBeTMlglHpCaeiQIUoAAFKEABClCAAhSgAAUoQIF4BRwawMsgdZKqVSytX/PkzIIXSxeGR2p3+KVNo5eZfuXKngnBV2+YPvKVAhSgAAUoQAEKUIACSVYgSs3GJK1MA4+csvsc/tq4E3sOHrN7O25AAQqkPAGHBvD37oWpru2p4OXpYZb09/XRTerNCx6/8UnjhQdh4dEX8zMFElzglz9Wo/EHfdHq02/12A3RCzBn0Vq9/q0P+kEuzkwUoAAFKEABCji/QEJf38PVIM7SRXTu4vV243wx+CdMnbPC7u2ib9Bz0CTUeKeb7r4afR0/U4ACyUPAoaPQS2gjAbxlcpHP1ov0apdUDn12YHlIvqeAXQIyRoMeWFFtteSvrXj7jarm7cMjIvDTL0tx+erNR8skgI/2b9ycmW8oQAEKUIACFHAagZR4fU+rKsgC/HzjndrZab4kFoQCFLBbwKEBvBz9oQpwRv4031yQwKOn8UA9kbRcJisPPkPzIvNO+YYCBgj4eHvpp9+N61aBfvCkjrFs9TYdvHt7eeCuamHCRAEKUIACFKBA0hIw+vou977RK7ASS6hv91aJdWgelwIUSCABQwL4KbOXxyh+bMvkDyoTBZxFoF3zN/DDlD+weuMu1K5eTj+MmjZvJV4sVUh3CzEN0ijllRr5Pt9Pxpnzwbh2IwSuri4okDc7WqvBGmtVK6dPad2W3Zg+708UL5wXvTo3N5+m1AhIU7m0ab0xsn+npz4lnzhzCbb9G4gubRvjRzU94/5DJ5A1Uzq0ePt1vKVaCUyatQR/qbKeD7qij92vR2uUKprPfBx589uS9Zi/bANOnA6CrxqHosILRfF5p2bIkM5P53veY0RGRukWCivW7VCzTgQjZ9aMqKXsOrVupKeMlIP8u/8oxkz+Xc9CcePWbazdvFuPf9Hirdcw6/e/UKFsMXRu00iXx/Rr2ZptuuzdPnoHZUsWMi22et28Yz9+/nWZthVjU5IuDytVeX4Y9CmkC490e/hVdZNY8tcWnD1/Gd7eHsiXKxverlcNb9SsoDcbMm42tu0KxGX13YSpB45ZMgZABtts37K+HsPDtG/5rof9OBdbdh3ELTXmR7FCeZApvb/eZtLQz0zZEHrnHkZO+k3nu3T5unZprL6ztu/Weer3bd6YbyhAAQpQwKEC9lzf5cByjf9+/Gx9/bodeheF8uXAx2o2peoVy1iVS/qsj1KVVgePnNbXirIlC1qtN304dPQMRv08H4dUvgfh4SiUPyfk+laudBFTFptfd+07oq+7MhC0XK9yqOtu5XIl0EldR2XMKWk1KPcr00d/oa83nXqPVteku7Huf8KQHkjj7anXxXe/EOsOuJACFEgUAYcG8O+//RpqVn7B5hNxdXW1OS8zUsBogfq1KmGeCnglKJQAfpMKECXwlcBMAk3LFBJ6Bwf+O4WXVfApAzLKRVSC6R5f/4ifh/8PFV8sri/0sxesxcz5q5BXDejYtEENSMD72YAfsU8F49NG9YozmDt59iLkQt2m2xAdmNeuXl4F9AcxaPQs/PzLMoSom4qXXyymg/c1m/7F9yoI/XV8H3Mxvxv7K6T/X8G8OSA3L3ID8eeGf/TsDwumDNTHft5jfPHtT1ixdjsqqZuHN199WT9kmDRrKY6ePI9xg7vqssjglhLE91DnfV0FwH6+afS4GPLQQ26MpM9fS/VQQh4wSJKaDHmwcPNWqH74oRfG8kuCadmvafBMU5bzF6/o5fKdSBIreTBTpkQBvP/O6/qByxZ1czNn4VpzAL9jz2HV5NAHFV8qrh/WiPtE9YDk+s3b6P9Za72f0Lv30KT91wi+cl1/nw1rVcbp85ewaft+uLs/+Vt2P+yBznfh0hW8Uq4k6r9eST20+FcH9Pfuh+kHMnqH/EUBClCAAgkiYM/1/ZaaPentj/rh9u27ePvNqvBX14Y/1/+DzioQllmW5G+6pH/UdeODz4bpALj+axXhpVrq7T4QcxA6yffR58MhlVZ1apbX265avxPtug/F7z9/jcL5c+lltvySa+tH/xumrldp9fXLzc0VewNPYLKqOGv5Ti14qIfzp89d0tfAqKiH6joPNetTRv1Q2bR/qUTYsvMg0gf4mh+023K/YNqerxSgQOILODSAlz9C9vwhSvzTZwko8ETAXV0I26gaUgmEt+w8gGkqsCxSIBdeKV8yRgCfP3c2bFk81ioAf1cF6PVa9cambft0AO+irpzD+3dEk4/6Qy6OJYrkUzXD2/WF9evP2jy1ZvlJiR69m/h9D1SpUEp/kMD/vU7fIJ268M6Z2A+ZMwTo5QNHzlA17RshNx4y44P06Z+9YI1+EDHy687mXUogKwH2ZhXAVnv50WwRsvJZjrH/8EkdvEst9rB+Hc3H6Dt0Khas2IQduw+r2vWi5uVZM6bD+G+7WbUSuH5DBcjDp6n8m7W9ZN727yGcUg8v2r9vXftt3pGdb2Rk39Tubpgyoic8PVLrrSMiItUDmJPmPc2f9LX5RkYWSq39Ox/2x4Zte9AfjwJ4eRAgwfsnH7yFDi0bmLft9MUo7Nz3n/mz3EhJawRxlwdBkqQVxRvv99ItMqSWxNRFw7wR31CAAhSggGEC9lzfpQZbHjaPGfgJXqv6oi5Tu2ZvqOv7Fxgx8TfdOksCZ7muywPnOT/2Rd5cWXW+MPUAt2zt9lbn8Y166C7XnlVzhkEGcJbUtH51yMC4M35bhW97f2SVP64PG7ftVTX4EfifaklnakEm+fcGHjc/BI++fe9PWpgXybg+bboO0de70QO76Bp7e+8XzDvjGwpQINEEHBrAJ9pZ8MAUcJBAE9WsepKq/e03bBqk6fMI1cQ9tiR93aS5tdQ+S5M4eS81xpKuXr9l3kSacI/+5hO07DJYPzWXALtZo5pooi7etiZ5gGBK0oxPUoE82c3Bu3yW5nhRUVE4fOyMbhXwz97/dBAqM0LMtGg9IDXKkk6eCbIK4J/lGLtV7bckaVlgmeRBhgTwuw8ctQrg2zavaxW8yzb1Xq+IEaqp+ZzFa9GqaW0d2P66YLXukiBOjkiFlc1/x89iwIjpaFjnFRRXzd7T+njjhRLWTR2Xq2b7/+z5D0GXr+mbt3NBwbhvMVOGaXqfRrVfibNY29UDCHl4c0ntx9JeWhhIl4tg9e8qa+b0ce6DKylAAQpQwLECtl7f5dqWzj+tOXiXUkgz83qqln3q3JU4F3RZP0SX2vCiBXObg/fYSiu13XK9lcqABSs3W2WRB8vSCs6eVPDxPYB0S42MjNQVAdmzZECZ4gVs2s03I2fqYL+/6nJn6p5m7/2CTQdiJgpQwFABhwbwEszsOXjc5gJLc6Me7ZvYnJ8ZKWC0gAS876m+2T9OX4TcOTLr/tyxHVNql7v1H6ebgJculh95VBP50uoCevz0hRjZJWCUJuwTVD92afb2RZf3YuSxdYH0b4stmZZLkzlJcoMhSZru7VNP5i2TNOdP7R77fiSfaV+W21guNx0jKPiqziLN8CxTgLrxkSQPQOJLUisho/7LWAObtu9DgdzZdQsG6S5gal0Q3z7iW/+xqi2XZvUyw4D8SKqm+jFK/0N5ICIPVaQWXWowcmbLpG/I5AGJ1FScOnvJvHsZa0AC7yxqHIK4khzLxSUV5i/dECOb2EvtCRMFKEABCiSsgK3X96DgayqAt76uSUn91fVb0kW1/rYa50RSeTWuTFzJdC2+qB7o/rZ4nVVWCbyl65Y9SbplSVP52QvX6LF0ZFu5V5GWXfKAIa4k3cb+UA/Xm9avYfXg3VTGZ7lfiOt4XEcBChgn4NAAXpq+Ss2brUn6AzGAt1WL+RJKQAZXk4HW2qka46c1dZ48e5nuUzZ3Qj/VNP7JAGqxzeEqNfJ/LN+oa2VlELcps1eggxoMx8hkGqRuWN+Ouu+3EcdKH+CndytjAeRTXQpM6ZCaeUKSKZDXH+L4JTXtM377Uzf5l9oFab4ufdVtTeGqOXxcSW5uZv7wJY6dOo8Dqtn/RtXFYd2WPWqO3BuY/9MAPWihBO/SZP9T1TzeNJLwZwNuWAXw6dP54r9jZyF94eMagFMeaMi/m2WzhsRVLK6jAAUoQIEEFrDl+i7XtuOnz8f4W295bTN1x5JgPq5kuhbLmCm9nuPhvekY0nRfKgE+alFPVZgdw79qvBZ5MN1Lzf0ulQnyEDq2JN28vhv3q651/6rr+1ZZTGU08n7B6oD8QAEKPLeAQwN4qXUypUaqqWpd1TdW/tg8LbnK6BpMFHAyAWn2LoO8xZVk9FdpYle8cB5zNgnOoyfpa929/3g1Yvkd3U/um9EzMX7aQh30WzZbj77d834uVii33oWMyC6Dt1kmGThOBlrLqEZPf55UuEBOvflWNRhOw9qVzbuSwXEkmdabVzzljYygW61SGWzYuhc7VdN/GVHeluaAUksu6eyFR60N5L0E/8GXb8hbc5LB+8RDBvOTHxnBv12P73UffZkaUL5LSTKKryl4l/1E/z5lxHnZ1x/LN+lB96SZvDSJl/7ulklaXEgth8xCULNyWctVenAhaa3BRAEKUIACCS9gy/W9iLq2HTlxVrdgM/0Nl2uCdI/yUK3G5G+4PKSVJvASRMvgtDIoq6Srqu+8ZZLrm3TZWqkGwZNR7OX4piT95+UaYs81QcaHya72KQ+KX6vyov7Jo/rfyzg4Ur7YAnhpUdBD3YfINX+M6vce/b48Ie4XTOfMVwpQwDECDg3gv1QDZRRRA9lNV7Vpi/78W4+g3bZZXci82k9rluuY0+BeKJCwAhLMyTRmvdR0cOXLFMGpcxf1QGxyQbZMQ9Q0NNIXXAatk5p66VP/jhrU7vNvJqra36/19C+W+R31vrJqZicBqUzHJiPm11FToklwGnjklH5aL/3f6tR4NBrusx5TBsGTc5Ip5KRpebkyhfVouAtVPz8JlGs/nk7Plv1Lrch6VSsuzctb2lj7Lg9PpJm9jFkQpW6gpMn7ynUyyv5Zq0N26j1KtRDIqqf3kyaL0m9RRpmX5vPeqhuP6SGMTCUnDx7l4YZMQyf95iVIN6UP33sTy9dsx9Dxc/TMAulVE8v/1LHk5k32Y0qd2zbCqg078b8BE9C88au6VuTKtVt6oLu1araA/eummh8UmLbhKwUoQAEKOIeAtMZarrqEfjNqpn74Lq3JfleDxMqMJx1bN9QzlUhJ5d5WZq6p897nelrSG2qMGbn+WSa5hsjUrf3U4K7vfjwA76sZV6Qb1vFTF7BaXQ+khdioAU8GmrXcNrb3c1Uz/DVqVhMZR0f61csxZdwYuQbFVikgDx4++WqMnlFFHrTLgwTL9MarFdS9gvH3C5bH5HsKUOD5BRwawMuTSblhfbdhDT3lxhQ1irf8AZS+v63U/NjNGtY0zzf5/EXnHijgGAFTravpNba9Rl/Xp2tLfPvDLzrQk8HPpDmdzM8uA8uo6EzvQpbrqcrU9GqmQevkafygnh+ga7+x6Np3rA7iLYNEy2M/ac9iufTR+8eHMK8wlc9y+agBXTBu6gLMU32xZaozSZJP5qk1NXl/nmPIvmSquC+HTNZT78n0e5LKqQcaQ75sbw5+n9YNQWd+/EvmgpcbEG8vT5sfLMjx5WZq0JhZGDZhrt6TjHovU1lKE/lU6j9JMorwYvVAUcYtkCS1EA1Uc8aP1RzvkhqomxoJ6uXGS0YVliQPP0oVzYfAx90BZJnUbMyZ0Ff/PTulpunxU30XZXRfmcJPppMzpcxqtP1fxn+FwWN+wUw1wrDcQEmS83tD/VswfVem/HylAAUoQAFjBEx/b02vsR0l+jqpEZfpY7/8bjL6fD9FbyI17NJsvWOrhuZd9Pi4KaR2Wx7mj52yQNfIS4AuA91ZXltlnBepxJL54uVBsSnp+dvLlzB91NfM6GUxr3z85sVShXRrNTmeJLnvLle6MD7r8K7F4KhPji6tAOVhtKTFq7boH/3h8S8ZzFXG5rHlfsFyO76nAAUSVyCVqjG0rjJ0cHmkea0E8tt3H9LNiKQm8nlr/hxcRO6OAs8sEHz1hh6xXC74MkCOMyYJIKWfnkxvIzXQcsF3dJKB4M6qpoA5s2eyaiJo63Gk+XznL0ejsxqIRwbjsSdJlwBphpg9qwwI9GiQoejbi8HlKzcg87CbpvuJnkfmjZfpdKQ1galPYPQ80T/LzVGtZv9DLnXe08f0jr4ask+xl5u3zBkDzA81YmTkAgpQgAIUcCoBuT2+cOmqHqxWHno/rSXp5as3ce3GLeRX3bqkWX1cSWrxZVwcucZYNqePa5vY1sk1V2Y0ya3uPZ5Wrti2i29ZQtwvxFcGrqcABeIXiPsvTfzbx5vD1fVJH/hQNWqnTKnBRIHkIiBNuB01WrpRJlIDLoG7kUnmni+paqyfNUm3G3c3N9V6p6bdu5D+hZYDCca2AzGIb/R4uQmK7xx6fD1eTY1XTAfs9+8/wHzVrFIe4nz64duxHVbfWNnTvzHWnXAhBShAAQokuIDUhksteXwpUwZ/yI8tSYL25wncTceQa678ODolxP2Co8vM/VEgJQoYEsDLU0sZ6fmnX5Zi36ETenAPmd7iwxZv6r6xKRGa50wBCsQuIHPXy+B1DWpV0gPzxJ7LOZZKn0Xp325KMhjQB6pvvOUgfqZ1fKUABShAAQpQgAIUoICjBRzahF6a3qza8I8K3JfppqhSo9X4jSpo1+wNw2sAHQ3D/VGAAgkjcF0NwiNzp+fMlvGpTeATpiTxH0VGrT9++oIa2ChUl1UGIJIWAEwUoAAFKEABClCAAhRICAGHBvAyaNPshWt0uaVGquU7tVSN2qO5omM7GdU66bmnsoptv1xGAQpQgAIUoAAFKEABClCAAhRIbgIObUIv0y+ZUmyjXZrWmV59vL2wY8UE00e+UoACFKAABShAAQpQgAIUoAAFKPAUAYcG8DI9lcyJbGvy9HC3NSvzUYACFKAABShAAQpQgAIUoAAFUrSAQ5vQp2hJnjwFKEABClCAAhSgAAUoQAEKUMBAARcD981dU4ACFKAABShAAQpQgAIUoAAFKOAgAYcF8DIX8upNu565WIFHT+Pf/UefeXtuSAEKUIACFKAABShAAQpQgAIUSM4CDgvgb4feRY/+4zFj/irIPPD2pPVb9qBttyEICr5qz2bMSwEKUIACFKAABShAAQpQgAIUSDECDhvELn2ALwrky4Gh4+fgz3U70KvzeyhTokCckKfPXcLoyb9j9cZdyJTBHwXyZI8zf3JZGW7HQH/J5Zyd/TxcXVLBReY1ZKIABShAAacXiIx6iCg7Kwuc/qSSeAHlGirXUiYKUIACFDBWwKGD2MkI9DN/X4Xx0xbh3v0w5M6RGXVrVED+PNmQLXMGuLu74mLwdZwNuow1qrn9vkMndNDUvPGr+PTDtyHTyiX3JG0TGoz9O7mfZpI7vwWdKsHd1WENUpLc+bPAFKAABZKSwJTNp7Bo74WkVORkX9aGZbLjwyp5jT/Ph2q2Iz68Md7ZniPIc5vICMDNw56tmJcCFHhGAYfVwMvxXVUA1PbduqhTvTxGTvoN67fuxcRZS2ItmuR9uWwx9Pi4CYoXToA/+LGWggspQAEKUIACFKAABZKMgATwk19NMsVNEQUNUPfxjX5MEafKk6SAMwg4NIA3nVDWzOkxrF9HPAiPwJ4Dx3Dh0hVcv3kbEZGRSO/vi4yqufxLpQrDJ03yr3E3mfCVAhSgAAUoQAEKUIACFKAABSjwPAKGBPCmAqV2d0OFskXVR/lhogAFKEABClDACIH7YQ9w9nwwrt0M0V3Y0qbxhoxNkydnFri4sHuQEebcJwUoQAEKUCAxBAwN4BPjhHhMClCAAhSgQEoR+GvjTsxfthG79v6nW71FP++0Pt6oXK4E2jStg5JF80Vfzc8UoAAFKEABCiQxAQbwSewLY3EpQAEKUIAC5y9ewaDRs7B5x36NUaZ4AZQqlh/Shc3f1wdXrt3ExcvXsH1XIP5c/w/+2rAT7zaqiW4fvsPua/znQwEKUIACFEjCAgzgk/CXx6JTgAIUoEDKE5jx258YM2UBItW4Mq1VzXpzFZjnzJbpqRAHDp/E1LkrMWfhWjUDzL8Y8HlbVHu59FPzcwUFKEABClCAAs4rwI5xzvvdsGQUoAAFKECBGAK/LliDfLmy4o/JA9GzU7M4g3fZWJrOjxrQGZOGfoaoqCgsXbU1xj65gAIUoAAFKECBpCHAAD5pfE8sJQUoQAEKUEALVK1YGjPG9EaBPNntEnmlfEn8Mu4r5M+Tza7tmJkCFKAABShAAecRYBN65/kuWBIKUIACFKBAvAJ9uraMN8/TMuTKnhkdWzd82moupwAFKEABClDAyQUMD+BDbt/B0ZPnERR8DcUL5dFP/q/dCMHlqzeQJVM6BPildXIiFo8CFKAABSiQdAQOHzuDwCOnUSh/TpQonCfBppE7fe4SDh8/g+oVy8DL08MM9vDhQzXY3gFVplPw9/NBpZdKIHeOzOb1fEMBClCAAhSggO0Chgbw0k9vzOTfcefufV2i7u2b6AD+oLqId/piFBrXrYJBvT6wvbTMSQEKUIACFKCAFjhxOghHTpzVfdxlELubIaF4v/MgnFKBtClVfLG47v8u08kZmS5dvo423Ybo0e//mjsc2bM8CuAleO85aBJWrN2u56S/fvM2hk+Yh7GDu6pAvriRReK+KUABClCAAslSwLAAfuvOg/j2h1+QPsAX9V6riIUrN5sBZfTbYoVyY92W3WoZA3gzDN9QgAIUoAAFbBCQB+RyjTWlDi0bIPTuPR28V69UBnlzZsX23Yew7d9A/Dh9EXp1ec+U1eGv8pC+Y+9RuHkrNMa+d+0/ooP3Pt1aqtHyX0XYg3C832UQho6fg0XTBsXIzwUUoAAFKEABCsQtYNggdivW7dBHnjKyJ/r1aA1vL0+ksihL2ZKFcCvkjq4xsFjMtxSgAAUoQAEKxCEQFvYAIyf9Bnc3N7z9RlVUqVAKE2ctwWwV1L/x6ssY/203/K/ju/h1fB8VyGfBvCXrER4REccen32VjGr/2YAfEa4C815dmsfYkcxB7+mRGk3qVdfrPFK7o2n9Gjh26jxOngmKkZ8LKEABClCAAhSIW8CwAF76wsmNQ8G8OWItQab0/nr53Xthsa535EJTLUT0fUpzwyV/bcXYqQsgDxyk9iJ6siVP9G34mQIUoAAFKGCUwOFjZ3FfBfHtmtfFwJ7tMPH7HqhVrRyiVHP1WtVeMh9WguXaNcrrWu/gKzfMyx35ZvCYX3Dwv1OYoMrg5+sTY9fStD6Puhdwc3M1rzPdF1y8fM28jG8oQAEKUIACFLBNwLAm9NmzZMCho6cReucefNJ4xShNoFqX2t1ND2QXY6UDFyxfs033vyteOC8qTnrS304G1WvbfQguq5saGZV38uzlyJc7G6aqFgOmgfVsyePAonJXFKAABShAgXgFTA+bixXMY84r/cn/2rgTfmnTmJfJm0wZAvTnq9dvIUfWjFbrnvfDjPmrsGDFJkwb9YWei/6ACuSjp+tq0No03p5Wi729HvWPl/7wku4/iMSDiCirPHF9cEmVCpHqYUVk1MO4snFdAgvIA6TQexH6QZKRh/b1VN8/v3sjie3edyr13YeFRSI8PNzubblByhTw9XZPmSfuoLM2LIB/oWRBLFPB87S5K9GpTSOr4q7etEvdaOzCS6ULQy7ERqUnP6gAAEAASURBVKXdB46iz/dTILUQ0dPUuSt0f73F0wfrAF4eKLToNAhzF60zT7FjS57o++VnClCAAhSggJECUvsuycPjybXNFCS7uj6p6ZY8ptHgIyNtD5Blu/iSNH+XfuyfdXhXP4iXmvabtx4F5Feu3tQP7uVhgrt6UB+pmtlbJtNn6QIgyc3Vxa57AbltkHsHI+8fLMvL97YJyPfh4e4CFcsZnKL43RssbPfu1Xfvrv4/drVoaWP3PrgBBShgs4BhAXzT+tWxZNUW3S9v8V9bcEtNJ7d09Tas27oHew8e19PafGHgoDpnLwTjk69+wNv1qkFuJi6qmwvLtEr1y6umprqR2ndJMsWdPFBYtWGnOYC3JY/lPvmeAhSgAAUokFACqSSSNaXH7y0Xyaron03Zn/f1tmpdJ2nExHn6x3J/LdQgdfVfr4QhX7VXA9n64cSZC5ar9f2ALEifzlcvd3NV5yE/diTJbdS52VEMZo0m4O5mWM/MJ0dSD4T43T/hcJZ3bm7q/0r1AIeJAhQwXsCwAN7FxQU/Df8fxk9bpGq116onsg/1oDVySkUK5EL/z9roVyNOUR4WdFTT1JUqlg9fftIC3fuPtzqMjIIrTfcK5s1utVw+Hzh8Ui+zJY/VxvxAAQpQgAIUSECBoT/OwcSZS/QRr6mm6pK+GTVTNVl/0m3tyrWbermjfxUtmBt/zh5qtdt1W/boWvlpo3qhwOPxbwqo6+oa1epOrsum5v17Ax89xJeR8pkoQAEKUIACFLBPwLAAXorho24ienVujs/VaLgXLl1FiLqA51aD2chyo5KMtNu1zw+q2XxqjOjfWdf0Rz+W9MmTJCPjWyb5LH0LZR+25JHmfzdD7evv45fGnX23LNGd5L00+bP3u3SSorMYFKBAAgpIE2EvD+tm6gl4eKtDyTzw0dPRk+ejLzLks4xhI3PPW6aMjwenza762qfzT6tXNaxdGRNnLEZf1Z2tc9tGuBh8XXetk5HzM6Tzs9yc7ylAAQpQgAIUsEHA0ADedHypjY9+oTetc/TrlDkrcPDIaUwe/rl+YCAPDe7dD9MDa0gfvQB1U5H6cZ94mf7GMkVERup+Va6qvLbkkW19vOwkVC2MXFzsaypoWUa+N0ZAmuPZ/V0aUxTulQIUcGIBZ2i6W6PSC9iyZJxdSmnTeNuV/1kym2wsm/bLwHnD+nVEv2FTsfbv3Xq3ZUoUwDdq9HwmClCAAhSgAAXsF7Az+rT9AFt2HsD2fw/FuYGHmhu2UL4ceLlsMfhGGzk3zg3jWClzy0vALn3woqdXm/bAuMFdVd/30jpQDwm9a5Ul5PZd+Pv56Fr7AHlVdyNx5ZGNdd89q73E/UHGdmH4HrdRYq2197tMrHLyuBSgQMoWcFWDRfnHMmVbYqvUrVEB8hM91VFT2dWqXg7nLlxGWh9vc+189Hz8TAEKUIACFKBA/AKGBfA79x7BVDUCvS1Jpm0b2rcDZBqc500dWjXAe41ftdrNwJEzcOXaLYwd/CmkiZ+0CMibO6saTO+YVb69gceQP8+jfvG25LHamB8oQAEKUIACFIhVQB6I587xaNDYWDNwIQUoQAEKUIACNgkYFsDLPPCSvu39IfLmymZVmKlzlmPt5t0YM+gTnAu6gh/VQHd9hkzG8l+GmKe8sdrAjg8ySI5poBzTZtK3PXXqu1bN+BvVqaJHzpV5bCuXK4GV63ZA+g5+2/sj02awJY85M99QgAIUoAAFEkBg597/IAPY2ZMG9/oQhfLntGcT5qUABShAAQpQwAkFDAvgd+w+rJvFN6hVWU33Yd1oXOaNXb3pXwT+dxqffPAWpM/5d2N/xb5DJ3Rzekc7yeGjFQGtm9TG6bMXMXzCPD1qrjRJbNesLhrUqmQ+vC15zJn5hgIUoAAFKJAAAjKi+6GjZ+w6kmnaN7s2YmYKUIACFKAABZxOwLAA/vK1G2oqG88YwbsIyIB20mz+4JFTGqRM8QL69ez5YEMC+NEDP9H7t/wlAftANYhO709b6BHypUwejwe3M+WzJY8pL18pQAEKUIACCSEg10+5Xsl0p2VLFsJHLeqh/AtF4hxfxT3a9S0hysljUIACFKAABSjgeAEXx+/y0R5z58gCGfX9lKrljp5kkLnQO/f0lG2y7u69+zpLZKT1qPDRtzPis5enBwqofu/Rg3fLY9mSxzI/31OAAhSgAAWMEnixVCGsnjcC7d+vj+OnL6DjFyPRrvv32KYGjpUZVGSA2Og/0gediQIUoAAFKECBpC9gWABft2YFPFSTa3/ccwQmzlyim/tJQL9y/Q50+XKMnmu9WcOaWlBuQCRlSM85YTUEf1GAAhSgAAXiEEgf4IuuH76Ntb+NRM9OzXDpyg10/nI0Grfri2VrtiH6NKlx7IqrKEABClCAAhRIQgKGNaGXEeU7tWmEiTMWY+zUBfrH0kXmga33WkW96IxqOp83V1YUL5zXMgvfU4ACFKAABSgQh4C3lwdaN62DFm+9rgP3gaNmotegSZi/dANmjOkdx5ZcRQEKUIACFKBAUhQwLIAXjM4qgK+u5lxf8tdWnDwTpJrKhyFb5vSo8GIxNKr9irl/fO9PWiRFO5aZAhSgAAUokOgCUaq12+rNuyCzqoSFPYC7mxtKFsmX6OViAShAAQpQgAIUcLyAoQG8FFdq1Vmz7vgvjnukAAUoQIGULRAREakekG/B5NnLIS3ZZLyWVmqGlTbv1kHmDAEpG4dnTwEKUIACFEimAoYH8OImffEi1U/0lEqNmevm5hp9MT9TgAIUoAAFKPAUAall/335Jkydu0IPFuvv66NbvLV4+3X4pU3zlK24mAIUoAAFKECB5CBgaAC/YMUmTJmzAjI9nDTxi57S+nhj+7Ifoy/mZwpQgAIUoAAFniKw+Z8D+PaHX/TaF0oURJP61XTt+47dh56yBfQUrb4M7p/qwxUUoAAFKECBpCJgWAC/+8BR9B06FZ5qOpvsWTPiXNBlPV+tp2dqnA+6grMXglGsUO6k4sRyUoACFKAABZxOYM/BY5Cf+NLMH76ETD/HRAEKUIACFKBA0hYwLIBftnqblpk59ktcvHQNXfuNxTc92yFPziwIvnIdb7bsrUeeT9p8LD0FKEABClAgYQWKFcqDrz9rY9dBc+fIbFd+ZqYABShAAQpQwDkFDAvgZU7arGrE+eLqRuOeGn1e0pVrN3UAnzljOlRTo9MvWvk3enZsBg9VS89EAQpQgAIUoED8AjKbS5P61ePPyBwUoAAFKEABCiQ7ARejzig8IgIPH/d7z54lgz7M8VMXzIfLmik97quBeC5cumpexjcUoAAFKEABClCAAhSgAAUoQAEKxC5gWACf3t8Xl6/e1HO/S0281Bj8unCN/iyB+449jwbbkWlvmChAAQpQgAIUsE3gy+9+xs2QUNsyR8t19OR5jPppfrSl/EgBClCAAhSgQFIRMCyAz5c7q54+buuug9qicd0qOHX2Iqo2/hTVGnfFoaNn9PzwEtwzUYACFKAABShgm8CufUfwfpfBOHD4pG0bPM61cv0OtPr0W1y4yJZvdsExMwUoQAEKUMCJBAzrAy/988qXKYpsj5vPd2jdEDduhWL1pl3q9bae0uabXh84EQWLQgEKUIACFHB+gfbv18ewCXPxXqdv8NYbVdGsUU0ULRj7rC4yhatMLzdVTem6dVcgcmTLiKYNqjv/SbKEFKAABShAAQrEKmBYAB/glxbyY0ouqVLhq67v65+IiEi4ubmaVvGVAhSgAAUoQAEbBd6pVw3VK5XBkLGz8fvyjfonX+5sKF0sv+6u5u/nowaNvYWLwdfwz57DCL56Q19zJfDv0LI+B4610ZnZKEABClCAAs4oYFgAL0H6oWNnkMbLE/nzZNPnfufufV0Df+7CZVRTNx+liuZzRhOWiQIUoAAFKODUAhnS+WF4/454682q+H3ZBl27vnDl5hhllllfJOBv9U5t87U4RiYuoAAFKEABClAgyQgYFsD//c8BdP5yNJo1rIm+3VvpEenbdPtO930XnZ9nL8PogV1Qs3LZJIPFglKAAhSgAAWcSaDSS8UhP5GRUbh05Tqu3wjBnXv34Zc2DdIH+CFTBn9nKi7LQgEKUIACFKDAcwoYF8DvPKCL9lGLevp147Z9Onh/sVQhNKhVGeOmLcTIib8xgH/OL5CbU4ACFKAABVxdXSBTtpqmbaUIBShAAQpQgALJU8CwAD5IjXKbOUMAsmRKp+W27Hw0Gn3nNo1RoWxRnL0QjClqUJ3QO/fgk8YreeryrChAAQpQgALJWCDwyCnsV6PhX7x8Hd5eHqj8UgmUjNY97qEaSG/zjgOQvNI/v5LKkztH5mSswlOjAAUoQAEKGCdgWAAvtQGpXFKZS77n4DG4u7mhbKmCepn0y5N0TTX3YwCvKfiLAhSgAAUokGQENmzdq7vKybVdRreX6/nYKQvwSbu30KFVA30eErz3HDQJK9ZuR56cWXD95m0MnzAPYwd31U3/k8zJsqAUoAAFKEABJxEwLICXEXHXbdmDVRt2wiO1Ow6rAe1eKl1YB/Fy7sdPXdAERvTPCwt7gO1q5N0Tp4Nw42aIagWQHrWrl4MM+mOZboaEYtP2/Thz/pIa3Cc7qr5cCj7e1q0BbMljuU++pwAFKEABCqQEgYzp/dCvR2s0rlsFqd3d8CA8Au26f49pc1eivRrtXmaf2bX/iA7e+3RrieaNXkXYg3A1h/0gDB0/B4umDUoJTDxHClCAAhSggEMFDAvg31WD1836/S/0+Hq8ucCdWjfS70Pv3sNfG3ciR9aM8PL0MK931Jv+w6dj6eqtSOvjrQfwOX3uEkb/PB/TR3+B4oXz6sMEqel12nYfgstXbiBX9syYPHs55KHD1JE9zdPf2ZLHUWXmfihAAQpQgAJJSUCup6ZrqpRbgngv1Yxemsmb2t/9uf4feHqkRpN61fWpyQP9pvVr4OsR03HyTJC+7uoV/EUBClCAAhSggE0ChgXw2TKnx4wxvTHpl6V4oJ64165RXvd9l1JJrbwE1zK1jRFJBsp7u15VlCtdRO/+1NmLaNyuL2YvXIvBX3yol02duwI3b4Vi8fTBOoAPPHoaLToNwtxF69CxdUOb8xhRfu6TAhSgAAUokFQE5KH8tl2B+mf7v4fQT808k0rVvku6pPrGS9N5NzdX8+kUzJtDv794+ZoO4MPVCPqRkQ/N6+N7I7uOwkNEqeb5TM4j8FB9J2HhkWrWIWPL5KnuXKOijD0G926ngPrOIyPU/8cPI+3ckNlTqoBn6ifXhJRq8DznbVgAL4WSgWzGqX5u0dPbb1SF/BiVmtSvbrVrmU7HRfXHD/BLa16+StUKVKtYRgfvsrB4oTy6ib88XDAF8LbkMe+QbyhAAQpQgAIpUODQkdPo1m+cPvMqFUrp7mgmBpnWLo23p+mjfpXB7iRJf3hJEoxF2BHAS9N8FSsaHijqwvGX7QISxKn4zfAHK/rO1eCnBLafNXNqAfVALeohIuR/TCYKUMBwAUMDeMNLH88BZKR7qQ1Ytmabbqovc9JLkj54cuNQMG92qz3I5wNqNF1b81htzA8UoAAFKECBRBI4H3QF67buwbkLl5FVtYBr16wubty6rfqf79AzwrxW9UXDSibj22xbOh6nzwej39CpaNX1Oyyd8Z1uUu+umtVHRqsuNX2Wwe8kebi76B97CihBvKvFQLn2bMu8xghIqwtvzwSoVYuK0JUyxpwF9/pMAuq791A1qh7q/3cmClDAeAHD/k+TKeJ+XbAmzjPwVc3ojRzEZsZvqzB38Tr1h94FXdo2Nk9pJzUCkry9otcKeEKaAoZHRMCWPHLzcS/MvuZCnh6uxj+djlOdK2MTkGfG9n6Xse2HyyhAgeQt4OaaSg3G6uJUJzl/6QZ8+8MvehA5KdgLJQrqAN7XJ426Dq/G5as38XeFsbovuhEFl2usr2rpVkq1umvzbh18NWQyjp06r1u2pQ/ww4kzjwatNR371u07+m36dL6mRXylAAUoQAEKUMBGAcMCeGmy7m7R582yPNL3XALltAbP//7FJ++hc5tG+FvNQS+1AjKifK/OzZFaDaIjKSparUCEavv16Km+i0159D6M7uylS8pfCSFgeLO/hDgJHoMCFDBU4OFD0/Bshh7G5p3LYKsSvMssK++99Rq2quvdvfsP9PYynauM/D5k3GzIVK4VXyxu835tyShTxJn6upvyy1RykrzUwHWSCqiWbWs27YIE7dKdTdLewOP6wXrenFn1Z/6iAAUoQAEKUMB2AcMC+Lbv1oX8xJb2HjyO9z8ZbNggdqZjSg15ugBfNKhVSU9js27Lbh3AB6gRciVQDwm9a8qqX0Nu39Wj50ptgi15ZKM0MpqKHUlqenX/PTu2YVbjBeSW3N7v0vhS8QgUoAAF4hbYufewrnnvoAZflbFljp28gHNBl80blSyST7+XJvZwcCv6QWNm4d69MLxe9SVky5Ie+wJP4Cc1cG2h/DmRJ9ej4Lxh7cqYOGMx+n4/BZ3bNsLF4Ot6mjnpKx99aldzofmGAhSgAAUoQIGnCtgXfT51N/atKFOiACq8UBQTZy5By3dq2bexDbljqxWQPu9eHo8GzpEAPW/urNiraiQs097AY3o+eFlmSx7LbfmeAhSgAAUokNACV68/qvF+uWyxWA/t4fGoxVn0mvJYM9u5sFC+nBgz+XcsXrXFvGWFskUx8H/tzA+qZbrYYf06ot+wqVj7926dT+4BvunZzrwN31CAAhSgAAUoYLtAogTwUryC+XJg++5DuqYgZ7ZMtpfYhpz1W/VGvdcrQaaTk3nmF6zYhMAjp3Q/eNPmjepUwYiJ8zBj/ipULlcCK9ftwNGT5/Ft749MWWBLHnNmvqEABShAAQoksED+3Nn0ETfv2A/TQK2WRdiimtRLkqncHJ3ebVBDzeleHVeu3VJN5EORKUOAuZm85bHqqGlka1UvpwfYkylk0/k/mRHGMh/fU4ACFKAABSgQv0CiBPAPwiN0fzxp4p4m2kBy8Rc5/hx5VdO9H2csUtOZqLlpVJL5Z2Vgnfbv1zdv3LpJbZxW88MPnzAPQ8fPgfQVlFF7pbm9KdmSx5SXrxSgAAUoQIGEFpDabD/fNJBBW3Nlz6wO/2Qapz/VdKmTZi1B5ozpUKJIXkOKJjX7mTL465+4DiBdx3LnkPIxUYACFKAABSjwPAKpVHPzJ1f759lTtG1l6jap1Y6e7qvBdf47flYPKCfB8ndfto+exSGf5SHBpcvXEBERieyqCZ/H44Hrou/83v0wXLh0FdIK4HnyRN/v0z4LdoOxfz9tNZcnksCCTpXgrh7iMFGAAhRIagKr1SBxnw340fzQWrqAyVzroXfu6QfYowZ0Rs3KZZPaacVZ3imbT2HR3gtx5uHKhBVoWCY7PqxizIMiqzNR08hh8qtWi/ghkQUC1Pfe6EfA3TuRC8LDUyBlCBhWA3/81AVs2Lo3VkW5sXj1lbLo+uE7sa53xMLUai7KR7URce9NmtgXyGM9H3z0LWzJE30bfqYABShAAQokhIAMIrdwyiCMn74Qh4+dRVDwVfj7+qB8mSL4pN1belC5hCgHj0EBClCAAhSggPEChgXwMtrsh++9GfMM1HDfPt5eMZdzCQUoQAEKUIACzySQP082jPy68zNty40oQAEKUIACFEg6Aoa1GZb+7T5qnvcYPwzek86/DpaUAhSgAAWcWuD8xSsYMGIGtu4KjLWch46ewQc9huLE6aBY13MhBShAAQpQgAJJS8CwAD5pMbC0FKAABShAgaQncFWNAP/b0vX4+PPhmDx7eYwTuHErRM/4cjMkNMY6LqAABShAAQpQIOkJMIBPet8ZS0wBClCAAhSwEnBX476M+mk+uvUfh7v3wqzW8QMFKEABClCAAslHgAF88vkueSYUoAAFKJBCBYb27YBa1cph9cZdaNZxAM6cD06hEjxtClCAAhSgQPIWYACfvL9fnh0FKEABCqQAAW8vT8h0cT3aN8GpMxfR9OOvnzoTTArg4ClSgAIUoAAFkq2AYaPQJ1sxnhgFKEABClDASQU+ULO/FC2UB58PnIAuX43BS6UKOWlJWSwKUIACFKAABZ5FwLAa+Nuhd5+lPNyGAhSgAAUoQIHnEKj0UnH89tPXKJw/J3buO/Ice+KmFKAABShAAQo4m4BhAfyUOSvQqG0fzF+6AffDHjjbebM8FKAABShAgSQv4O3lgQJ5skNeLVP2LBkwe3wfNKhVCWm8PeHqYtjl3vKwfE8BClCAAhSggMEChjWhl5uHU+cu4usR0zFSjYz71htV0LzRq8iRNaPBp8TdU4ACFKAABVKGQCFVy754+uBYT9bDIzW++7J9rOu4kAIUoAAFKECBpClg2CP5JvWrY828EejcphE8Pdwxfd6fqPteT3T+cjS2/RuYNLVYagpQgAIUoEAiC0Q9fIjwiAjIKxMFKEABClCAAilLwLAaeGHMmN4fnVQA/3HLBliz+V/MWbhGj4q7Yete5MudDe81fhUNa78So+lfyvoKeLYUoAAFKEAB2wX+WLZRt27r270VShTOi/Y9h8e78aTvP0PJovnizccMFKAABShAAQo4t4ChAbzp1F1dXVC7ejm8VuVF/PTLUoybthAnzwRh0OhZGP3T72ismtdLMJ8re2bTJnylAAUoQAEKUCAWAWka75s2DVK7u8Hd3RUZ0/nHkst6kaurq/UCfqIABShAAQpQIEkKJEgAf+XaTfyuagxkQLvgqzc0lNQElH+hKJat3oZZv/+FX/5YjbGDPkWNyi8kSUgWmgIUoAAFKJAQAjIwnfyY0tP6wJvW85UCFKAABShAgeQjYGgAv3Pvf5izaC3W/r0bERGR8EjtjkZ1XtG17cVVsz9JXT94G3+u34EZv61C6N17yUeWZ0IBClCAAhRIRIHQO/fgk8YrEUvAQ1OAAhSgAAUo4GgBwwL4iTOXYOzUBbq8MvJ80wY18PabVeHv62N1DtK8/s3XKuqfyMgoq3X8QAEKUIACFKBA3AI9vh6PkNt3Mf67bvpB+f7DJzFo1EwEHj2NbJnTY3j/TihdLH/cO+FaClCAAhSgAAWShIBhAfyD8HC8Ur4kmqu+7VVfLg2XVKniBZFgnokCFKAABShAAdsEjp44h1UbdqqpWqvq4F22GjL2Vx28y2Cxp85eRLd+Y7FqznDdZ962vTIXBShAAQpQgALOKmBYxFxYzU0rA+z4qYF2bAnenRWI5aIABShAAQo4q8CxU+d10erWrKBfJaDfd+gEKr5YHEtnfIsBn7fF5as3OX2rs36BLBcFKEABClDATgHDauCPnjyPdVv2oFXT2nYWidkpQAEKUIACFLBF4MatUJ0tV7ZM+vXAkVP6VWZ+kVSudGH9euHiFf3qyF8yD/3eg8dw6OgZXL8ZghdKFESFssVi1PQ/VPk27ziAQFU2fz8fVHqpBHLn4KwzjvwuuC8KUIACFEg5AoYF8AXyZteKF4OvpxxNnikFKEABClAgAQWyZEqnjyY18TmyZcTazbv151LFHs35Ln3jJbm7Of5yv2jlZvQdOhUyrV3GdH6YNGspvL08MLRPB/OMMhK89xw0CSvWbkeenFlUoH8bwyfMw9jBXVUgX1yXjb8oQAEKUIACFLBdwPFX9MfHrlKhFDJnCNAXbcvpbmwv2rPnvHP3vm4uKH3/JFV9uRQK588VY4c3Q0Kxaft+nDl/CfnzZNf5fLytR+y1JU+MHXMBBShAAQpQIAEEypYsBC9PD3zx7U+ooKZm3bx9H4oWzI1C+XLqo+/Yc1i/SnDv6JQ9S0Z82/sj1FMD0coYNueDruCtD/tizOQ/zAH8rv1H9H1An24t0bzRqwh7EI73uwzC0PFzsGjaIEcXifujAAUoQAEKJHsBwwJ46YeXJ1cW1WxuP75TA+pkSu8fA9NdTSvX6p1aMZY/74Lu/cdhy86DSOefVu9q9M+/I2+urJg19ksE+D1aFhR8DW27D8HlKzeQK3tmTJ69HDLgz9SRPe3K87xl5fYUoAAFKECBZxWQ65wEx/2HT9NTtqbx9kTPTs2QSg0cKw+zp89bqWvFpXm7o1OFskWtdikPCV4qXQS79v1nXv7n+n/gqWrom9SrrpfJdLJN69fA1yOm4+SZIH3dNWfmGwpQgAIUoAAF4hUwLICXmu0dux89+f/lj9WxFkRqu40I4F9Rtf+ftHsLJYvmgzTfm790AwaMnIG5i9ahY+uGuixT567ATdV3cPH0wTqAl+l2WnQaZHeeWE+MCylAAQpQgAIJJNCoziuQVm+nz11CiSJ5zaPRS2133+6t1MNsXx1EG12cqKgo7As8rh+Ym4516fJ13XTezc3VtAgF8+bQ7y9evqYDeHWZxkP1n73J/i3sPQLz2ysg4yIYnfToy8YfxujTSHb7l/tt+WGigC0CHODcFqWn5zEsgJcbCmnaF1dyM2jaOMuHAlIL0aB2ZQxUc+JeVLXuprRK1QpUq1hGB++yrHihPKrmoLCejscU5NuSx7Q/vlKAAhSgAAUSSyB9gC/kxzJJ7Xytao8Gs7NcbtT78dMXQbqd9f+stfkQ12+EQFoFWCbpJy9J+sNLuhsWoZrWR+n3tvxycUmFiKiHiIxksGCLV0LliVTfScidCESpVyNTOh8X/f0beQzu2z6BVOo7v38/EmH3w+3bkLlTrEA639Qp9twdceKGBfAyWI38OEPao0bJlaeCeXNn1cWRWgm5cSj4eKA9Uxnl84HDJ23OIxnlgmVPkhsP+7awZ+/M+zwC9n6Xz3MsbksBCiRNAXkorP6MM0UTmL1wDSbOXIJWTWpbPTRwV9PJRqqaectk+mwaWC+NpxvSWMf4ltljfe+mvgQ3V34RseIk0kJX9Z34+7gbf/SoCH73xivbdwT13afxUv8fuzMosw+OuSnwbAKGBfCm4kREREIGsTlzPhj37oUhe9YMKFkkH0wj55ryGfUaFvYAIyb+pvu1N65bRR9GagQkeXtZ3zHI59C79xAeEQFb8sjNR8gd+542+vuktjvo14XlL0MFpNVXyF37vktDC8SdU4ACTing4e4CbxVwMj0RmDJnBUZO+k13ievVufmTFepd+gA/nDhzwWrZrdt39Of06axbDFhl4gcKUIACFKAABWIVMPQuRPrADxg5XQfvlkeXwPf9t19Hjw5NVU2GcU/QH4RHoEufH/RAORO/7wF/Xx9djNRqEB1J0l/PMkVERuryuLq4wJY8sm1AWvueNkrtu9QcMDmXgPwztPe7dK4zYGkoQAEKJKyAXEOHjJuN2QvXottH7+CjFvViFECmlF2zaRckaPdLm0av36v6ybuo62zenI9axcXYiAsoQAEKUIACFHiqgGEBvAym0+Wr0QgPj8Rbb1RVte5qYB01Em3QpatYsGITpqmRcX3SeKFDqwZPLdzzrJDRdz/pMwb7D53EODXfbHk1vY4pBfj56EA9JPTR/Lim5TJfrr+sUzcWtuQxbcdXClCAAhSgQEoTGKFq3X9dsAavV30RuXNkxl8bd5oJiqlxZXJkzYiGagyaiTMWo+/3U9C5bSM1Fs11TJu7Ug+6l0HNHc9EAQpQgAIUoIB9AoYF8L8v24h79x/gp2H/Q6WXiluVqm2zumjecSCmzFmOj1vW19PdWGV4zg/BV2+g0xejEKymiJs6qhdKqdHoLZN+8q/6w+9VfeMt097AY3o+eFlmSx7LbfmeAhSgAAUokJIErl67pU939aZ/IT+WqX+P1mjaoIYO4of164h+w6bqae4kT5kSBfBNz3aW2fmeAhSgAAUoQAEbBQwL4PcfPoGc2TLFCN6lXDInbCPVH33o+Dk4F3TZPBK8jWWON9t7nb6BTF3TvX0T9XpN/5g2qlm5LGQ6m0Z1qqi+8fMwY/4qVC5XAivX7cDRk+fxbe+PTFltymPOzDcUoAAFKECBFCTwfZ+PIT/xpTo1yqNW9XI4d+Ey0vp4q2nt0sa3CddTgAIUoAAFKPAUAcMCeOlvflZdrJ+WZEA7o9LV649qBUb9ND/GIbYtHQ9f1Q+vtRop9/TZixg+YZ5+kOCqprRrp1oGNKhVybyNLXnMmfmGAhSgAAUokAACi1dtQeide3YdSYLo6NPM2bWD58ws491IM3smClCAAhSgAAWeT8CwAL544by6udzPvy7Dh++9adVM/sTpIPzyx2pkyuDv8Np34di3Zkq8KhKwD1RN+Hp/2gIXVL98aS3g8XhwO9PGtuQx5eUrBShAAQpQICEExk9bqK9b9hyrSIFciRrA21NW5qUABShAAQpQ4OkChgXwLd+phUV//o3RP/8OqS0ooQJ6T8/UuHDxCrar0ell9NphfTs8vWQJtMbL0wMF8mSP82i25IlzB1xJAQpQgAIUcJBAP9W//O69+3btLZ8a94WJAhSgAAUoQIGkL2BYAO/t5YFpagA5aca+fO12nFLN1U0pV/bM+ExNIfdalRdNi/hKAQpQgAIUoIANAq+UL2lDLmahAAUoQAEKUCA5ChgWwAtWlkzp9AA3Az9vi7NqsDqZ2k2aqidmP7zk+CXynChAAQpQIGUL3FbTov6z9z89UFz6dL6o/3ol3U9+174jCFCDxpUulj9lA/HsKUABClCAAslEwNAA3mQk878XzJvD9JGvFKAABShAAQo4SGDD1r3oo+ZZv3Hrtt7jCyUK6gBeZlz5esR0hD0Ix+aFP+gZWBx0SO6GAhSgAAUoQIFEEjA0gI+MjMLewOPYuusgboaExjhFb9X//LMO78ZYzgUUoAAFKEABCsQvcO1GCHoNmgRXNxc0b/wqDh89Y95Ipmx9/+3XdVe2PYHHUK50EfM6vqEABShAAQpQIGkKGBbAy1RuDdt8FWvgbqLy8fZiAG/C4CsFKEABClDAToEdew4j9O499P6khQ7Wv/xuMs6pLmumZGo6L3OwM4A3qfCVAhSgAAUokHQFDAvgJ85aooP3hrUro1GdV+DnmwYuLi5WUi6prD9breQHClCAAhSgAAXiFAhS06BKql6pTKz5/Hx99PIH4RGxrudCClCAAhSgAAWSloBhAfzRE+d0f7tven4AmU+diQIUoAAFKEABxwrkzpFZ73D3gWPIkTVjjJ3vPnBUL8uTM0uMdVxAAQpQgAIUoEDSEzAsspa51aUPvDTtY6IABShAAQpQwPECpYsVgAwUO+v3VTh97pLVAWQMmvHTFsI3bRoUL5THah0/UIACFKAABSiQNAUMC+BrVy+Phw8fYsGKTUlThqWmAAUoQAEKOLlApgz++LzjuzikBq+r16o3/tq4E8dOncdbH/RDyy6Dcf3mbXz2cVOk9fF28jNh8ShAAQpQgAIUsEXAsCb0FcoWhfR/Hzd1Ic4HXUFkVFSM8nipUeh7dW4eYzkXUIACFKAABShgm0DzRq8id44sGDP5d0j3tXv3w3Di/gUUzJcT3du/gyoVStm2I+aiAAUoQAEKUMDpBQwL4E+dvYht/wbiftgDzF28LlYIGYWeAXysNFxIAQpQgAIUsFmg0kvFIT9RquXb1Wu3kD7Al+PP2KzHjBSgAAUoQIGkI2BYAD9vyXpcvnoTb79RFQ0fj0LvGm0U+lSpUiUdKZaUAhSgAAUo4OQCLuq6Ks3qmShAAQpQgAIUSJ4ChgXw/x0/q0eh7/9ZG9YCJM9/OzwrClCAAhRIBIEh42bj2o0Qu47cpW1j1cz+0Yj1dm3IzBSgAAUoQAEKOJWAYQF8gbzZsWvfET0KvZ8aAZeJAhSgAAUoQIHnF1j3925ceDz/u617a9awJgN4W7GYjwIUoAAFKODEAoYF8I1qv4J5i9fj96Ub8MF7bzoxAYtGAQpQgAIUSDoCcyf2R3hEhC7w5Ss30KzjQHzQ/A20ePt1q5O4e/c+WnQZhKIFcqNUsXxW6/iBAhSgAAUoQIGkKWBYAB989QbSeHvixxmLcfp8cKw6Hh7u6NO1ZazruJACFKAABShAgZgC6fzTmhdu3XlQv69ZuSwyZwgwLze9ad2kDn6Y8gdOnA5CkQK5TIv5SgEKUIACFKBAEhUwLIA/cPgkbofe1SxPmwteRqFnAJ9E/+Ww2BSgAAUokOgCN26F6jK4uLrEWhZTzfueg8cYwMcqxIUUoAAFKECBpCVgWADftlldvPVGlTg1XFLFfsMR50ZcSQEKUIACFKCAFiiQJ7t+/XP9PyhVNGYz+eOnLuj1YWHhFKMABSiQpAWiHkbhrzN/JelzSI6Fr5OnTnI8Lac+J8MCeBm4joPXOfV3z8JRgAIUoEASFyj/QhHkyZkFM377E6fOBqFKhVIoU7wgzly4hH2BJ/CbmtLV39cHDWpXNvRMA4+exs1bt1G5XMkYx3mo5qbfvOMAAo+cgr+fj5qvvgQH1IuhxAUUoEB8ApEPIzHt4LT4snF9AgvUzlMbqdR/TAknYFgAL6cgF+01m//F7gPHcDH4KurXqoxXXymLf/cfxbZ/A9VFvDjKlixk6Nmu3rQLBfPm0Dc40Q90MyQUm7bvx5nzl5Bf1WJUfbkUpFm/ZbIlj2V+vqcABShAAQoklICnR2qMGtAFPb4er69nck2zTKnd3dCne0tY9pu3XO+I96fPXULvb39Sx/CNEcDLfUDPQZOwYu12fR2+fvM2hk+Yh7GDu+p7AEccn/ugAAUoQAEKpCQBwwL4yMgotP98OLbvPmT2LFHkUfO+DOn88NMvS7Hv0An8POx/5vWOfBMREYkN2/aiR//x+KpbyxgBfFDwNbTtPgQygm+u7JkxefZy5MudDVNH9kSA36MBgmzJ48gyc18UoAAFKEABewUK5cuBRVMH4c8N/+DwsTM4H3RF17rnyp5JPzjPlMHf3l3anL9Bmy/1AHmyQboyvjG227X/iA7e+6jrcPNGryLsQTjeVyPjDx0/B4umDYqRnwsoQAEKUIACFIhbwLAAfu7idTp4r1n5BTRrVFMF0j+aG1fkzpFZPaUvgW27DiFKPZ13SeXYZhfHTp1H43Z9dQuAp53+1LkrVHO/UCyePlgH8NL8r0WnQZi7aB06tm6oN7Mlz9P2z+UUoAAFKECBhBJwc3NFvdcq6p+EOqYcZ8KQHggPj8BXQybHeljpmy+tBJrUq67Xe6R2R9P6NfD1iOk4eSZIPziPdUMupAAFKEABClAgVgHDAvgdqubdVY2KO7BnO12jLTcXlqlYoTy6uZ/UgGfJlM5y1XO/l/6Ay2Z+hzt376HpxwNi3d8qdVNRrWIZHbxLhuKqPC+VLoxVG3aaA3hb8sS6cy6kAAUoQAEKJKDA/bAHWLhyM46dPI8r124iQzp/FMyXHY3rVoGXp4dhJcmeJYPet7eXh5qbPjLGcS5dvq5bwFneA0i3NkkXL19jAB9DjAsoQAEKUIACcQsYFsCH3L6jL9qm5ujRi+Hi8mgEeumf5+jk7uamjx16516su5YmfNIPr2DeR6P3mjLJZ5n+TpIteUzb8ZUCFKAABSiQWAJ7A4/r7mLBV2/EKMJPvyzD6IFd1MB2BWKsS4gF12+EII23p9WhJNiXJNdhSXfDIvEgPGbwr1fG8svFJRUiVeu9yKiHsazlosQSkBaVIXfDEWXw9+Lv7YLISH73ifU9x3bcVOo7v38/Ag/Ug0Qjk7eX+n/f4H9fRpY/Oe/7Zqh9372/T+rkzGH4uTk+en5cZBkUbqdqRn/mfHCM0WZlUJuNW/cirY830gXE7DNn9FnLDYUkb6/oNxWeCFW19uEREbAljzwosPcfrF+a1PzjY/QX/Az7V/8k7f4un+Ew3IQCFEjiAqndXeHtYd2iLDFP6c7d++jefxxuhdxB+/frQ7qtBfinxQ0VHK/9e7cenf6zAT/q7mLRB2lNiHK7q4f0kVFRVocyfZZrqCRPdxekdrN9WlnpdCdd7ySQZ3IeAflO0ni4wfjQOpLfvfN87Y9Kov5f9Ejtqv4/dje0ZA9TRTi8262hBU5BO/fxMva7T0GUNp2qYQH869Vewjw1fY30c+vRvom5MKYRaKXP+bsNapiXJ+Sb1KoPnqSoaDcVEZHqoqAuQK6qdYAteWQfdv+DVfcbvOkQOedKMgyD3d+lc50CS0MBCiSAgLPFjDv2HMLlqzfRp6saJK7xq2aBHFkzoqSaFz5zxgAMGj0Lu/YdQXXVbSyhU/oAP5w482guetOxb6kWepLSp3v0AF+uibaH74/2IqG7/DA5l4CrawJ8K+p5kFyzmZxLwFX+OBr8/Yfzu3euL92iNG4Gf/cWh+JbJWBYAP9y2WL4oPkbenT3Zh0HauzRP/+OkT/N1+9lILtuH72TKF9CgJqHVgL1kNC7VscPuX1Xz1ErzfttySMb2/sPVp5M87pjxe40H+z9Lp2m4CwIBSiQYgVOnA7S515FTYMaW5KxXiSAP3HqQqIE8AVU17Q1ajpXCdr90qbRRZQm/3KdzZsza2xF5jIKUIACFKAABeIQMCyAl2N2VzXvr1QoidkL1uLU2YuQfvG51QBz5dRgcRLce6iRaRMj6RuH3Fmx9+Axq8PvDTym54OXhbbksdqYHyhAAQpQgAIJLGAaRO5c0GVIrXv0dOb8Jb3Iz9cn+iqHfJYHCPcfPICMOSPTx0rrOi91bZdpWSU1rF0ZE2csRt/vp6Bz20a4GHwd0+auRJUKpdRAe34OKQN3QgEKUIACFEhJAoYG8AJZrnQR/ZOQqDIA3fHTF3Dn8SB2Mp+73FRkzhBgvmFoVKcKRkychxnzV+kp7Vau24GjavTeb3t/ZC6qLXnMmfmGAhSgAAUokMACZUoUhPQlHzhyJob364DihfOaS7BfDco6YMQM/UD65ReLmZc78k3Xvj/g1LlHDwlkv03bfw2Zl36hmpdekjxUGNavI/oNm6r75MuyMiUK4Bs1Qw0TBShAAQpQgAL2CxgewNtfpOffQgbOk5sIU5oyeznk55N2b6FDqwZ6cesmtXFatQoYPmEeho6fo6e8a9esLhrUqmTaDLbkMWfmGwpQgAIUoEACC2TLnB6fdWiKIeNm62lTM2XwV13AfNUI7yF6OjkpjoxDE1vtvCOKumzWkHh3U6dGedSqXg7nLlx+NHitGmSPiQIUoAAFKECBZxMwNIDfvGM/Nmzbi227AnEzJDRGCWUU+lWzh8VY/rwL5Ol/4Ibpce7GNEd9709b4MKlq8iZLZMaQfPR4HamDW3JY8rLVwpQgAIUoEBiCLR8pxaKFMiFSbOW4tip86o12TmkU0GyjEUjI9NXKFs0MYpldUwZd0bGvmGiAAUoQAEKUOD5BAwL4P/dfxQdeo3UpZOp4tL5++rR3S2La5oL1nJZQr/38vRAATXlXVzJljxxbc91FNACURFqBEMXYjibgB7OmENLOtvXwvLYJ1CujOqupn4kyXzcEjAzUYACFKAABSiQ/AQMC+CnzFmhtcYN7ooaal5aJgqkeIHIB8CiTsCNUymewqkAPlyrRq007E+hU50qC5MyBBi8p4zvmWdJAQpQgAIpU8Cwu9bwiAikdndj8J4y/13xrClAAQpQwCCBw8fO4Jc/Vtu1dxn/RbqKMVGAAhSgAAUokLQFDAvgSxbJi607D+rp4/Lm4lyvSfufCUtPAQpQgALOIiDjtiz682+7ivPWG1UZwNslxswUoAAFKEAB5xQwLIB/t2FNzF64Fj9MWYBRAzo759mzVBSgAAUoQIEkJuCuWreZ0gtqGrk279ZBJjVNalwp/+N52ePKw3UUoAAFKEABCji/wJO7AAeXVeZcf6NmBcxbsh4V63dGVGRUjCP4pvXG6nkjYiznAgpQgAIUoAAFYheo9nJpzBr7JSbPXoFN2/fh84ET0LDOK/ig+RusZY+djEspQAEKUIACyUbAsAB+9aZd+G3pBg3l6eEOv7Q+cHGxHoHbGUahTzbfJE+EAhSgAAVSjEDZkoXw43eFcPz0BUydsxILV27GH8s3QeZc/+i9N1Eof84UY8ETpQAFKEABCqQkAcMC+L827sJDNZXNpKGf4ZXyJVOSKc+VAhSgAAUokCACMg3qt70/RNcP38KM+X9h9oI1WLF2OxrXrYJBvT5IkDLwIBSgAAUoQAEKJJyAdZW4A497KyRUj0LP4N2BqNwVBShAAQpQIBaB23fu4dr1W4iMetRd7aa6BjNRgAIUoAAFKJD8BAyrgS9TvAC2qFHoT54JQj4OnpP8/uXwjChAAQpQINEFDv53Cj/9shTrtuzRrd5eLlsMH71fD/LKRAEKUIACFKBA8hMwLIBv8fbrmLt4nRqF/g+MHvhJ8pPjGVGAAhSgAAUSSWDnvv/w06yl2LorEC6pUuG1KmXxUYt6KF44byKViIelAAUoQAEKUCAhBAwL4KUf3rUbIVi96V+8WLt9rOfik8YLGxeMiXUdF1KAAhSgAAUoEFNgoxp5vtMXo/QKmUZORp/Pmyur/nz63KWYG6glWTOlg4dH6ljXcSEFKEABClCAAklHwLAA3t/PB8UL5YlTwsvLI871XEkBClCAAhSggLVAeHiEecGeg8fQ5av4H4TP/OFLvFiqkHk7vqEABShAAQpQIGkKGBbAN2/0KuSHiQIUoAAFgN3Bu3H4+mFSOJFA0XRFUTZzWScqkW1FyZUtE5o3tu/6mimDv207Zy4KUIACFKAABZxawLAA3qnPmoWjAAUokMACgdcCsezksgQ+Kg8Xl0DUw6gkGcDLHO99uraM69S4jgIUoAAFKECBZCpg2DRyydSLp0UBClCAAhSgAAUoQAEKUIACFEgUAQbwicLOg1KAAhSgAAUoQAEKUIACFKAABewTYABvnxdzU4ACFKAABShAAQpQgAIUoAAFEkWAAXyisPOgFKAABShAAQpQgAIUoAAFKEAB+wQYwNvnxdwUoAAFKEABClCAAhSgAAUoQIFEETBsFPrT5y4hV47McEmV6qknJnny5Mzy1PXOsOJmSCg2bd+PM+cvIX+e7Kj6cin4eHs5Q9FYBgpQgAIUoIDTCzx8+BCbdxxA4JFT8PfzQaWXSiC3uj9gogAFKEABClDAfgHDAvhFf/6N/46fxbC+HZDWxztGyeYsXIvx0xfh78VjY6xzlgVBwdfQtvsQXL5yA7myZ8bk2cuRL3c2TB3ZEwF+aZ2lmCwHBShAAQpQwCkFJHjvOWgSVqzdrh/YX795G8MnzMPYwV1VIF/cKcvMQlGAAhSgAAWcWcCwJvTpAnzVE/f9aPrxABw7dd5scO9+mL6YDxozCy4uT6+dN2+QiG+mzl2Bm7dCsXj6YP0z+8e+OHXmIuYuWpeIpeKhKUABClCAAklDYNf+Izp479OtJZbPGoINf4xWD8KzYuj4OUnjBFhKClCAAhSggJMJGBbAt3qnFvr1aI3gK9fRvOM3+GvjTkiT+WYdBmL5mm0onD8XZv7wpZNxWBdn1fp/UK1iGV37LmuKF8qDl0oXxqoNO60z8hMFKEABClCAAjEE/lTXUU+P1GhSr7pe55HaHU3r19AP9k+eCYqRnwsoQAEKUIACFIhbwLAm9HLYdxvUQOli+dHj6/Ho3n88Uru74UF4BJo1qomenZpDLuTOmsIehEOa+hXMm92qiPL5wOGTVsv4gQIUoAAFKECBmAKXLl/XTefd3FzNKwvmzaHfX7x8TXdLM6/gGwpQgAIUoAAF4hUwNICXo0uf8TLFC6pB4IJ18J43V1Z8+sHbTh28S7mv3wiRF3h7eepX0y/5HHr3HsIjIuDu5oart8JMq2x6Te/ngWJZfW3Ky0wJKZDK7u/S3tJ5IBxpMhTGw9R+9m7K/AYKuML4795VdRfK4JUJhQOKGXgm3LW9AvKd3Lj9AJFRD23e1DO1K3y8DL902lweZ88o19I03tGvox662PKQXFLovQjcfxCp39vyS/5/yuTLa6ktVgmZJ7P6Tuz9/+lZypchrRsiM5d5lk25jUECqXyz4M7dcISp/4xM/mldeR01Evg59m1vPJRBxUNMzy5g6F3I2QvBqvb9Rxw+dgYSuEvz8/lLN+CtD/piRL9OKFOiwLOX3OAtUz9uHRAVFWV1pIjISD2yvqvLs/U+uKYC/s9fL2y1T35IfIFboQ8ML0QYPBFWtofhx+EB7BS4HWHnBvZnlwCxXLrq+sf+rbmFkQL2BO9GliO57ttdtbyLjHYdNX2Wh+DPkuQ7q5gnvf55lu25jXECCfH/01X5m119qHEnwT07rcDN25H4tMQXTlu+lFqwa7eMv4dOqbZPO+9nu3o+bW8Wy7fuCkT3fuN0bXXdGhUwsGc7VZvtgZfLFkPfoVPQquu36PZRE7RrVtdiK+d5G6CmupEp8EJC71oVKuT2XT0NjsvjAJ5PkKx4+IECFKAABShgFkgf4IcTZy6YP8ubW7fv6M/p0z1qjSYtGtiqwYqIHyhAAQpQgAJPFXi2auSn7u7Jin/2HFZN4h6g9yctMLx/Rx28y9o6Ncpj7oT+yJUtEybNXPJkAyd7JwF6XjVS7t6Dx6xKtjfwmJ4P3mohP1CAAhSgAAUoEEOggBo3RmZvMQXtkmFv4HE1C426xubMGiM/F1CAAhSgAAUoELeAYQF8jmwZMeP/7d1trJZzHAfwX+fUoZSHEvJYeUgPQtlEy2QoKU8Nm9p4EV4hvDKLGW8wNmGWVhhh2MlTKWqe8pRJRqJFKYkUJdRB5b5uKz3czjnZ/8+99bnenPt66Hv996kXfc99Xf//PTfEyOFn7DCCwzsfGE+Ou7lc5nc4WUUHzhs8IIonCR55enosXLws7p1YHwu+/DrOP2tAFY3SUAgQIECAQHUKnDuof3lgY26fEJ9/sSRee3tuPPTkSzHgxN6xb3vzgVTn35pRESBAgEA1C7TYVNqqeYD/59g2bNgYt9z1cEyeNiuKd+Fra2vi0gsHxXVXXhQtSo/X2wgQIECAAIHGBYql5G66c2Jpkqv15QuL+W/G3np1dNjHhK6NyzlLgAABAgR2FMha4DeWfjewcNGyWLRkefxRmrV9+223uro4/ZS+2x+uuv116xti2bcr45DSY//VvPRd1cEZEAECBAgQKAkU/x9YumxFtGvbJtrv3Y4JAQIECBAg8C8FshX4Yr330WPujdff/egfh9a2Tet4b+oD/3jeCQIECBAgQIAAAQIECBAgQOAvgWyz0E+Z8U65vB/X84g4qFPHKPavGTW89Jv3PeOjT7+I+qlvxAVDvEvuHyIBAgQIECBAgAABAgQIEGiOQLYC/96c+VFXWv913B3XxwcfLygX+IH9j48juxwc5w7uH7Pnzo/5C5c0Z4yuIUCAAAECBAgQIECAAAECu7xAtlnoV/24Jg7Yr0O03aN17LPXX++7Fe+RF1urli2j/wm94v25n8Xqn37e5f8SABAgQIAAAQIECBAgQIAAgaYEshX4urpWsfbnX8v371paT71Y83XuJwu3jKeY0KbYVqxcveWYDwQIECBAgAABAgQIECBAgEBlgWyP0HfssHf8uGZtLP9uVXTav0N0P/KweHzyjOhx1GHRsmVtvPrWh+Wl2Drt177yyBwlQIAAAQIECBAgQIAAAQIEtghk+wb+2B6HR1Hi55Tefy+20aUJ7Nata4hrb74/rrpxbKz8YU1cfM7A8pIyW0bjAwECBAgQIECAAAECBAgQIFBRINsycpXuVkxsN+PND8rlvV/fHnHhsFOjpkWLSpc6RoAAAQIECBAgQIAAAQIECGwl8J8W+K3u6yMBAgQIECBAgAABAgQIECCwEwLZHqHfiTG4lAABAgQIECBAgAABAgQIEGhCIOkkdrfd82g8N21WE7f8+/Se7faImU/d/fcBnwgQIECAAAECBAgQIECAAIGKAkkLfEPD7/FraaK6Ytu/Y9Ozy7dpvXvFQTlIgAABAgQIECBAgAABAgQIbCuQtMD37NY5psx8Nxoafouuh3aKy0cMjRP7dN/2jvYIECBAgAABAgQIECBAgACBnRZIPondD6vXxqT6V+KJZ2fGmp8N+g+0AAAGHUlEQVR+iWO6d40rRg6NgScfX173fadH6A8QIECAAAECBAgQIECAAAECkbzAbzZdt74hnnnx9Xjk6emx/LtVcUTng2LUiLNjyGn9orbW3HmbnfwkQIAAAQIECBAgQIAAAQLNEchW4DfffMOGjfHgYy/EfQ9NLh+6YuSwuGbU8M2n/SRAgAABAgQIECBAgAABAgSaIZD0Hfjt7/flV9/E+Ekvlt+LL8717NYlTunXe/vL7BMgQIAAAQIECBAgQIAAAQJNCGQp8PMWLI7xpW/dZ7w5JzZt2hT9+vQoPz5/Ut+eTQzHaQIECBAgQIAAAQIECBAgQKCSQNICP+/zRTF2Qn3Mmv1xecK60wf0iVGXDI1eR3epdG/HCBAgQIAAAQIECBAgQIAAgWYKJH0HfswdE6N+6hvlW59z5snRpbSUXGNbXatWcdnFgxu7xDkCBAgQIECAAAECBAgQIECgJJD0G/itRZ9/+e2tdyt+btumtQJfUcZBAgQIECBAgAABAgQIECCwrUDSb+AXL/02vl+1ets7NLJXU1MTfXsf1cgVThEgQIAAAQIECBAgQIAAAQKFQNICj5QAAQIECBAgQIAAAQIECBDII1CTJ1YqAQIECBAgQIAAAQIECBAgkFJAgU+pKYsAAQIECBAgQIAAAQIECGQSUOAzwYolQIAAAQIECBAgQIAAAQIpBRT4lJqyCBAgQIAAAQIECBAgQIBAJgEFPhOsWAIECBAgQIAAAQIECBAgkFJAgU+pKYsAAQIECBAgQIAAAQIECGQSUOAzwYolQIAAAQIECBAgQIAAAQIpBRT4lJqyCBAgQIAAAQIECBAgQIBAJgEFPhOsWAIECBAgQIAAAQIECBAgkFJAgU+pKYsAAQIECBAgQIAAAQIECGQSUOAzwYolQIAAAQIECBAgQIAAAQIpBRT4lJqyCBAgQIAAAQIECBAgQIBAJgEFPhOsWAIECBAgQIAAAQIECBAgkFJAgU+pKYsAAQIECBAgQIAAAQIECGQSUOAzwYolQIAAAQIECBAgQIAAAQIpBRT4lJqyCBAgQIAAAQIECBAgQIBAJgEFPhOsWAIECBAgQIAAAQIECBAgkFJAgU+pKYsAAQIECBAgQIAAAQIECGQSUOAzwYolQIAAAQIECBAgQIAAAQIpBRT4lJqyCBAgQIAAAQIECBAgQIBAJgEFPhOsWAIECBAgQIAAAQIECBAgkFJAgU+pKYsAAQIECBAgQIAAAQIECGQSUOAzwYolQIAAAQIECBAgQIAAAQIpBRT4lJqyCBAgQIAAAQIECBAgQIBAJgEFPhOsWAIECBAgQIAAAQIECBAgkFJAgU+pKYsAAQIECBAgQIAAAQIECGQSUOAzwYolQIAAAQIECBAgQIAAAQIpBRT4lJqyCBAgQIAAAQIECBAgQIBAJgEFPhOsWAIECBAgQIAAAQIECBAgkFJAgU+pKYsAAQIECBAgQIAAAQIECGQSUOAzwYolQIAAAQIECBAgQIAAAQIpBRT4lJqyCBAgQIAAAQIECBAgQIBAJgEFPhOsWAIECBAgQIAAAQIECBAgkFJAgU+pKYsAAQIECBAgQIAAAQIECGQSUOAzwYolQIAAAQIECBAgQIAAAQIpBRT4lJqyCBAgQIAAAQIECBAgQIBAJgEFPhOsWAIECBAgQIAAAQIECBAgkFJAgU+pKYsAAQIECBAgQIAAAQIECGQSUOAzwYolQIAAAQIECBAgQIAAAQIpBRT4lJqyCBAgQIAAAQIECBAgQIBAJgEFPhOsWAIECBAgQIAAAQIECBAgkFJAgU+pKYsAAQIECBAgQIAAAQIECGQSUOAzwYolQIAAAQIECBAgQIAAAQIpBRT4lJqyCBAgQIAAAQIECBAgQIBAJgEFPhOsWAIECBAgQIAAAQIECBAgkFJAgU+pKYsAAQIECBAgQIAAAQIECGQSUOAzwYolQIAAAQIECBAgQIAAAQIpBRT4lJqyCBAgQIAAAQIECBAgQIBAJgEFPhOsWAIECBAgQIAAAQIECBAgkFJAgU+pKYsAAQIECBAgQIAAAQIECGQSUOAzwYolQIAAAQIECBAgQIAAAQIpBf4EONwdBfM9iSwAAAAASUVORK5CYII=",
+      "text/html": [
+       "<div>                            <div id=\"cc61cbaf-044f-48b0-ac4c-6f42bd67a0ca\" class=\"plotly-graph-div\" style=\"height:600px; width:900px;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"cc61cbaf-044f-48b0-ac4c-6f42bd67a0ca\")) {                    Plotly.newPlot(                        \"cc61cbaf-044f-48b0-ac4c-6f42bd67a0ca\",                        [{\"marker\":{\"color\":\"rgba(31, 119, 180, 0.8)\"},\"name\":\"PyTorch\",\"showlegend\":true,\"x\":[\"PyTorch\"],\"y\":[99.0],\"type\":\"bar\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"marker\":{\"color\":\"rgba(255, 127, 14, 0.8)\"},\"name\":\"tinyRuntime (no quant)\",\"showlegend\":true,\"x\":[\"tinyRuntime (no quant)\"],\"y\":[99.0],\"type\":\"bar\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"marker\":{\"color\":\"rgba(44, 160, 44, 0.8)\"},\"name\":\"tinyRuntime (quant)\",\"showlegend\":true,\"x\":[\"tinyRuntime (quant)\"],\"y\":[99.0],\"type\":\"bar\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"marker\":{\"color\":\"rgba(31, 119, 180, 0.8)\"},\"name\":\"PyTorch\",\"showlegend\":false,\"x\":[\"PyTorch\"],\"y\":[7.563920259475708],\"type\":\"bar\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"marker\":{\"color\":\"rgba(255, 127, 14, 0.8)\"},\"name\":\"tinyRuntime (no quant)\",\"showlegend\":false,\"x\":[\"tinyRuntime (no quant)\"],\"y\":[6.604063987731934],\"type\":\"bar\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"marker\":{\"color\":\"rgba(44, 160, 44, 0.8)\"},\"name\":\"tinyRuntime (quant)\",\"showlegend\":false,\"x\":[\"tinyRuntime (quant)\"],\"y\":[12.067646026611328],\"type\":\"bar\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"marker\":{\"color\":\"rgba(31, 119, 180, 0.8)\"},\"name\":\"PyTorch\",\"showlegend\":false,\"x\":[\"PyTorch\"],\"y\":[462.953125],\"type\":\"bar\",\"xaxis\":\"x3\",\"yaxis\":\"y3\"},{\"marker\":{\"color\":\"rgba(255, 127, 14, 0.8)\"},\"name\":\"tinyRuntime (no quant)\",\"showlegend\":false,\"x\":[\"tinyRuntime (no quant)\"],\"y\":[78.375],\"type\":\"bar\",\"xaxis\":\"x3\",\"yaxis\":\"y3\"},{\"marker\":{\"color\":\"rgba(44, 160, 44, 0.8)\"},\"name\":\"tinyRuntime (quant)\",\"showlegend\":false,\"x\":[\"tinyRuntime (quant)\"],\"y\":[39.828125],\"type\":\"bar\",\"xaxis\":\"x3\",\"yaxis\":\"y3\"},{\"marker\":{\"color\":\"rgba(31, 119, 180, 0.8)\"},\"name\":\"PyTorch\",\"showlegend\":false,\"x\":[\"PyTorch\"],\"y\":[44.93835258483887],\"type\":\"bar\",\"xaxis\":\"x4\",\"yaxis\":\"y4\"},{\"marker\":{\"color\":\"rgba(255, 127, 14, 0.8)\"},\"name\":\"tinyRuntime (no quant)\",\"showlegend\":false,\"x\":[\"tinyRuntime (no quant)\"],\"y\":[44.66026306152344],\"type\":\"bar\",\"xaxis\":\"x4\",\"yaxis\":\"y4\"},{\"marker\":{\"color\":\"rgba(44, 160, 44, 0.8)\"},\"name\":\"tinyRuntime (quant)\",\"showlegend\":false,\"x\":[\"tinyRuntime (quant)\"],\"y\":[11.949405670166016],\"type\":\"bar\",\"xaxis\":\"x4\",\"yaxis\":\"y4\"}],                        {\"template\":{\"data\":{\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"white\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"#C8D4E3\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"white\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"radialaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"yaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"zaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"caxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,0.45],\"showticklabels\":false},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.625,1.0],\"title\":{\"text\":\"Accuracy (%)\"}},\"xaxis2\":{\"anchor\":\"y2\",\"domain\":[0.55,1.0],\"showticklabels\":false},\"yaxis2\":{\"anchor\":\"x2\",\"domain\":[0.625,1.0],\"title\":{\"text\":\"Time (s)\"}},\"xaxis3\":{\"anchor\":\"y3\",\"domain\":[0.0,0.45],\"showticklabels\":false},\"yaxis3\":{\"anchor\":\"x3\",\"domain\":[0.0,0.375],\"title\":{\"text\":\"Max memory usage (MB)\"}},\"xaxis4\":{\"anchor\":\"y4\",\"domain\":[0.55,1.0],\"showticklabels\":false},\"yaxis4\":{\"anchor\":\"x4\",\"domain\":[0.0,0.375],\"title\":{\"text\":\"Model size (MB)\"}},\"annotations\":[{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"Accuracy\",\"x\":0.225,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":1.0,\"yanchor\":\"bottom\",\"yref\":\"paper\"},{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"Time\",\"x\":0.775,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":1.0,\"yanchor\":\"bottom\",\"yref\":\"paper\"},{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"Max memory usage\",\"x\":0.225,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":0.375,\"yanchor\":\"bottom\",\"yref\":\"paper\"},{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"Model size\",\"x\":0.775,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":0.375,\"yanchor\":\"bottom\",\"yref\":\"paper\"}],\"legend\":{\"orientation\":\"h\",\"yanchor\":\"bottom\",\"y\":1.1,\"xanchor\":\"right\",\"x\":1,\"itemclick\":false,\"itemdoubleclick\":false},\"font\":{\"size\":14},\"height\":600,\"width\":900},                        {\"displayModeBar\": false, \"responsive\": true}                    ).then(function(){\n",
+       "                            \n",
+       "var gd = document.getElementById('cc61cbaf-044f-48b0-ac4c-6f42bd67a0ca');\n",
+       "var x = new MutationObserver(function (mutations, observer) {{\n",
+       "        var display = window.getComputedStyle(gd).display;\n",
+       "        if (!display || display === 'none') {{\n",
+       "            console.log([gd, 'removed!']);\n",
+       "            Plotly.purge(gd);\n",
+       "            observer.disconnect();\n",
+       "        }}\n",
+       "}});\n",
+       "\n",
+       "// Listen for the removal of the full notebook cells\n",
+       "var notebookContainer = gd.closest('#notebook-container');\n",
+       "if (notebookContainer) {{\n",
+       "    x.observe(notebookContainer, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "// Listen for the clearing of the current output cell\n",
+       "var outputEl = gd.closest('.output');\n",
+       "if (outputEl) {{\n",
+       "    x.observe(outputEl, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "                        })                };                });            </script>        </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Accuracy (%)</th>\n",
+       "      <th>Time (s)</th>\n",
+       "      <th>Max memory usage (MB)</th>\n",
+       "      <th>Model size (MB)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>PyTorch</th>\n",
+       "      <td>99.0</td>\n",
+       "      <td>7.563920</td>\n",
+       "      <td>462.953125</td>\n",
+       "      <td>44.938353</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>tinyRuntime (no quant)</th>\n",
+       "      <td>99.0</td>\n",
+       "      <td>6.604064</td>\n",
+       "      <td>78.375000</td>\n",
+       "      <td>44.660263</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>tinyRuntime (quant)</th>\n",
+       "      <td>99.0</td>\n",
+       "      <td>12.067646</td>\n",
+       "      <td>39.828125</td>\n",
+       "      <td>11.949406</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                        Accuracy (%)   Time (s)  Max memory usage (MB)  \\\n",
+       "PyTorch                         99.0   7.563920             462.953125   \n",
+       "tinyRuntime (no quant)          99.0   6.604064              78.375000   \n",
+       "tinyRuntime (quant)             99.0  12.067646              39.828125   \n",
+       "\n",
+       "                        Model size (MB)  \n",
+       "PyTorch                       44.938353  \n",
+       "tinyRuntime (no quant)        44.660263  \n",
+       "tinyRuntime (quant)           11.949406  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#| label: fig-arm\n",
+    "#| fig-cap: \"Performance comparison on ARM\"\n",
+    "\n",
+    "df_arm = df[df[\"Architecture\"] == \"arm64\"]\n",
+    "plot_perf_comp(df_arm, \"plotly_white\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64f97742-2a0c-40c2-905f-b3d832b60f84",
+   "metadata": {},
+   "source": [
+    "# Runtime Optimization Progress"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "7a5e7a24-b02a-41ed-af98-f14b3193cac2",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "displayModeBar": false,
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "color": "blue"
+         },
+         "mode": "lines+markers",
+         "name": "PyTorch",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:04:12"
+         ],
+         "xaxis": "x",
+         "y": [
+          11.44523000717163,
+          11.552532196044922
+         ],
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "green"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (no quant)",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:04:12"
+         ],
+         "xaxis": "x",
+         "y": [
+          10.546698331832886,
+          10.451820135116575
+         ],
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "orange"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (quant)",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:04:12"
+         ],
+         "xaxis": "x",
+         "y": [
+          71.7505316734314,
+          72.08225703239441
+         ],
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "blue"
+         },
+         "mode": "lines+markers",
+         "name": "PyTorch",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:03:05"
+         ],
+         "xaxis": "x2",
+         "y": [
+          7.714339017868042,
+          7.563920259475708
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "line": {
+          "color": "green"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (no quant)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:03:05"
+         ],
+         "xaxis": "x2",
+         "y": [
+          7.511744976043701,
+          6.604063987731934
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "line": {
+          "color": "orange"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (quant)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:03:05"
+         ],
+         "xaxis": "x2",
+         "y": [
+          12.869556903839111,
+          12.067646026611328
+         ],
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "x86",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "ARM",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 0.425,
+          "yanchor": "bottom",
+          "yref": "paper"
+         }
+        ],
+        "font": {
+         "size": 14
+        },
+        "height": 800,
+        "legend": {
+         "itemclick": false,
+         "itemdoubleclick": false,
+         "orientation": "h",
+         "x": 0.5,
+         "xanchor": "center",
+         "y": -0.2,
+         "yanchor": "bottom"
+        },
+        "margin": {
+         "b": 50,
+         "t": 100
+        },
+        "showlegend": true,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Execution Time History"
+        },
+        "width": 1000,
+        "xaxis": {
+         "anchor": "y",
+         "autorange": true,
+         "domain": [
+          0,
+          1
+         ],
+         "matches": "x2",
+         "range": [
+          "2024-07-18 11:01:03.9559",
+          "2024-07-19 05:03:08.0441"
+         ],
+         "showticklabels": false,
+         "type": "date"
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "autorange": true,
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          "2024-07-18 11:01:03.9559",
+          "2024-07-19 05:03:08.0441"
+         ],
+         "title": {
+          "text": "Datetime"
+         },
+         "type": "date"
+        },
+        "yaxis": {
+         "anchor": "x",
+         "autorange": true,
+         "domain": [
+          0.575,
+          1
+         ],
+         "range": [
+          5.814742831096114,
+          76.71933433641487
+         ],
+         "title": {
+          "text": "Time (s)"
+         },
+         "type": "linear"
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "autorange": true,
+         "domain": [
+          0,
+          0.425
+         ],
+         "range": [
+          6.132647972164715,
+          13.34097291940633
+         ],
+         "title": {
+          "text": "Time (s)"
+         },
+         "type": "linear"
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA/AAAAMgCAYAAACEYYkhAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAD8KADAAQAAAABAAADIAAAAAAwD/peAABAAElEQVR4AezdB2AUVf7A8V86CSShIx0EwYq9YO+9n57tzoKnZ/3b21mxnb2LvVcUTmwIir2ABUQQEVAERHoJCQSSTTb/93vZGXY3m0a2ZDLfuUtm5r03b9583rDmtzPzJq3KTMKEAAIIIIAAAggggAACCCCAAALNWiC9WbeOxiGAAAIIIIAAAggggAACCCCAgBUggOdEQAABBBBAAAEEEEAAAQQQQMADAgTwHugkmogAAggggAACCCCAAAIIIIAAATznAAIIIIAAAggggAACCCCAAAIeECCA90An0UQEEEAAAQQQQAABBBBAAAEECOA5BxBAAAEEEEAAAQQQQAABBBDwgAABvAc6iSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICABwQI4D3QSTQRAQQQQAABBBBAAAEEEEAAAQJ4zgEEEEAAAQQQQAABBBBAAAEEPCBAAO+BTqKJCCCAAAIIIIAAAggggAACCBDAcw4ggAACCCCAAAIIIIAAAggg4AEBAngPdBJNRAABBBBAAAEEEEAAAQQQQIAAnnMAAQQQQAABBBBAAAEEEEAAAQ8IEMB7oJNoIgIIIIAAAggggAACCCCAAAIE8JwDCCCAAAIIIIAAAggggAACCHhAgADeA51EExFAAAEEEEAAAQQQQAABBBAggOccQAABBBBAAAEEEEAAAQQQQMADAgTwHugkmogAAggggAACCCCAAAIIIIAAATznAAIIIIAAAggggAACCCCAAAIeECCA90An0UQEEEAAAQQQQAABBBBAAAEECOA5BxBAAAEEEEAAAQQQQAABBBDwgAABvAc6iSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICABwQI4D3QSTQRAQQQQAABBBBAAAEEEEAAAQJ4zgEEEEAAAQQQQAABBBBAAAEEPCBAAO+BTqKJCCCAAAIIIIAAAggggAACCBDAcw4ggAACCCCAAAIIIIAAAggg4AEBAngPdBJNRAABBBBAAAEEEEAAAQQQQIAAnnMAAQQQQAABBBBAAAEEEEAAAQ8IEMB7oJNoIgIIIIAAAggggAACCCCAAAIE8JwDCCCAAAIIIIAAAggggAACCHhAgADeA51EExFAAAEEEEAAAQQQQAABBBAggOccQAABBBBAAAEEEEAAAQQQQMADApkeaGODm7hw8XK5/JbH6i2/+45bybmnHVVvueZeYNqMP2RV8RrZfGAfaVvQpkZzTzr3ZllRVCKXnH28HLzPTjXyk5nw9Kvvy6ff/NjgXbbObSVP3n25jP54gjz49Ejp2KFQXnnkugZvn6qCzjmYJmny8iPX1tqMMy65U8oDAfnvNWdJr+5dbLmmHmt950OtjSEDAQQQQAABBBBAAAEEPCHQogL4tevKZPLPv9UL361Lx3rLeKHA7Q+/Yo/30f9eLHsP3qZGk/9atEyWryyW1WvW1shLdsLc+Ysb1DdOu9q0zrWLJabt8xcutcGuk9ec5w09B3+cOksCFRWypnSdezhNPdb6zgd3RywggAACCCCAAAIIIICAJwVaVAAf3gNvPXOLSFpaeJK7XFjQ2l1uyQsP3HyBCXwrpF/vbik/zAuHHCv/PO7AiHa8P2686JX5LQb0kVuv/ldEXmZG9dMd++y6rfTu0UVysrMi8lviip+OtSX2H8eEAAIIIIAAAggggECiBVpsAD+gX8967VaXrpWV5hZznbpv1FHS0yOHBAhWVclf5uqvTp06tJVWOdl2WX+tKyuXGb//KbNmz5fcVtnSv293Gdivl5sfvVBRUSl//LlQfpvzl2RlZErvnl2kf5/u5juG6i8Z9NbrispK0bsDMkLBq1NHUfFqKVldKu0K88W5Mj1/wVJZt67cFlmydKX8uWCJU1x6dO1k6+3RtbOUlZdLQX7NLyz02GbPXSC//jZPAibI17YP2LiHZGZmuPXoQpk5ziXLi+yxq4Hekj/119mi7e3bs6vssPXAGu2NqCC00rljW9Gf8Glip/Z2tbW52q77jjXply3aNznZ6+213OJlK6W8PCBdTB3pxlCP45eZc6Rn986y7ZabuH2lV7ln/PanTJ81V9oWtpFttuhv+zLWvjRN71qY8fs8WbKsyN7avvmA3jEfT6ht+6ak13asWmdlZdAc41yZ+9cSs1x9ngw053hjzgenbatK1liPP+YtNLadZLNNesU0ie573V49F5vzTS2LVq2WKnMede7YLuYXLHo3wrIVqyTbfPnSxZRhQgABBBBAAAEEEEAAgaYJtNgAviEselv3P86/1V6lPvPkw+RS86x4+PTEi+/II8+9ZQPnEU8NlY06Vwecn379o9xwz3OywtyeHj7tuuOWcttV/6oRqH757RS58e7nbNAZXr5Ht05y/cWnyu47bSWnXHCbCYxWiN45EP3lw/1Pvikj3vvctk/bqcH3QSdf4VY19L4X3GVd+PKth6R9uwK58LoH5edf/zDPkl8mu5nn/p1Jg+8rb31CJk2d6STZ+cbmSv29N5wbsf+vf/hZLrz2IXuVfOftNpMX3hxrg0lnwy037SuP/fcSuz8nLZ7zbydNl3Ovvk+23ryfvDrserfq866+3wbt551+tOiVfO1LZ8pvk2efP9cg/Ia7n7VfNjh5rfNayT03nCd77jLISbJz/YLkZuM4+pNvI9Lb5OXKVRecJMceumdEeiJWajvWCZN+kZvueT7iSxrdf3ZWpvz9yH1M+05u0Pmg27w26mO5e9jr5oudgK7aSb8AOfsfR4hahn955PT99oMGyHXmPL3jkVdEb/3Xuzp23WEL6/rHn4vsGAv/Mudl9PTAUyPk5ZEfyQF7bi8P3HxhdDbrCCCAAAIIIIAAAggg0EiBFhvA61XG2DfQm8DHXBHUq+l66/Y1F54iGgA/+9po2dFcTd5j5+rA7rsfp8uw50fZq/L33XSeG7yP/ex7ufSmR236CSZ42sIEsBrUfPj59/LN9z/Lf/77lDx97/rg+oNPv5XLh1YPrLfdVgNkx20Gmqv+q+X7ydPNFflFNsDWAL4xkx7XUQftJp+P/0n06ry2u2uXDm4VrVrluMvRC3pV9BTzpYVewdbB0w7bfxfJysyUcV/+YK5gz5WTzrtFRr98h72yHb7tNHN1W390P9ub49A7ED4xX2ToFwSPvjDKfhERXj5Zy9pHenu9BpSdOrST8RN/tlfPdQC/0rVlNsjVLx66du5g8n6xX5LcfP8LMuaVu9y7DfTq9qkX/Vdmmjsq+vXpJn87bC+pClbJ+x+PtybX3/Ws9Om5kWj/NWaq6xwMVgUbVNWiJSvkousftuMY6J0Fg81xBk179Y6Cr76fKj/98rs9zxtyPrw04kMThL9q7844fP/BoncX6Bcf/xv9pTz+0juid6Tov4foaer02XL82TeK3kWid2jkhs6vE4/eT/5rxmF4451PZchJh9o7IZxt9TwbNeYru3ryMfs7ycwRQAABBBBAAAEEEECgCQItNoDf9Yjza2U5dL9d5O7rz7H5egXzx59nyTsffiPX3P6UjHzmZnOLe4a9Qq1Xuq8870TZadvNbFkNSu589DW7fOtVQ0wQvbtd/pu5OqtX7/c+7mITJE6z9WmwpQHRnY9Ul9crlDoavDNp3SPe/Uxywm7Ld/Lqm+tt97eb0ctPueBWOzDc6SceEnMQu1j1PPf6BzZ419v3Xxl2negVZp2GnHSI6FXtb36YJnrl9L//OTtic71yfdk5J8jxR+ztBmovmoDwThMQfvr15JQF8LuZux6GXn6G+wWGDnh38MlX2uBd++2WK4aI3umgk35pccAJl9krx7P+mG9uHe9t0/WqtAbvGqSPfNr0v/lCQ6fTTzhYbn/oZXnlf+PMlzlvR3wxYwvU86uuc7CeTd1svXtDByHUY3j+gavdLx20gD428dW3U21AXt/5UGy+0HrsxbdtvUOvOEP0nHUmfUOBjoqvDieZoFwdwie94q6PHlx81nGytZnrlX/9ciQYDNpzRR87+GLCTxHn4Lvm35O2e5O+Pdx/P+F1sowAAggggAACCCCAAAKNF4h86Lvx2zfbLfRKcW0/Hczt5eHTjZedbp/BXrmqxF4tv+zmx2Spee5br1KedvxBbtHvJv9qr+BqvYfvv6ubrgt6y/qOW29q02aa5+J10qv4Wo8++33+GcfYNOeX3rasXx7oldNkTh998YPdnd6K7wTvmqBB6/mnV7fxoy8m1mjSpv17id5xoO12pv332N4uLjWBsV6dTcV05kmHucG77l+f/+9jBr3TaYj5YsMJ3nVdn8MesHFPXZSFS5bbuf7SL290OuOEQ9zg3SaYX87r92bO/tNJavC8tvNP0xs6ZZlgWac1a9bZcyl8u57dOstJx+wXnlTr8nc//mpfOah3XRxzyB4R5fSLDr2DQe9E0Lsqoie9Uv+SeSXejttsaoN3zc/LzbHP3x95YPW/g9dHfRKx2WtvV6+fcuz+EemsIIAAAggggAACCCCAwIYLVEcHG759s91y3PB7G9w2vZ1en9H9+9k3uc+Fa8B6s7lSGT7NMYN+6bTY3Na8398vDc+yy/oFgE7OwHd/zFtk1wdt1s8NfGxCin7pgGPzzCBoOm05sI+dh//S98nr1X2900CfH48edC68rC63MwOZ6aR3E+jgZtED4NnMFPzSZ+B1qjRXiKMnJy/8GfA5ZnBBne594g075kH4Nk4d+jo+HdStMXdM1HUObrP/v6xZ+L5iLe+727bWVc+tA0+6QnY2wbaOB7DdoE1M0L2l7a9Y20Wnzf1rsU3SYDz8Sxin3BYD+9q7L+bOrz5nnXSd6y3zsbbRPL2Nfri5hf7r76aKDqyoX5hMnDLT3tGggyceEQrwtSwTAggggAACCCCAAAIINE2gxQbwjWXRV5UddfBu9nZp3VavbEYHa4vM6Ns6tWubX+er2fTKqE5LzJVpndq3jbzibxNT8EvfOa7PruvUtqA6+A5vht4areMDaKC6clVxvQF8cwnYw49BlzPMIxC1Tc7r6Zx8fczBeRe7PlagBjWmvqGUsLsPapRJUIIGwQ/fepHcNew10VHj9REN/dFJHwH4z/+d0qBn85eZO0F0itXvmp5v3gSgk/NWBrvSgF/69gB9E8EPP80wgfwn9jGL19762G557KF7uG8DaEBVFEEAAQQQQAABBBBAAIF6BGJEK/Vs0UKzp5iBut545zP36O59/A3ZZbvN7S3ZTqJz67NeAX34touc5Frn3czrz3RauqI6eKq1YFiGXslu9FTVsC30lWN627wGrfp6L73tP3zSK+8avOukA8L5YVIPddHnta+96B+id140t0lHzNef3+csMIPW/WaDZR1MUQeyu+3Bl+1z+xFtjnE+OG9Q0H6PNa00r4TTqVPUq/5ilY1O0+fmNYDXwfD0ivxHZkBEvWKv6UwIIIAAAggggAACCCAQP4EW+wx8Y4j03eYX3/CIvaX58nNPsFcUddCvS258JOJ1W/16d7XVTjKjzuvo7/VN+p50nfSWYg2a65r0mWKdlkW9mq6ubXSwPZ3WlpXVVSwir1eP6rsDvjXP50dP+oy/ThrQtjd3Gfhl6mden6fTx19NataHrCPk6+vsdMC6Uc/datv662/zRAfu06mu86F3j+qB6SZP+82+Bs5uEPbL6XunXFhWvYs6FkKnDm3tv4l/X3GPHQ9hz8FbR3z5VW8lFEAAAQQQQAABBBBAAIF6BXwfwOtI2pffPMwOTrf3rtvYgczuMiPUtyvMt68Qu+2Bl1zEHcwgdTpCtwbvV5n3qGvgHz7pe9yvveNp+Wz8ZJustxbrlU/9MuDW+1+KCJz0SvdjL7xt36uuhXuGRkp/a/QX9plyTdOr8c8N/0BGfzxBV2tMzh0BX06YWiOvtgRnALNnXx8d8V5xfcb6wadG2s2OjRrkrLa6Wkr6cYfvZQ/lyZfflXFRA/jpuAHqf/END6fkcPUc0Ve/OeMrOI1YZM41nfQxBmegu7rOh8Hbb25fDahX4B957i2nGjsf8f7nMm3GH/ZZ94P33ikiryEr2gZ9O4FO+mpEnU459gA75xcCCCCAAAIIIIAAAgjET6DF3kK/4yH/rlXpkH12lpuvHGLz9ZVp306abgNtvbKpk45Wfts1/5Lzr3lARpqAepst+9srn/q+cX1l2b8uu1u+MoN2HWJeV6Z5esV6hrkSqu/U1gHdnHfJ61X16y76p1x43UPy7kffyA9TZsigzTaWgHktl44KrlflLxxyrN3nEQfsal7FNUV0BPjD/nG1uaJZaL9A0Nvaa5v0/fE6gvrbY78SHYhNn2/WK7L6Kjz9AiLWdMKR+8qb5vV1OlL+cWfdaG7N3lr0uXB9R7qOmN+xfaGce9pRsTZtsWl6VfvDz38QfWXbRSZQH9Cvp+jz8Brs/jJzjr29fuPQVfpkI5SuXSf6/nbtsy3MIIPajgXmtW0/TfvdNuWsUw6356uu1Hc+6N0lV97yuDzz6vv2DQkDzXHqwHMTJv1i6/r3P4+od9wDWzDGr+MP31ueMO+S15Hs+/bqKvqFARMCCCCAAAIIIIAAAgjEV6BFBfA6groz6Xuqa5ucEcg1YH7mtdFm0LN0ufeG86TQDBjmTHuZwPa0vx8kzw8fI7eaq/D6XncNTPSqut6+rFdFdTAxDeSdSQP5/Xbf3ozw7ox6JrKPGUX8ZfMKrtsefMk8szzPvoNcy6enp4vuYw/zbLNOh+y7sw3YX3hjjBkpfrH90UH0zjv9aBuwjRrzlaSZbcInfZ/91F//kFdGfmSeja4O6LReZ3JGDk9LW5+mx/ryI9fJLfe/KO+PGx9xdV/fqX7b1f8SHTjNmdJD2zp1Oek6T9P/GXO9Sh1uH16mzuVQd4V1W43i6enVhdJCc6eAk+7MnXSdO21x5rHynONy8ob992J53bz67PEX37EjqOt74Z1piwF9xLlK76TVNnf26cxrK+e025lrOWc5/Fj3GryNPW++NUG2PoqhPzrpyPD6mjwNup2pvvPhUHOOFZgR+q+/6xmZasZ80B+d9Ly95sJT5OiDd3eqsnPHKFbfRxQ0K/rGAh28cY65An/KMfu7fRBdjnUEEEAAAQQQQAABBBDYcIE0E3zFGPJqwyv005Z6tfHPBUukyAwA1rVLezMAWLtaX7elLvqlwp8LFtvgXYMdfX1d9KS35eto43r1fpO+PRr0aja9Sv+XuSqrgVZ3M3Be9Oj50ftw1nVEer0SHzTH0b9vdxvIOXl+nusjEvq6Pe0ffa+8Mz5BKk3KzV0beuVd7wrQuyR0gMSYI+abRjbkfFiweLn8aY6xS6d20su8gaEhQXpdxz9p6kz554W320ESPx35QLMwq6u95CGAAAIIIIAAAggg4EUBAngv9hptRqCZCVx0/cMy7suJ8s/jDpSrLzi5mbWO5iCAAAIIIIAAAggg0DIE1t9b3TKOh6NAAIEkC+hdKJ+YEfz1sQFeHZdkfHaHAAIIIIAAAggg4CsBAnhfdTcHi0D8BV5962M7eKMOotfb3I7PhAACCCCAAAIIIIAAAokR4Bb6xLhSKwK+EdBXMQaDVXYQvvBBFH0DwIEigAACCCCAAAIIIJAkAQL4JEGzGwQQQAABBBBAAAEEEEAAAQSaIsAt9E3RY1sEEEAAAQQQQAABBBBAAAEEkiRAAJ8kaHaDAAIIIIAAAggggAACCCCAQFMECOCbose2CCCAAAIIIIAAAggggAACCCRJgAA+SdDsBgEEEEAAAQQQQAABBBBAAIGmCBDAN0WPbRFAAAEEEEAAAQQQQAABBBBIkgABfJKg2Q0CCCCAAAIIIIAAAggggAACTREggG+KHtsigAACCCCAAAIIIIAAAgggkCQBAvgkQbMbBBBAAAEEEEAAAQQQQAABBJoiQADfFD22RQABBBBAAAEEEEAAAQQQQCBJAgTwSYJmNwgggAACCCCAAAIIIIAAAgg0RYAAvil6bIsAAggggAACCCCAAAIIIIBAkgQI4JMEzW4QQAABBBBAAAEEEEAAAQQQaIoAAXxT9NgWAQQQQAABBBBAAAEEEEAAgSQJEMAnCZrdIIAAAggggAACCCCAAAIIINAUAQL4puixLQIIIIAAAggggAACCCCAAAJJEiCATxI0u0EAAQQQQAABBBBAAAEEEECgKQIE8E3RY1sEEEAAAQQQQAABBBBAAAEEkiRAAJ8kaHaDAAIIIIAAAggggAACCCCAQFMECOCbose2CCCAAAIIIIAAAggggAACCCRJgAA+SdDsBgEEEEAAAQQQQAABBBBAAIGmCBDAN0WPbRFAAAEEEEAAAQQQQAABBBBIkgABfJKg2Q0CCCCAAAIIIIAAAggggAACTREggG+KHtsigAACCCCAAAIIIIAAAgggkCQBAvgkQbMbBBBAAAEEEEAAAQQQQAABBJoiQADfFD22RQABBBBAAAEEEEAAAQQQQCBJAgTwSYJmNwgggAACCCCAAAIIIIAAAgg0RYAAvil6bIsAAggggAACCCCAAAIIIIBAkgQI4JMEzW4QQAABBBBIhkBVVZWsXrO2UbsKVFQ0qjyFEUAAAQQQQCA1Apmp2S17RQABBBBAAIF4Csydv1jufux1Gf/DNFlXVi55uTmy1y7byGXn/F26dukQsavKyqA889r7MmHSL/LLzLlSsrpUTvv7wXLleSdGlGMFAQQQQAABBJqXAAF88+oPWoMAAggggECjBYLmqvslNz4qfy5YLCcfs58M7N9Lvv/xVxk5+guZMftPGfn0zZKdVf2f/BUri+XiGx+RiVNmyqam3OEHDJaqYJW0K2zT6P2yAQIIIIAAAggkV4AAPrne7A0BBBBAAIG4C7w/brzM+H2enHHCIeaK+wm2/sP3HyxLlq+ULyZMkV9mzJFttuxv0x98eqQN3s859Ui54IxjJC0tLe7toUIEEEAAAQQQSIwAz8AnxpVaEUAAAQQQaLLAJ19PklP/73a589HXIupaurxIzrz0LnslPRgMyurV1c+8d2hfEFFu0/697XqVVNn5kmVF8vbYr2Xn7TaTC4ccS/AeocUKAggggAACzV+AAL759xEtRAABBBDwqcDeg7cxt75nyYtvjpU33vnUKujz65cNHSY/TJkhpx53oKSnp8ueg7eWrMxMefiZ/8lLIz6UMvMM/MpVJfLh59/LRp3by9ZbVF99/+ybH0UHrNOr8+O+nCjPvv6BvGDqnjbjD58Kc9gIIIAAAgh4SyDNjFZb/bW8t9pNaxFAAAEEEPCFQFHxajn+rBtl2YpV8sqj18sHn0ywgfdNl50uxx+xt2swZfpsGXLJnbJ2XZm0aZ1rf/JyW8mTd13mDmJ3/5NvytOvvm+vvOt//jMy0kW/ENDpuMP3kqGXn+HWxwICCCCAAAIIND8BrsA3vz6hRQgggAACCLgCbQvayAO3XGiD7rMuv1ueGz5GTjx634jgXUedf3nkR6aMyNUXnCx77jxIdLC6eX8tlrc//Fp0kDudFixebueXm+fkvxz1sEz5+FkZ8+pdstVmG8uI9z6Xdz78xubzCwEEEEAAAQSapwABfPPsF1qFAAIIIICAK7DFgD4y5KRDRa/Ga0CvQXr4pMG3DmR3y5Vnyj/NbfV333CuvP38bTKwXy97W/2Eib/Y4rk52XZ+wF47SPu2+Xa5Z7fOcv0lp9rlHyb/auf8QgABBBBAAIHmKUAA3zz7hVYhgAACCCDgCujt8yPf/9w+767Ptj/z6mg3Txc+/fpHu77L9pu76b26d5Hzzzjaruuz7zr16tHFzucvWGrnzi99fl4n/YKACQEEEEAAAQSarwABfPPtG1qGAAIIIICAVFRU2ne8rypeI68Nu1623LSvPPrcW/LVd1NdncKC1nb58/E/uWm6MGv2fLveOi/XznVbnd4e+5WdO78++WqSXdT3wjMhgAACCCCAQPMVyLjJTM23ebQMAQQQQAABfwvc/vAr8tHnP8j1F58q++y2rQzefgsZNeYr+eiLiXLwPjtJQX5r0QD9/XETZOr03+2gdDnZmTL642/N8/IfSEZ6htxw6alSaG6979G1k/z862wzOv0PdpT6YLDKjlo//J1PJL9Nntx21ZmSm5vjb3COHgEEEEAAgWYswCj0zbhzaBoCCCCAgL8F9Ln2K299Qg7dbxe5+/pzXIxxJni/6IaHRa+Yv/nkTfbW+nc/+kbueWy4Ha3eKbjZJr1N8H6aDDKD1DnTcjO43U33PCefhG6713S9Mq/Pzw/YuIdTjDkCCCCAAAIINEMBAvhm2Ck0CQEEEEAAgQ0R0FfCzV+41Abx3TfqKF06tbOj18eqa1XJGpk3f7F9T3ynDm1jFSENAQQQQAABBJqZAAF8M+sQmoMAAggggAACCCCAAAIIIIBALAEGsYulQhoCCCCAAAIIIIAAAggggAACzUyAAL6ZdQjNQQABBBBAAAEEEEAAAQQQQCCWAAF8LJUWnlYWCEpJaUULP8rmd3jlFUEpLg00v4a18BYFjPuqNbgnu5srKqukaHV5snfr+/1VmlHlV5bgnuwTIVhVJSuKcU+2u2GX5cVlyd4t+zMCy1bhnooTQc93Pe+Z/C1AAO/v/ufoEUAAAQQQQAABBBBAAAEEPCJAAO+RjqKZCCCAAAIIIIAAAggggAAC/hYggPd3/3P0CCCAAAIIIIAAAggggAACHhEggPdIR9FMBBBAAAEEEEAAAQQQQAABfwsQwPu7/zl6BBBAAAEEEEAAAQQQQAABjwgQwHuko2gmAggggAACCCCAAAIIIICAvwUI4P3d/xw9AggggAACCCCAAAIIIICARwQI4D3SUTQTAQQQQAABBBBAAAEEEEDA3wIE8P7uf44eAQQQQAABBBBAAAEEEEDAIwIE8B7pKJqJAAIIIIAAAggggAACCCDgbwECeH/3P0ePAAIIIIAAAggggAACCCDgEQECeI90FM1EAAEEEEAAAQQQQAABBKxAVSUQPhUggPdpx3PYCCCAAAIIIIAAAggg4DGBsuUiU24QGdVTZMwOIr8/aw6gymMHQXObIpDZlI3Z1oMCSz6XrBnDJHPNPJGB54j0OkEko5UHD4QmI4AAAggggAACCCAQL4GwILjKWXbmuo+w5bry3bzwbULb2llYPW6dsfKjypnVtECZpM0YKjLrseqDXrtQ5NszRdr0Eemyb3Uav1u8AAF8i+/isANcMVFk3N7i3nYxfoLI6jkiW90YVsgri84HXdSHm9t8k26zYuWH0urKdzdzFpy57sAs29WoNGff7gd3VH5FUNLKze1OGc4/u6h8W3WMNOfD3WbVku8mOwvOPLy9oWXbzrB8t7315YdtE7NNUfl2NSotfN915bubOQvO3FTQyPamVQYlQ93XGfeIfYbVqRkReeEWoeVa851tY2yjSTq5bbaVVKe5hjHS3Dy7cah8+HJoGztztnfmoXLuqrPgzE1+Xe2xmztlnXnYvt1tw9J0McowLVgl2eUVIq30fA/VY2dOnc48tK07c9KdeSjDXXUWnLlW7yw7c7ey0K6ddGcenh8jTbOjjscmOcfh5oXK2cyoetxVZ8GZa9XOsjMPq8cmOenOPDw/Rpqzf5OVbupuFTDne3aG7sjmVGc7y85cU8OW62xTWDl3m1CanTU0P6qcu+osOHNtmrPszJva3tD2trpYdYbSIvKjyrmr7oJrmGba2yYQFMnS/8I6+c5ck8KWo/NtlpPvzEPtdWdOujMPZdjVqDTN0n24ye5CdXqt+VHl3FVnwZmH1x+VZuvW3Tjpzjy0jTtz0p25mxG2bViaLrrHtH6bNJNWaD7jJSOt7uN12xNe5/p61rc3Rr4t5pR15mHlYtYdyo/YNmwb91jC08KXzYburpwFZ27KxdxnKN/Owsq6FcXKjyrnrjoLzjx8n9VpHbQNht2d3DaFbePs283T0lH5djUqzVYaSqsr393MWXDmuhtn2ZlH7Ttmvt1xs/7VvrbWaUBPAF+bTotLdyKJFndgHFAMgVnDaib+fLPIjAeq0+1nXKwPulBaRH5UOXfVWXDmpuqYH5JOvpk7i+sXdKNQm9zM9WnVOZ77nW1arD9MyRXQD7k2yd0lezMCGj7mIZF0Af17Ojfpe2WH6s7ne2rOA/6QTY17eOyemhYkYq9hR5XmLDtz3V9o2c6cdGcenh8jLea2YdtovruZs+DMQ+XMqv5JnVZRbBbMF1fhU1ZB+BrLLVyAz70W3sERhxcw/+CjJ/0AKC+KTvXAeuhDzf2A1SZHfdDZpBhpTjmb5eQ781A97qqz4MzD86PSNEsnt0018/XriLQ68tdvayvSX2YK1WNnNeu0+W6ys+DMQ9u7q86CM9fqw5adfTlzm+XkO/Pa2hSVH7Ft2DZ20SnrzMPzTZqb7Cw4c1OurvbGqFv/Y2cuBktGulOvU5czD+3brkalaZZO7j5j5Zs0N9ld0I3spuu3tRVVp9nfznYxtnG3jbGNs62b5WzvzN2MUBOcdGceyrerUWlO3W6yu2BynGUzdxbdBTfB5FUvq3ug0lyFz9QrkqF8O3PKOvNQe9xZjHTd3k12Fpx5aEO7GpWmWTrV1X9uni1oi1f/CtUVM9/Jq2WbBrc3fPuwtrv7DEtzANy88G3XL+tnTFl5UFrl6FcoUdvb1ag03VQnt95Y+SbNTXYXdCO76fptbUXVaW5eeFr4srNtjDRbg8m3RULlnDQ7N79S0V63Ke6CNsS2SN1L11VK61z9s8rJd+ZaxCzb1ag0zdKpruNx82xBW7z6V6iumPlOXi3buO0Jz49qm7vqLDhzs427z7A057jdvPC6w5btJs52zjyUH5EXto0uum1ev01VVZoUlwaksLX5+sRNdheqt7Gbxkhbv0HY8YT2ozMn327qbO/MQ/nuqrPgzMPzo9I0yz2W0LJNC1uOaRhWT135tlhYWec4nHlEflQ5d9VZcObaZGe5er68uFw6FOS4LY/Or84IbeNuG3aMtoDJt0VC5Zy08HlEflQ5d9VZcOah/djVqDRbt/nltik838lsvvMVxWXSYc4dIj/fFNnITc6LXGetRQsQwLfo7o06uE3OFZk3IjJR07a+vTqt1g86k+F+vjkLzlw3rSc/5odkaHs3L1RPdUuq67RJUftx8723UG5uoV9nbuUuyMvyXuM93OIK415aVmn+wMM9md1YaYL30rUByW7DdclkugfNt1Vr1wSkVT7uyXSvMt9YlZUEpHUB7sl015v1KkrKRMIDyaQ2wL87q8o27jlhAbx/KZJ+5FWbXyVp+X3Mc/BPmFvdeokMMH/Lt98+6e1gh6kTIIBPnX3y99xlH5Gdn5GqmY+KrF0gaf3PMgPZXWTu+2ub/LawRwQQQAABBBBAAAEEEGicgA4+3fe06p/GbUnpFiJAAN9COrJhh2GuZvcbIuW9Tpfy8oDkt+ab04a5UQoBBBBAAAEEEEAAAQQQSL2AOyB56ptCC5IqkKbPRzIhgAACCCCAAAIIIIAAAgh4RYAA3is9RTsRQAABBBBAAAEEEEAAAQR8LUAA7+vu5+ARQAABBBBAAAEEEEAAAQS8IkAA75Weop0IIIAAAggggAACCCCAAAK+FiCA93X3c/AIIIAAAggggAACCCCAAAJeESCA90pP0U4EEEAAAQQQQAABBBBAAAFfCxDA+7r7OXgEEEAAAQQQQAABBBBAAAGvCBDAe6WnaCcCCCCAAAIIIIAAAggggICvBQjgfd39HDwCCCCAAAIIIIAAAggggIBXBAjgvdJTtBMBBBBAAAEEEEAAAQQQQMDXAgTwvu5+Dh4BBBBAAAEEEEAAAQQQQMArAgTwXukp2okAAggggAACCCCAAAIIIOBrAQJ4X3c/B48AAggggAACCCCAAAIIIOAVAQJ4r/QU7UQAAQQQQAABBBBAAAEEEPC1AAG8r7ufg0cAAQQQQAABBBBAAAEEEPCKAAG8V3qKdiKAAAIIIIAAAggggAACCPhagADe193PwSOAAAIIIIAAAggggAACCHhFgADeKz1FOxFAAAEEEEAAAQQQQAABBHwtQADv6+7n4BFAAAEEEEAAAQQQQAABBLwiQADvlZ6inQgggAACCCCAAAIIIIAAAr4WIID3dfdz8AgggAACCCCAAAIIIIAAAl4RIID3Sk/RTgQQQAABBBBAAAEEEEAAAV8LEMD7uvs5eAQQQAABBBBAAAEEEEAAAa8IEMB7padoJwIIIIAAAggggAACCCCAgK8FCOB93f0cPAIIIIAAAggggAACCCCAgFcECOC90lO0EwEEEEAAAQQQQAABBBBAwNcCBPC+7n4OHgEEEEAAAQQQQAABBBBAwCsCBPBe6SnaiQACCCCAAAIIIIAAAggg4GsBAnhfdz8HjwACCCCAAAIIIIAAAggg4BUBAniv9BTtRAABBBBAAAEEEEAAAQQQ8LUAAbyvu5+DRwABBBBAAAEEEEAAAQQQ8IpAplcamqh2ri5dK1N+mS3TZ82VdWXlcuJR+0qHdgXu7oqKV8sXE6bI3PmLpF+f7rLnLoOkTV6um88CAggggAACCCCAAAIIIIAAAskQ8HUA/8NPM+SyocNkxcpi6bZRRyleXSq77rCFG8AvWLxczrjkDlmydKX06t5Fnn71fdm4dzd59r4rpV1hfjL6h30ggAACCCCAAAIIIIAAAgggYAV8G8D/uWCJnHnZXbLDoIFyx1NDpVOHthIMBqWqav2Z8ezro6Vo1Wp5+/nbbAA/beYcOeW8W+X1UZ/Iuacdtb4gSwgggAACCCCAAAIIIIAAAggkWMC3z8A/8dK7UlkZlBsvO80G7+qcnp4uGRnrScZ++p3sNXgbG7xr/hYD+sgOWw+UsZ99r6tMCCCAAAIIIIAAAggggAACCCRNwLdX4D/7ZrIM2LinfPTFRJk9d4FkZWXK3rtuI3ubgF2nsvKArCgqkU36do/oDF2fOn22mxYMu2LvJjbzBecuAy+2vZnT1tk83OvkSVgm7gmjrbNi3OvkSVgm7gmjrbNi3OvkSVxm6G8w/p5JHHFdNeNel07i8vTzxoPhRwRIelrEKiuNFPBlAK+D1a1cVWJ/srMzpbt5/n3qr7PlzXc/kwuHHCvnnHqkfS5eLfNyW0WQ6roOfBeoqJCszEwpKimPyPfCSpX+szf/D1QEvdDcFtNGddcP3aIK750zXu4E192D/1Zx97JAatrO+Y57agRSs1cNYux/V/l8T0kHePFv4JRAxXGner6vXF0uXo9/2xdkx1HFf1X5MoDXK+s6XXbOCTLkxEPsctD8izjv6vtl2Auj5AyTlp2dVZ1unosPnyoqKyU9LU0yzO32OnnxBCwLBKXc/OTn+bL7w7szqcvl5guTdeWVUpBXfW4ldec+3pl+UVVaVimFrXFP5mlQUVklq9cGpG0b/iOdTPdKc0mseE1A2uXjnkx3/RuiqCTgyb8JkukU731pMLOipAz3eMM2oL5lq3BvAFPciywvNu7m892EIkw+Flj/wLePEDqbAev0effStevco9agXG+h1+fi5/y50Iwy38YG6joyffhUXFIqbTUvFMCH57GMAAIIIIAAAggggAACCCCAQKIEfBnAZ2ZmSI+uneTHqbMiXJ1n2zt1aGcD9L69u8rknyPLTJ42y74PPmJDVhBAAAEEEEAAAQQQQAABBBBIsIAvA3g1PfOkQ2XCpF/k0edHmSvui+SlER/KODOg3V67bC3t21a/4/3og/eQb36YJi+8OVZ+m/OXPPzs/2Tm7PlyzCF7JLhbqB4BBBBAAAEEEEAAAQQQQACBSAHfPgR97GF7yux5C+XxF9+RYSaI12m/3beToVec4QqddvxBMseUueex4XLXo6/ZV8zpM/NHHrirW4YFBBBAAAEEEEAAAQQQQAABBJIhkFZlpmTsqLnuY+26Mpm/cKl06dhOCvJbx2ymlvlr0TLp2a2z5IQGt4tZ0COJDGKXmo5iELvUuDOIXWrcGcQuNe4MYpcadwaxS427M4hdh4Kc1DTAx3vVQew6FuKe7FOgehC7HAaxSzZ8M9ufb6/AO/2Q2yrHvOu9h7Mac65l+veJfB98zIIkIoAAAggggAACCCCAAAIIIJAgAd8+A58gT6pFAAEEEEAAAQQQQAABBBBAICECBPAJYaVSBBBAAAEEEEAAAQQQQAABBOIrQAAfX09qQwABBBBAAAEEEEAAAQQQQCAhAgTwCWGlUgQQQAABBBBAAAEEEEAAAQTiK0AAH19PakMAAQQQQAABBBBAAAEEEEAgIQIE8AlhpVIEEEAAAQQQQAABBBBAAAEE4itAAB9fT2pDAAEEEEAAAQQQQAABBBBAICECBPAJYaVSBBBAAAEEEEAAAQQQQAABBOIrQAAfX09qQwABBBBAAAEEEEAAAQQQQCAhAgTwCWGlUgQQQAABBBBAAAEEEEAAAQTiK0AAH19PakMAAQQQQAABBBBAAAEEEEAgIQIE8AlhpVIEEEAAAQQQQAABBBBAAAEE4itAAB9fT2pDAAEEEEAAAQQQQAABBBBAICECBPAJYaVSBBBAAAEEEEAAAQQQQAABBOIrQAAfX09qQwABBBBAAAEEEEAAAQQQQCAhAgTwCWGlUgQQQAABBBBAAAEEEEAAAQTiK0AAH19PakMAAQQQQAABBBBAAAEEEEAgIQIE8AlhpVIEEEAAAQQQQAABBBBAAAEE4itAAB9fT2pDAAEEEEAAAQQQQAABBBBAICECBPAJYaVSBBBAAAEEEEAAAQQQQAABBOIrQAAfX09qQwABBBBAAAEEEEAAAQQQQCAhAgTwCWGlUgQQQAABBBBAAAEEEEAAAQTiK5AZ3+oaV9vvcxbIJ19PkgkTf5FFS1fIylUlUlUl0r5tvnTt3EEGb7+57Lv7dtK3V9fGVUxpBBBAAAEEEEAAAQQQQAABBFqYQEoC+OKSNXLfk2/KiPc+NwF7lWRkpEuXju2kf5/ulnfh4uXy3eTpMn7iNHngqRHy96P2kUvOOl7atM5tYfwcDgIIIIAAAggggAACCCCAAAINE0h6AP/euPFy56OvyYqVxbLrjlvKUQftJvvvsb20ysmOaPHadWUy7suJMuqDr+T1UZ/Ix19OkqsuOEkO2WfniHKsIIAAAggggAACCCCAAAIIIOAHgaQG8HpF/apbn5DePbrIXdf929wiv0WtxrmtcuSIA3a1P199N1VueeBFuXzoY9K5QzvZftCAWrcjAwEEEEAAAQQQQAABBBBAAIGWKJDUQeyCwaDsvN1m8uaTQ+sM3qOhd99pKxn51M2yw9YDRetgQgABBBBAAAEEEEAAAQQQQMBvAmnmGXQzbFxypjWl6yQrK1Oyzc+GTGXlAamsDEpebs6GbM42IYGyQFDKzU9+3ob1A5AbJlBeEZR15ZVSkJe1YRWw1QYJBIx7aVmlFLbGfYMAN3CjisoqWb02IG3bRD4etYHVsVkDBSqDVVK8JiDt8nFvIFlcigXNn1JFJQFpX4B7XEAbWIn+BbuipEw6FPB3YQPJ4lZs2aoy6ViIe9xAG1jR8uIyaZ+fI2lpDdyAYi1SIKkRXOu8Vg1CdL5TSIs6O3Oy+QO8QYAUQgABBBBAAAEEEEAAAQQQaHECSb2FPlpv+qy58n/XPSQvj/zIzXrhzbFy4ImXy46HnCM33vOcBCoq3DwWEEAAAQQQQAABBBBAAAEEEPCrQEoD+FFjvpKPv5okm23S2/rre+HvGfa6LFleZEel19fMPfPqaL/2DceNAAIIIIAAAggggAACCCCAgCuQ0gB+xm/zpFuXDu6o8sPf+UT0ObLbrv6XfPzGvbLFgD4y8v3P3caygAACCCCAAAIIIIAAAggggIBfBVIawC8vKpE+PTdy7adOny1ZmZlywJ47SI55L/z2ZtT5RUtWSEVFpVuGBQQQQAABBBBAAAEEEEAAAQT8KJDSAL5Lx3Yy589F1n2puW3+F/NM/MD+PcUZrK507TpJS08zIy0y1KIfT06OGQEEEEAAAQQQQAABBBBAYL1AUkehX7/b6iV9J/z4idPkX5fdLWtK19or7Yfut4vN1JHoJ02dJV07d5CMjJR+zxDdbNYRQAABBBBAAAEEEEAAAQQQSLpASiPjf/ztANl68342iJ9ibp/fuHc3OfmY/SzCmM++k9lzF8gu222edBR2iAACCCCAAAIIIIAAAggggEBzE0jpFfjcVjny4kP/kR+nzZKM9HTZZstNJD10u3yHtgUy9IozZOdtN2tuZrQHAQQQQAABBBBAAAEEEEAAgaQLpDSA16PNzMyQHbfetMaB72QCd/1hQgABBBBAAAEEEEAAAQQQQAABkaTeQj9z9nz5/qdfN9hdn5fXd8UzIYAAAggggAACCCCAAAIIIOA3gaQG8EuXr5R/X3GvvD9ufKOdR435Ss696n5ZUVTc6G3ZAAEEEEAAAQQQQAABBBBAAAGvCyT1Fvqe3TpLpw5t5cpbn5B3PvxGLj/3BNmkb486DWf8Pk/uHjbcDnTXq3sX6bZRxzrLk4kAAggggAACCCCAAAIIIIBASxRIM69rq0rmgZWVlcuwF96W598YY18bt9kmveXAvXaQvr262lfGaVsWLllu3w8/5tPv5Nff5klWZqacedKhcvY/j3DfEZ/MNre0fZUFglJufvLzkvr9TUtjbPTxlFcEZV15pRTkZTV6WzbYcIGAcS8tq5TC1rhvuGLjt6yorJLVawPStk124zdmiw0WqAxWSfGagLTLx32DETdgw6D5U6qoJCDtC3DfAL4N3kT/gl1RUiYdCnI2uA423DCBZavKpGMh7humt+FbLS8uk/b5ORIa83vDK2JLTwskPYLLycmWS84+Xo44cFe557HhMmHiLzJ91tyYiNlZmbLX4G3kCnOlXgN8JgQQQAABBBBAAAEEEEAAAQT8KpD0AN6B7t+nuzx+56VSurZMfvhphixeukKWh55v11fIde3SQbYfNED0VXNMCCCAAAIIIIAAAggggAACCPhdIGUBvAOfl5sje+4yyFlljgACCCCAAAIIIIAAAggggAACMQSSOgp9jP2ThAACCCCAAAIIIIAAAggggAACDRAggG8AEkUQQAABBBBAAAEEEEAAAQQQSLUAAXyqe4D9I4AAAggggAACCCCAAAIIINAAAQL4BiBRBAEEEEAAAQQQQAABBBBAAIFUCxDAp7oH2D8CCCCAAAIIIIAAAggggAACDRAggG8AEkUQQAABBBBAAAEEEEAAAQQQSLVAyl8jpwArV5XIb3/8JYvMu+C3HzRQupl3wC9etlKKTHr3rp2kTV5uqp3YPwIIIIAAAggggAACCCCAAAIpFUj5FfhHnntL9j3uEjn94jvk6tuelIlTZliQz76ZLMeeeYM8P3xMSoHYOQIIIIAAAggggAACCCCAAALNQSClAfy7H30jj73wtrRvVyAnHrVvhMdxh+0lnTq0lU+++jEinRUEEEAAAQQQQAABBBBAAAEE/CiQ2gD+w28kIyNd3nziJrny/JOsf1pamp1r+tab95M58xf5sV84ZgQQQAABBBBAAAEEEEAAAQQiBFIawM/9a7HssPVAewU+olWhlc4d20mgPCCBiopY2aQhgAACCCCAAAIIIIAAAggg4BuBlA5it1Gn9jJ77kIJBoMxwX+ZNUe6mgHtsjIT38wJk36RqqoqGbz9FhFtKSpeLV9MmCJzzZ0A/fp0lz13GcSgehFCrCCAAAIIIIAAAggggAACCCRDIKVX4LfdchNZurxI3nj3Mxs8hx/wa6M+lsk//yZaJtHT++PGy5mX3iX3PzkiYlcLFi+XE84ZKjfe/ayM+2KiXHP7k/LPC2+3o+ZHFGQFAQQQQAABBBBAAAEEEEAAgQQLJP7Sdh0HcPY/jpAxn34nt9z/orzwxlhbcvjbn8qLZnnazDmS2ypHLjn7+DpqaHrWpKkz5bo7n5Gc7KwalT37+mjzKrvV8vbzt0mv7l1sm04571Z5fdQncu5pR9UoTwICCCCAAAIIIIAAAggggAACiRJI6RX4vNwcefmRa+Wog3aT+QuX2mPUgFqD9+22GiDDH79RNurcPlHHLvPMM/gXXvuQ/O3wvWSPnQfV2M9Y8+XCXoO3scG7Zm4xoI99Zn/sZ9/XKEsCAggggAACCCCAAAIIIIAAAokUSOkVeD2wju0L5fZrzpKhV5whf/61RNaWlUvfnl1Fg/tETqtK1si5V98vgzbfWP5z4SlyyY2PRuyuzAyet6KoRDbp2z0iXdenTp/tpq0rr3SXvbJQUVkllcEq8WLbvWIcq51qHsQ9Fk1C03BPKG+tlevQJuZ053OmVqHEZKi5Gc4F98Tw1lqrIRf94b+rtRIlNAP3hPLWWjnutdIkNKMs4L3YIxqkVXZGdBLrjRBIeQDvtFUHqtu4dzdnNaFzHdX+ouseMrfNZ8u9N54v6ek1b0RYsbLYtiEvt1VEW3R9delaOzK+tlmDYa9NGtDogH1ebLvXrMPbawNJc7rgHq6S+GX90kT/leKeeOvwPQQ1iuRzJpwkKcv62a7/43xPCre7E/spw/nueiRrQT/b9aOG8z1Z4pH7wT3SIxlrer4HTOxR/dLtZOyRfTRHgZQH8GXmivt3k3+VbydNt4FxNJKOVH/OqUdGJzdp/ZnXRsvPM+bI0/dcIcXmSrz+rF1XJoFAQBYtWSHt2uZLduiZ+OgR8isqKyXdvKs+IxT0t8lNOWGjLcoCQSk3P15se6MPthltUF4RtFdncE9upwSMe2lZJed7ctntH9SrgwHck+yuXxRWrME9yezmbpMq+zcEn+/JlddgptxcjcQ9ue66N736jnvy3fXqe5tWmWJCESYfC6Q0+pw5e76caEZ519vVa5v69ekW9wB+VXF1wH7KBbfW2O1+f79UHrntIvPs+9Y2UC9eXRpRprikVNoWtol51T6iICsIIIAAAggggAACCCCAAAIIxFEgpQH8g0+PsMH7GSccIvvvub3kt84zgXHkV0pZWfFvol7RP/mY/SIYb77vBfNKu1Xy8G3/J506tLUBet/eXc2r7GZFlJs8bZZ9H3xEIisIIIAAAggggAACCCCAAAIIJFgg/tFxIxr82x9/2VHmLz/3hEZs1fSihfmtRX/CJ322PTu7VHp26+wmH33wHnLv48PlhTfHym47bikffPKt6F0DOugeEwIIIIAAAggggAACCCCAAALJFEhpAN/fjOj+vXn+XZ8zjzWQXDIh9FmS6OdJTjv+IJkzb6Hc89hwuevR1yQjI12GnHiIHHngrslsGvtCAAEEEEAAAQQQQAABBBBAQNLMiLU6iGdKpvfGjZerbn1C7rru33LY/oNT0oaG7FQHuPtr0TJ7dT4nNLhdQ7ZrrmWcQezy81L6/U1z5UlYu5xB7AryshK2DyquKeAMYlfYGveaOolL0dGJV68NSNs22YnbCTXXENBB7IrNIHbt8nGvgZPABB3ErqgkIO0LcE8gc42q9S/YFSVl0qEgsa8errFjEmTZqjLpWIh7sk+F5cVl0j4/p8ZFx2S3g/2lViClEdzhJmgf9cFX8t+HX5XvfjRX4mN8l7BR5/Zy/ulHp1Qpt1WO9O8T+T74lDaInSOAAAIIIIAAAggggAACCPhOIKUB/KSpM2Xq9Nn29XEj3v88Jr6OQp/qAD5mw0hEAAEEEEAAAQQQQAABBBBAIIkCKQ3gXzSDw60uXStnnXK47L/H9tKmdW7NUegzU9rEJHYFu0IAAQQQQAABBBBAAAEEEECgdoGURsczfp8vXbt0kIvPOq72FpKDAAIIIIAAAggggAACCCCAAAKSnkqD/ub2+OKSNXYU+lS2g30jgAACCCCAAAIIIIAAAggg0NwFUhrA/+3wvWRN6Tp5b9yE5u5E+xBAAAEEEEAAAQQQQAABBBBIqUBKb6FftmKVZGZmyJ2PvCoTJk6LCdG5YztusY8pQyICCCCAAAIIIIAAAggggICf7Gh0qQAAQABJREFUBFIawE/8aYZUVFRKUfFqeXvs1zHddRR6npGPSUMiAggggAACCCCAAAIIIICAjwRSGsBfdcHJcsGQY+vk1iv0TAgggAACCCCAAAIIIIAAAgj4XSClAXzbgjaiP0wIIIAAAggggAACCCCAAAIIIFC3QNIHsVu9Zq29Zb7uZpGLAAIIIIAAAggggAACCCCAAALhAkm/An/6xXfI9FlzZeqnz8kNdz0r73wY+9l3p5Gb9O0hI5++2VlljgACCCCAAAIIIIAAAggggIAvBZIewHfp1E5WmUHrdOrRtZNstenGdcJ3N2WYEEAAAQQQQAABBBBAAAEEEPC7QFqVmfyO4LfjLwsEpdz85Ocl/fsbv1FHHG95RVDWlVdKQV5WRDoriRUIGPfSskopbI17YqUja6+orJLVawPStk12ZAZrCRWoDFZJ8ZqAtMvHPaHQUZUHzZ9SRSUBaV+AexRNQlf1L9gVJWXSoSAnofuh8poCy1aVScdC3GvKJDZleXGZtM/PkbS0xO6H2pu3QNKfgb/2jqfluLNubN4qtA4BBBBAAAEEEEAAAQQQQACBZiaQ9AB+yfIimb9waTNjoDkIIIAAAggggAACCCCAAAIING+BpAfwzZuD1iGAAAIIIIAAAggggAACCCDQPAUI4Jtnv9AqBBBAAAEEEEAAAQQQQAABBCIEUjKKWXmgQp4fPiaiIbWttC1sI0cfvHtt2aQjgAACCCCAAAIIIIAAAggg4AuBlATwZWXlcvdjrzcIuF+fbgTwDZKiEAIIIIAAAggggAACCCCAQEsWSEkAn5OdJdde/M8GuRa2ad2gchRCAAEEEEAAAQQQQAABBBBAoCULpCSAzzYB/N8O3bMlu3JsCCCAAAIIIIAAAggggAACCMRVgEHs4spJZQgggAACCCCAAAIIIIAAAggkRoAAPjGu1IoAAggggAACCCCAAAIIIIBAXAWSfgt9354bSaA8ENeDoDIEEEAAAQQQQAABBBBAAAEEWrpA0gP4//zfP1q6KceHAAIIIIAAAggggAACCCCAQNwFuIU+7qRUiAACCCCAAAIIIIAAAggggED8BQjg429KjQgggAACCCCAAAIIIIAAAgjEXYAAPu6kVIgAAggggAACCCCAAAIIIIBA/AUI4ONvSo0IIIAAAggggAACCCCAAAIIxF2AAD7upFSIAAIIIIAAAggggAACCCCAQPwFCODjb0qNCCCAAAIIIIAAAggggAACCMRdgAA+7qRUiAACCCCAAAIIIIAAAggggED8BQjg429KjQgggAACCCCAAAIIIIAAAgjEXYAAPu6kVIgAAggggAACCCCAAAIIIIBA/AUI4ONvSo0IIIAAAggggAACCCCAAAIIxF2AAD7upFSIAAIIIIAAAggggAACCCCAQPwFCODjb0qNCCCAAAIIIIAAAggggAACCMRdgAA+7qRUiAACCCCAAAIIIIAAAggggED8BQjg429KjQgggAACCCCAAAIIIIAAAgjEXYAAPu6kVIgAAggggAACCCCAAAIIIIBA/AUI4ONvSo0IIIAAAggggAACCCCAAAIIxF2AAD7upFSIAAIIIIAAAggggAACCCCAQPwFCODjb0qNCCCAAAIIIIAAAggggAACCMRdgAA+7qRUiAACCCCAAAIIIIAAAggggED8BQjg429KjQgggAACCCCAAAIIIIAAAgjEXYAAPu6kVIgAAggggAACCCCAAAIIIIBA/AUI4ONvSo0IIIAAAggggAACCCCAAAIIxF2AAD7upFSIAAIIIIAAAggggAACCCCAQPwFCODjb0qNCCCAAAIIIIAAAggggAACCMRdgAA+7qRUiAACCCCAAAIIIIAAAggggED8BQjg429KjQgggAACCCCAAAIIIIAAAgjEXYAAPu6kVIgAAggggAACCCCAAAIIIIBA/AUI4ONvSo0IIIAAAggggAACCCCAAAIIxF2AAD7upFSIAAIIIIAAAggggAACCCCAQPwFCODjb0qNCCCAAAIIIIAAAggggAACCMRdIDPuNXqkwjWl62T8xGnyx7yFtsV77jJIBvbrVaP1RcWr5YsJU2Tu/EXSr0930XJt8nJrlCMBAQQQQAABBBBAAAEEEEAAgUQK+DaAv+TGR+Tr73+W9m3zre8DT42Qvr26yksP/0faFVanLVi8XM645A5ZsnSl9OreRZ5+9X3ZuHc3efa+K90yiewc6kYAAQQQQAABBBBAAAEEEEDAEfDtLfS77zxIXn/sBvly1MPyxVsPyY2Xnmavxr8+6hPHRp59fbQUrVotbz9/m/15ddj18sfchRJexi3MAgIIIIAAAggggAACCCCAAAIJFPBtAH/qcQfKVpttbGnT0tLkyIN2E50vNFfdnWnsp9/JXoO3sVffNW2LAX1kh60HytjPvneKMEcAAQQQQAABBBBAAAEEEEAgKQK+DeCjdX/8eZZUVVVJ395dbVZZeUBWFJXIJn27RxTV9fAgPyKTFQQQQAABBBBAAAEEEEAAAQQSJODbZ+DDPcvKyuXex9+wz7Ufc8geNmvFymI7z8ttFV5UdH116VoJVFRIVmamFJcGIvK9sBIMigTNlxVebLsXfGtrI+61ySQ2vcqc75VBzvfEKtes3XzE4F6TJeEp6s7ne8KZa+7AuOtFAP67WpMmoSnWXXBPKHLtlXO+126TqBz9jC/R2CMtUXtITr0FeVnJ2VEL3YvvA/jyQIVccN1DMnvuAnn8zkulbUEb29XZ2dUnVlCjrrCporJS0s2t9hnp1TcvtMrKCMv1xmKgMigVlSJebLs3hGO3ssKcS+UVVbjH5klYqrpXBXBPGHAtFeuXJkHzw+dMLUAJStbgvbIS9wTx1lqt+ZSRAO61+iQqw8Qyxj3I50yigOuotzyAex08CcsKVAQlJzvD6/F7wnz8UrGvA3h9ldyF1z0oU36ZLY/cdpHstO1mbr+3K2xjA/Xi1aVumi4Ul5RKW80LBfDZWd57CkH/g6dfTHix7RGd4bWVCjFfnFThnuR+SzPuAfPFCed7cuH1XC8LVOKeXHZ710NaGu5JZrd3PZQK7sl216uROvH5Xu2Q7N+4J1vc7G+tOd8z0824XSnYN7tsNgK+DeAXL1sp5119vyw2r4h79v6rZFBoQDunZzRA1+fhJ5tn48OnydNm2ffBh6exjAACCCCAAAIIIIAAAggggECiBXwbwJ983i2yaMkKueTs4818uf1xsPfdbTvJzMyQow/ewzwbP1xeeHOs7LbjlvLBJ9/KzNnz5fZrznKKMkcAAQQQQAABBBBAAAEEEEAgKQK+DeCXrVhlge9/8s0a0OPffVQK8lvLaccfJHPmLZR7Hhsudz36mmRkpMuQEw+RIw/ctcY2JCCAAAIIIIAAAggggAACCCCQSIE0M2pq6AmiRO7G23WvXVcmfy1aJj27dTYDR3h/1MQyM/CIDj6Sn+fb729SckKWm4FH1pVXCiNvJpdfB3wpLauUwtbe/7ebXLmm7U2fgV+9NiBt22Q3rSK2bpSAfePCmoC0y8e9UXBNLKyDBxaVBKR9Ae5NpGzU5voX7IqSMulQkNOo7SjcdIFlq8qkYyHuTZdsXA3Li8ukfX4Oz8A3jq3FlSaCa0CX5rbKkf59It8H34DNKIIAAggggAACCCCAAAIIIIBA3AS8N4R63A6dihBAAAEEEEAAAQQQQAABBBDwjgABvHf6ipYigAACCCCAAAIIIIAAAgj4WIAA3sedz6EjgAACCCCAAAIIIIAAAgh4R4AA3jt9RUsRQAABBBBAAAEEEEAAAQR8LEAA7+PO59ARQAABBBBAAAEEEEAAAQS8I0AA752+oqUIIIAAAggggAACCCCAAAI+FiCA93Hnc+gIIIAAAggggAACCCCAAALeESCA905f0VIEEEAAAQQQQAABBBBAAAEfCxDA+7jzOXQEEEAAAQQQQAABBBBAAAHvCBDAe6evaCkCCCCAAAIIIIAAAggggICPBQjgfdz5HDoCCCCAAAIIIIAAAggggIB3BAjgvdNXtBQBBBBAAAEEEEAAAQQQQMDHAgTwPu58Dh0BBBBAAAEEEEAAAQQQQMA7AgTw3ukrWooAAggggAACCCCAAAIIIOBjAQJ4H3c+h44AAggggAACCCCAAAIIIOAdAQJ47/QVLUUAAQQQQAABBBBAAAEEEPCxAAG8jzufQ0cAAQQQQAABBBBAAAEEEPCOAAG8d/qKliKAAAIIIIAAAggggAACCPhYgADex53PoSOAAAIIIIAAAggggID3BIqKRCoqvNduWtx0AQL4pht6qobZs0X+c02anHFahnz2mUhVlaeaT2MRQAABBBBAAAEEEPCtwJ9/igwZItKtm0ifPiJDh4pUVvqWw5cHnlZlJl8euQ8PesYMkc03FwkG1x/8vfeKXHrp+nWWEidQXhGUdeWVUpCXlbidUHMNgYBxLy2rlMLWuNfASWBCRWWVrF4bkLZtshO4F6qOFqgMVknxmoC0y2+6e31/HZC/Xj9oMFaVGPeC9e74rPeJtRQPH62jaE25tIvxOROP+mO120lLZf2J3rceY337WFFs3Ov4nKlve/KdMyn2vDafotXl8uC92TJyZOR277wjcsQRkWmstVwBAviW27c1juzii0UefDAyOSdHZLPNItPC12r7AHHKkO9IxJ6H++g3Zfp9WXpamls4PN9NDFtIdb42pSltaMq2Td13+PbajjB2zbJTc2mf057ouZfbV1/b9VjrK0N+9BkRud4Un/q2jdwTawgggAACzVngsMNE3nuvObeQtsVTIDOelVFX8xb47TfTvrxlIts+K1Jo7r/54d9StmRLmTy5ebe7ZbVuffDeso6Lo0EAgZYmEOtLr/BjJD9cw3whZVbDP+HxifSJXouXj979EP7FuLOfeNXv1Bc9b0r9TdlW25Ho7RuyD3XPSA8/4yOFEt1Gv9avd1n9NitNysvNJ07vL0RKeois6Cf9+kX6s9ayBbgC37L7N+Lonh4xR876yVxuz1znpm87/0l59vyz3PXoBb9+QDoO8Tz+QGVQygJBadNq/fdm8azfaXP4nPpF9Bb6teVB8+jCenfHCB9HIva8KT76R0Z9t9A3pX5tMdvX7DfnFvr2Ybdy1yxVv12sbUirXUCDmSJzC3197rXXQM6GCOidJCtKyqRDgbmdkCmpAstWlUnHQtyTim52try4TG5+/Cd5aN7pIp2mm28O0yXt9wNl4lUjZNstWye7OewvRQI1/6JNUUPYbeIFZhU+ERG86x5n9LlUrpz6ZvXOQ1+kpkVcQ4jdrlrLhH0ZW2uZsCprLdOIemqtQ/cTj2OKUz0mnjHjD1RJZqa2OOwAwzzCF+stY6qot4wlqGNfDfSpdz/xaEvIud591XdMUfWouQY1WZk1x+ysd1/xOK4kG1cffminuhI9NbA9ulmdPvXUo39Y65cn2Vnmj4u6zvd66glvfq31hB1urWXCKqq1TDzaUg1n91brfhrSlg2sRx/T0fE2crIy1u8lXscValOyjqve/ZjjqreMaXO9ZeJQjzndpcx8UZibE+a+vgcilpLRHuefXH37qi9fG+6W0fNIDzR0Pmle9OSWjc4IW0+r55u3BtWhjTD/18+ZteUVkpdT88/ZxtQT1rwaiw2qp55j0kobXE+8jOuop0FtCRnX1udr1lVGXJCoARdKsPuq45xpsI3Tntp2ZNIbdFzaV3XYNLg99dTToLboMTlT2KKTpPPoelavq5DPCp6sDt5tgaBU9R8jP5S/KttK7Rfkwutk2fsCNT/xvH9MHEEtApMXT6qRU1qxWj6a/VGNdBIQQAABBBBAAAEEEECg+Qu8/vPrctZ2BPDNv6fi00IC+Pg4eqKWIdsOkQ9//zCirfv13U+u2v2q6jT9RtJMVfaryerl2n7XWcaj9dR5TNUwTbKpMLfQ65WxvOzMJtVj+8SjxtWMocbHOrlMVr39YLart0xYPXr1XR9dyItxZazOerSZ+kW9XuKpZ/JcPeZ46mxz6HjrLBNiqa1MtXulvTJWWxnTCGus81rLNLQtzamvtM0NOKbqYiHI0HHWmDWyHnO6S5l560Juq9CVYK1er+w0sp5Y7WhW/x60gU09Jucg41CPfk6sVfcYnzPObpx5ved6Uz9zQjtq8meX1qPnj52FFqpXY/6u77jceuqpqrH1rDVvd8nNrnnnQ2PriXlQJjFZ9bj7qcPHLVNbY5321lGHbhqPevR8b5VT88626Ka5+6qjTW6Z6I3D1t0yTajHrUPrraWeiDJh+w9fjCgTj3pqqaO6mZGZ+jajsbPfk8VrFoc3SfTveSb/CPAMvH/6WgKVAbl47MXy0k8vyZrAGjm4/8Fy34H3ycCOA32kkLpD5TVyqbHnNXKpcec1cqlxd56Br+v1TqlpWcveK8/Ap6Z/9bsOnoFPjT3PwKfGXZ+B//yv0XLK/06WdRXVY1p1y+8mP/77R+ncunNqGsVeky5AAJ908tTvcNmaVbK4eJls0bVf6hvjoxYQwKemswngU+NOAJ8adwL41LgTwKfGnQA+Ne66VwL41NhrAN8+P0dWrFsuL0x+QXoV9pKjNj1KstKzUtMg9poSAW6hTwl7anean50vOYWMVJnaXmDvCCCAAAIIIIAAAgg0XqBDbge5dPCljd+QLVqEQP0Pr7SIw+QgEEAAAQQQQAABBBBAAAEEEPC2AAG8t/uP1iOAAAIIIIAAAggggAACCPhEgADeJx3NYSKAAAIIIIAAAggggAACCHhbgADe2/1H6xFAAAEEEEAAAQQQQAABBHwiQADvk47mMBFAAAEEEEAAAQQQQAABBLwtQADv7f6j9QgggAACCCCAAAIIIIAAAj4RIID3SUdzmAgggAACCCCAAAIIIIAAAt4WIID3dv/RegQQQAABBBBAAAEEEEAAAZ8IEMD7pKM5TAQQQAABBBBAAAEEEEAAAW8LEMB7u/9oPQIIIIAAAggggAACCCCAgE8ECOB90tEcJgIIIIAAAggggAACCCCAgLcFCOC93X8b1PqM9DTJzqLrNwivCRupew7uTRDcsE3Tcd8wuCZuZdilVXZGE2th88YKpKel4d5YtDiUTxPjnsP5HgfKRlVhTnfJzcls1DYUjo9AHud7fCAbWYs93815z+RvgbQqM/mbgKNHAAEEEEAAAQQQQAABBBBAoPkLcBm2+fcRLUQAAQQQQAABBBBAAAEEEEBACOA5CRBAAAEEEEAAAQQQQAABBBDwgAABvAc6iSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICABwQI4D3QSTQRAQQQQAABBBBAAAEEEEAAAQJ4zgEEEEAAAQQQQAABBBBAAAEEPCBAAO+BTqKJCCCAAAIIIIAAAggggAACCBDAcw4ggAACCCCAAAIIIIAAAggg4AEBAngPdBJNRAABBBBAAAEEEEAAAQQQQIAAnnMAAQQQQAABBBBAAAEEEEAAAQ8IEMB7oJNoIgIIIIAAAggggAACCCCAAAIE8JwDCCCAAAIIIIAAAggggAACCHhAgADeA51EExFAAAEEEEAAAQQQQAABBBAggOccQAABBBBAAAEEEEAAAQQQQMADAgTwHugkmogAAggggAACCCCAAAIIIIAAATznAAIIIIAAAggggAACCCCAAAIeECCA90An0UQEEEAAAQQQQAABBBBAAAEECOA5BxBAAAEEEEAAAQQQQAABBBDwgAABvAc6iSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICABwQI4D3QSTQRAQQQQAABBBBAAAEEEEAAAQJ4zgEEEEAAAQQQQAABBBBAAAEEPCBAAO+BTqKJCCCAAAIIIIAAAggggAACCBDAcw4ggAACCCCAAAIIIIAAAggg4AEBAngPdBJNRAABBBBAAAEEEEAAAQQQQIAAnnMAAQQQQAABBBBAAAEEEEAAAQ8IEMB7oJNoIgIIIIAAAggggAACCCCAAAIE8JwDCCCAAAIIIIAAAggggAACCHhAgADeA51EExFAAAEEEEAAAQQQQAABBBAggOccQAABBBBAAAEEEEAAAQQQQMADAgTwHugkmogAAggggAACCCCAAAIIIIAAATznAAIIIIAAAggggAACCCCAAAIeECCA90An0UQEEEAAAQQQQAABBBBAAAEECOA5BxBAAAEEEEAAAQQQQAABBBDwgAABvAc6iSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICABwQI4D3QSTQRAQQQQAABBBBAAAEEEEAAAQJ4zgEEEEAAAQQQQAABBBBAAAEEPCBAAO+BTqKJCCCAAAIIIIAAAggggAACCBDAcw4ggAACCCCAAAIIIIAAAggg4AEBAngPdBJNRAABBBBAAAEEEEAAAQQQQIAAnnMAAQQQQAABBBBAAAEEEEAAAQ8IEMB7oJNoIgIIIIAAAggggAACCCCAAAIE8JwDCCCAAAIIIIAAAggggAACCHhAgADeA51EExFAAAEEEEAAAQQQQAABBBAggOccQAABBBBAAAEEEEAAAQQQQMADAgTwHugkmogAAggggAACCCCAAAIIIIAAATznAAIIIIAAAggggAACCCCAAAIeECCA90An0UQEEEAAAQQQQAABBBBAAAEECOA5BxBAAAEEEEAAAQQQQAABBBDwgAABvAc6iSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICABwQI4D3QSTQRAQQQQAABBBBAAAEEEEAAAQJ4zgEEEEAAAQQQQAABBBBAAAEEPCBAAO+BTqKJCCCAAAIIIIAAAggggAACCBDAcw4ggAACCCCAAAIIIIAAAggg4AEBAngPdBJNRAABBBBAAAEEEEAAAQQQQIAAnnMAAQQQQAABBBBAAAEEEEAAAQ8IEMB7oJNoIgIIIIAAAggggAACCCCAAAIE8JwDCCCAAAIIIIAAAggggAACCHhAgADeA51EExFAAAEEEEAAAQQQQAABBBAggOccQAABBBBAAAEEEEAAAQQQQMADAgTwHugkmogAAggggAACCCCAAAIIIIAAATznAAIIIIAAAggggAACCCCAAAIeECCA90An0UQEEEAAAQQQQAABBBBAAAEECOA5BxBAAAEEEEAAAQQQQAABBBDwgAABvAc6iSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICABwQyPdBGmogAAggggIBvBS4f+pj8Pm+BDNp0Yxl6xRk1HM67+n5ZuHSFTU+TNMltlS39+3aXvx+xt2wxsG9E+ZdHfiQjR38h+a1z5Zn7rpSszMg/A14b9bG88e5nppY0GfH0UElPS4vYnhUEEEAAAQQQSK0AV+BT68/eEUAAAQQQqFXgzwVL5INPv5WZv/8pb435UlasLK5RVoP7uX8uku4bdZSNOrWTdWXlMuK9z+Xk82+VLyZMiSi/dHmRrWvilJnyzoffROQFKirkyZfftfkzfp8nUlUVkc8KAggggAACCKRegAA+9X1ACxBAAAEEEIgp4ATZRx20m1RWBuW9jyfELNepQ1t55LaLZNgdl8jIp2+Wu677t1RUVMoLb4yJWb5NXq48+9poCYYF6e99NF6WLCuSvNycmNuQiAACCCCAAAKpFyCAT30f0AIEEEAAAQRiCrxrrpJv1Lm9XH3ByZKdlSnvfvh1zHLRiYftP1jy2+TJb3P+is6y60NOOlTmmKv2H33+g12vMoH8c8M/kO0HDZDtthoQcxsSEUAAAQQQQCD1AgTwqe8DWoAAAggggEANgck//yZ6C/1h++0iBfmtZc9dtpZfZs6V3+csqFE2OmFN6TpZu65Mttps4+gsu37EgbtKl07t5alX3rPrX3w7xdZ79j+OiFmeRAQQQAABBBBoHgIE8M2jH2gFAggggAACEQLvhK62H26uput02P672LmTblfCfulV9LLygMz6Y75cfvMwewv9gXvtGFZi/WJWZoacfsLBMn3WXPn6+6nynLmdftP+vWT3nbZaX4glBBBAAAEEEGh2ApHDzza75tEgBBBAAAEE/CegA8qN+ew72aRvDxnQr6cF2GvwNqLPrr83brxcfNZxkhY2Qvz8hUtly33Wj1Cvz7Hfce3ZcsQBu9aKd/zhe8kTL74jN9z9nCxaskLuvfG8WsuSgQACCCCAAALNQ4AAvnn0A61AAAEEEEDAFfh8/E+yqniNtMrJkQuvfdBNT0tPs8H295N/lZ223cxN1+fdzzv9aAmage6eMCPJ65X43j02cvNjLeS2ypGTj91fhj0/ypTtIgfuHftqfaxtSUMAAQQQQACB1AhwC31q3NkrAggggAACtQro4HV6hb1j+0JZbEaGd366dulgt3FGp3cqKDTPyJ/6/+zdB3wUZfrA8SedBJIQQJqggNi7Z+/1LGfvZy9n17OderZDPT177556qH8929l7x4YKKoqggiLSO6T37P99JplhdrOzmU2272/4LDvlnXdmvrNJ9nnnLYf+0aoWf+c1Z5se61vlrEtvlznzFttJwr4fbQL4tddYzQr+GfM9LBErEUAAAQQQSCkBnsCn1O3gZBBAAAEEsl2gsrpW9Am89gj/2J2XBnHosG+7H36hvDNuglx53rFSVFQYtF0X9Mn8VReeIFfc+Iicdsmt8uS9V0jfsj6d0ukKXf/CI9eE3cZKBBBAAAEEEEg9AZ7Ap9494YwQQAABBLJY4M0PvhRtA293Xuem0Kfkf9ptK9Fe5t//9Bv3pqD5g/beQU45el9rqLizL7vTqlIflIAFBBBAAAEEEEhLAQL4tLxtnDQCCCCAQKYKvPH+F1KQny97erRJ33eP9l7pXzfpdMrLzQ3q0M52Ofcvh1h5fPvDdOtpvK63O76z3+207vdI29zpmEcAAQQQQACBxAvkmGFnAok/LEdEAAEEEEAAAQQQQAABBBBAAIFoBHgCH40WaRFAAAEEEEAAAQQQQAABBBBIkgABfJLgOSwCCCCAAAIIIIAAAggggAAC0QgQwEejRVoEEEAAAQQQQAABBBBAAAEEkiRAAJ8k+GQetqU1II3Nbck8haw8dmuburdm5bUn86LVvaEJ90TfgzbcE01uHU97talv5POeaHx1r8M90ezW8XBPCrvUNbQk58BZflT9vNN5WZZ/CMzlE8Bn4WdAA5omAviE3/n2AJ6Ck0TDayBJgVWi1UUMOwUniWc37hRYJYHdfKE27gTwCadvL7AikEw4vDkgBSfJUNcCWvN5J4JPDn4KHZUAPoVuBqeCAAIIIIAAAggggAACCCCAgJcAAbyXDOsRQAABBBBAAAEEEEAAAQQQSCEBAvgUuhmcCgIIIIAAAggggAACCCCAAAJeAgTwXjKsRwABBBBAAAEEEEAAAQQQQCCFBAjgU+hmcCoIIIAAAggggAACCCCAAAIIeAkQwHvJsB4BBBBAAAEEEEAAAQQQQACBFBIggE+hm8GpIIAAAggggAACCCCAAAIIIOAlQADvJcN6BBBAAAEEEEAAAQQQQAABBFJIgAA+hW4Gp4IAAggggAACCCCAAAIIIICAlwABvJcM6xFAAAEEEEAAAQQQQAABBBBIIQEC+BS6GZwKAggggAACCCCAAAIIIIAAAl4CBPBeMpm6PtAiuXNekMJf7xRpWpapV8l1IYAAAggggAACCCCAAAIZJ5CfcVfEBXkLNCwSeWszKaib255m6pUi2z0pMuwg733YggACCCCAAAIIIIAAAgggkBICBPApcRsSdBK/PiJiB+96yNZ6kYl/Fan8USSvRCS/2LyHvKx1Zpu93p0mJy9BJ85hEEAAAQQQQAABBBBAAAEECOCz6TOw4L3OV1s3R+S7yzuv97Mmt6hz0J/vCvY7Bf2ube6CAE0Xul/Q9o7CBcnxc1akQQABBBBAAAEEEEAAAQQyUoAAPiNvq8dFrX6kyMIPgjeWrS0y/GCRFvM0Xp/It9a1vzvL9nrz3tKxzUpnltsaTTt685IVwXnGaymvV0hNgAgFAuFqFDiFAhH2cxckxOs6yBcBBBBAAAEEEEAAAQQQ6IYAAXw30NJ2lxFHicz+n8iCd0UCbSJl64hsM1ak/1bdu6RWE7zbAb8G9aFBf2jAH5QmioICJ98GczzzkuXdO99o9wpXM8BaZzcziFQQoGmCt+dKL8lrKzSFHqWdaxxo4QQTAggggAACCCCAAAIIIBBBgAA+Ak7GbcrvLbLLW9K0fJq0VM+WktV2NZfYg2rpeaYKvb6kIjFU9pN/J6A3hQbWOlMYELrOWe5OQYGdb8d7jK5Of9i8f+DMfXA//Q8qKHAVBji1CDoKEazl4IICp78CzcOrJoI2f2BCAAEEEEAAAQQQQACBtBLwjifS6jI42WgEAn1GS2vRKLNLD4L3aA4Yq7RWQGqCUvMQO/5TIExTgp4VFARMoUKbqZWQ16Y1CexCgo4CBq3N0FLb/or/xZlbbzogtD2DCgVMYUDQsp+Cgo4ChND9nGWzPbcgEVfFMRBAAAEEEEAAAQQQyGgBAviMvr1cXPcFTOGGVQXeBJ8xmppb2qShqVXKSsIEs9qkwR3UOzUIOgJ9Z9kO+M16Z52dxrXNzstJ07HNXm5rMvvXtL+0G4N4TznmV407oO9Uw8AuKOgoDAhbuBChRoGV3lWQoMdjQgABBBBAAAEEEEAgwwT4lpthN5TLSVOBnFwT4JomDvpKxBRo7ahhEBL02wG+3TRB34PW6XI39mlrFmmubn8l4vr0iX9HUJ9v+hcozTXBf4ErwHcH/DrvFC54FCQEpQnNx+zDkIqJuKscAwEEEEAAAQQQyHoBAvis/wgAkJUCGnDm92l/JQKgrcUUGHQR+MeioMDKwxxHCwysQoMqq6FI3BuLhBtS0Qr6I9UoCFMQ4BQUuPYLLVzQNFrgw4QAAggggAACCCCQdQIE8Fl3y7lgBJIgkGt+1eSWmafg5pWISZsIdDQjaGmslYb6WulT2LEutKDAqmXgKlwI3R5a4yCoVkLHfskcUtFX0G8KBEILApxlHwUJibhnHAMBBBBAAAEEEECgSwEC+C6JSIAAAmknkGt6OtRXQbkE8tukNd80Gegdpu+BWF2YBvBBgb8J7IOW3U0ROoL+0O1aQyF0nbXckb6jQKI9TRKGVIyyoCDXNFso0mETS0xND903ZFhFpxNFK19XjQOGVIzVp5J8EEAAAQQQQCADBQjgM/CmckkIIJBgAa1CX6hD8/VNzIFb7ZEMwgT9Tg0BV+AfVDDQnX06Oko0lRj8TlrJ34Tt3Zh0SMUuAn6v4RGjKigwx9DjMKRiN+4RuyCAAAIIIIBAsgQI4JMlz3ERQACB7groU2rrSXVFd3OIbr/QZgZOIUFHYG/3b+AqKGhrrpNm03yhKNfUTgiqPeC9T3s6UzihzRb0lYjJc0hFDfDdNQO0UKEj6LcKCnQ5TNMEJ41rX6e5gtlHa4YwIYAAAggggAAC3RQggO8mHLshgAACWSNgB6xRXHBba0Dq65ulqE+UAWvQkIodwX5oUwJXQYEV9If2UxC0vaMmQtA6k6+9T1KHVLQLBVzBvm3tBP0d25zljn2sgoKQ/TRNTi/JaTTNRXqVt9cwYEjFKD61JEUAAQQQQCD1BQjgU/8ecYYIIIBA9ggka0jFoFoFXkG/Fih0bOtUq8Brn5D0cR5S0YwvEdyQwxlS0aOwIKhgwKOwILQmQtA+Jl/3doZUzJ6fVa4UAQQQQCApAgTwSWHnoAgggAACKSHgHlJRuzGI9xQwQyo6tQG8gv5uFBRYBRDt+QVM/jltWsvAvFxDKsb70qz8tYlAuKYFTtDvqjXgrLMLF/Tdtd1pjtCxPVy+DKmYkNvKQRBAAAEEUkeAAD517gVnggACCCCQ6QJapb2gtP0Vh2ttbQtIVW2zVJR2NF3QAN6qLWCCe6fgQAsIOgJ8e5v17l6nacLs4+zXUfjgLHfkqU0S9NW8Ig5XFyZLqz8IO8A3706hgKsgwFnXkc5dY8BPIYGTxuTJhAACCCCAQJIFCOCTfAM4PAIIIIAAAnET0Cr0+iooi9shgjLWIRVDg3pr2RXwd9oepqDAKWxw7eescxcuJHNIRS0QaC8oyDVBfqmYKhxFvc06nwUFTsFAR/qgZc3XdFbJhAACCCCAQIgAAXwICIsIIIAAAggg0E0BHZZPXwWJHlKxowaAFeR7Bf3uwN+dvmO9Fix0Klww6+wOD+3t+h5mSEVTTBLjyR5ScWVBwcoaBu6g31XbwCk8sLd3bOtUC8GVp11wwJCKMb5/ZIcAAgjER4AAPj6u5IoAAggggAAC8RZIxpCKQUF+e2FBwAT5NdU1UlrU0WQhXNDv1CDwKmAw6500WpjgHlJxabwlzQgGuR21B3wG/Xbg7xQa+ChIcO/DkIrxv6ccAQEEMlKAAD4jbysXhQACCCCAAAIxF7CD1ZDREQOBgDQXm+C9LGRDj04g4ArovYL+MDUEnEKAjn2cZS0U6HiFFjBoGm3+0FLb/urRefvcWfuDcAf0tm1oHwVBaYILF3LMtsImU/eh2vQr4e4AsVONA7MfQyr6vDEkQwCBVBcggE/1O8T5IYAAAggggEAWCmgVehN46kv6x//6A20dAX5oTQAtJNDA31WIEFQLoWNb2IKCkP3cabSzw5bq9lcPrs6E7v6mTkMqhjQjCCoo6NjWqSAgpGlCp33MdrsAgiEV/d0XUiGAQNQCBPBRk7EDAggggAACCCCQYQJahT7fdMKnr0QNqdipIEALC6IoKDAFAk2NNVKYYwoD3AUM7oICezSFpAypqAF9SNDvLLvWh65zljtqHEQqKNBt+mJIxQz7geRyEPAWIID3tmELAggggAACCCCAQDwEtEp7vnl+rq9uTqblglRXN0r/Mh8lDs6QilorQAsKItQOsAsDggoCwuzj5NORp11YoOudIRUru3l1Ue6WZwysYL4j6HcKAaIoKOi0j9nXrlFgFxTYaaI8PZIjgEDsBAjgY2dJTggggAACCCCAAAKpKJDwIRW1VkCYoD+0UMAd9Gv67u7TqkM4mpesSIh+/1wzzKEd3NtBvV2AELTcUYBgrfMqXIhQUGAXHCTkqjgIAukhQABv7tO7H0+UNUcOkxHDBwfdtdq6Bhn/9RT5bdZ8a/2OW28ka6+xWlAaFhBAAAEEEEAAAQQQCBLQXvb1VVAetDpuC1YArwUAXp0XevVtEGkfLYAI36Qhp82MktBkXgmZTH8QGsiHFgzYBQh2kB+UxqOwIHSfoDztJgs+anQk5Lo9DhJoFZn7Wvvna8ieNJ/wYMrk1VkdwLe0tMpH4yfJBWPulcvPO7ZTAH/+mHvkswk/SL++7dW77vj38zJytSHyxN2XSUV596t8ZfIHimtDAAEEEEAAAQQQSLCAVYVeA8++CTnw0uWV0r+3CSSdGgMdtQc8axRE2G7lEb6goL1AwhQUWAUTJk0iJmdIxTC1B+zCAifw70FBgZ1HFEMq5lVNlpwPDhGpm9Uu0WcNkV3eEikdnQgZjpEiAlkbwE//bY4cdNKVokO/eE3bb7WRnHPSwbLhuqOsdM+9+pFcfdtj8vRLH8gZxx/gtRvrEUAAAQQQQAABBBDIWIGAVqEvTNSTavNdvVNBQZjaAU4aV2FAaJMFjxoFVv524UPCh1TMc9UwsGsBhNY4aF9fuviLlcG7frpqfhWZfp/IZrdl7GeNC+sskLUBvFaXf+3x66W2rl4OP+3qzjJmzXGH/tFZn5OTI/vvuZ1cc/vjMn/hUmc9MwgggAACCCCAAAIIIBAvAa1CrwGseSVicoZU7Kg10FWHh6GFBOFqFDiFC5pnRwGDvZ81pGKNaa5gXl1MJtTvPM15mQC+s0pGr8naAL4gP9+qMl9Ta36QfE7f/jDdehI/cvUhPvcgGQIIIIAAAggggAACCKSNgHtIxUSctLZp1wA/XOBvB/kdQX/LTw9K/vLxwWc17MDgZZYyXiBrA/ho72xjY5Pc+sCzVtv3g/bewdm9srbZmU+XGW020NYmko7nni7G4c4T93Aq8V+n7q183uMPHXIEbZ3U2hbg90yISyIW2ww+v98TIR18DNyDPRK1pL9r+LwnSjv4OLgHe/RsSZsjdPRhoI/Zwz5qN6MTFmwg5RMPkdy6363DtfUeLbXDTpW2NItHynsX9Iwry/cmgPfxAWhqbpGzr7hLZvw+Tx648QLpW9bH2aukyOMnzEmRejNNLQFpMRFNOp576mn6P6Pm1oA0mY4TcfdvFouULca9sRn3WFhGk4cG7/WNAT7v0aDFIK26t5rPPL9nYoAZRRYavOvvGtyjQItBUg3e+T4TA8huZFHZwvfIbrD1eJeqsg2kZZ/pkrfgTQmYzu8Cg/eQXmKaGDBllQABfBe3W4eSO+eKO+X7qTPknuvOlS03XTdoj4L83KDldFhoM2172tpyJB3PPR18vc7R1HswXzRw9/KJ3/o2U3CCe/x8w+ecY4KZnJxWfs+E54nb2lwTwOMeN17PjDWAzxE+755AcdqgAbxOfJ9pd0j0/7gnWrz9eAUFBZKz2v7JOThHTQkBAvgIt2HhkuVy5t9vl4WLl8ujt18iG5ne6JkQQAABBBBAAAEEEEAAAQQQSIZA1gbwjU3N8svMuVLb0YndPNOz/JRpM2XQgAoZ0K/cuhdHnflPWbBomZx/6mHmfan1sm/SrtttJvn56Vd93j5/3hFAAAEEEEAAAQQQQAABBNJLIMd08NRRASm9TrynZzttho4Df0WnbHTc99OPa6+WsvHuJ0uLabMcbhr/6r1SVto73KaUX9fYbKoUm1dpSdaW3yTlHjWZ9mINTa1SVkLHHYm8Ac3Gva6xVegwJZHq2i41IDX1zdK3T2FiD5zlR9M28FWmM6OKUtwT+VHQKvQrqpulXxnuiXTXb7DLqhulf1mixiNP5NWl9rGWVDbKgHLcE32XllY1Sr/SItNUKtFH5nipJJC1Edxao4bJlI/GRrwX3733SMTtbEQAAQQQQAABBBBAAAEEEEAgUQLp1wNbomQ4DgIIIIAAAggggAACCCCAAAIpJEAAn0I3g1NBAAEEEEAAAQQQQAABBBBAwEuAAN5LhvUIIIAAAggggAACCCCAAAIIpJAAAXwK3QxOBQEEEEAAAQQQQAABBBBAAAEvAQJ4LxnWI4AAAggggAACCCCAAAIIIJBCAgTwKXQzOBUEEEAAAQQQQAABBBBAAAEEvAQI4L1kWI8AAggggAACCCCAAAIIIIBACgkQwKfQzeBUEEAAAQQQQAABBBBAAAEEEPASIID3kmE9AggggAACCCCAAAIIIIAAAikkQACfQjeDU0EAAQQQQAABBBBAAAEEEEDAS4AA3kuG9QgggAACCCCAAAIIIIAAAgikkAABfArdDE4FAQQQQAABBBBAAAEEEEAAAS8BAngvGdYjgAACCCCAAAIIIIAAAgggkEICBPApdDM4FQQQQAABBBBAAAEEEEAAAQS8BAjgvWRYjwACCCCAAAIIIIAAAggggEAKCRDAp9DN4FQQQAABBBBAAAEEEEAAAQQQ8BIggPeSYT0CCCCAAAIIIIAAAggggAACKSRAAJ9CN4NTQQABBBBAAAEEEEAAAQQQQMBLgADeS4b1CCCAAAIIIIAAAggggAACCKSQAAF8Ct0MTgUBBBBAAAEEEEAAAQQQQAABLwECeC8Z1iOAAAIIIIAAAggggAACCCCQQgIE8Cl0MzgVBBBAAAEEEEAAAQQQQAABBLwECOC9ZFiPAAIIIIAAAggggAACCCCAQAoJEMCn0M3gVBBAAAEEEEAAAQQQQAABBBDwEiCA95JhPQIIIIAAAggggAACCCCAAAIpJEAAn0I3g1NBAAEEEEAAAQQQQAABBBBAwEuAAN5LhvUIIIAAAggggAACCCCAAAIIpJAAAXwK3QxOBQEEEEAAAQQQQAABBBBAAAEvAQJ4LxnWI4AAAggggAACCCCAAAIIIJBCAgTwKXQzOBUEEEAAAQQQQAABBBBAAAEEvAQI4L1kWI8AAggggAACCCCAAAIIIIBACgkQwKfQzeBUEEAAAQQQQAABBBBAAAEEEPASIID3kmE9AggggAACCCCAAAIIIIAAAikkQACfQjeDU0EAAQQQQAABBBBAAAEEEEDAS4AA3kuG9QgggAACCCCAAAIIIIAAAgikkEB+ss+lsalZJv3wiyxYvFSWr6iRgPnXr2+pDBnYXzbZYE0pLEj6KSabiOMjgAACCCCAAAIIIIAAAgggIEmLjmfOXiC3P/ScfPLVZGlsbAp7K3oVFcqOW28sF5x2mAwfOjBsGlYigAACCCCAAAIIIIAAAgggkA0CCQ/gm5pb5N9PviYPm5fOrzFiqOy585YyYtggGTKov2U+f+FSmTlnobz14VfyzrgJMm78JDn12P3k5D/vIwX5CT/lbPgccI0IIIAAAggggAACCCCAAAIpLpDQaHjOvMVy2iW3ij5932qzdeXC04+Q9dca0Zlow/ZVZ51woEz+cYbc8sAzcvcjL8jr730hD910oRPod96RNQgggAACCCCAAAIIIIAAAghkpkBCA/jf5y6QufOXyLWXnCwH7b2DL9EN1x0lj915qTz36kdy7Z1PyJz5iwngfcmRCAEEEEAAAQQQQAABBBBAIJMEEhrAD+hXLvffeL5s84f1ozY8bL+dZfDAflJhOrhjQgABBBBAAAEEEEAAAQQQQCDbBBIawK+9xmo98t1hq416tD87I4AAAggggAACCCCAAAIIIJCuAgkN4EORGkzv87/8NlfKy3o7vcxXVtdandctr6yW3Xf4g4wesWrobiwjgAACCCCAAAIIIIAAAgggkHUCucm84pfe+lSOOP1qeeP9L63T0F7pDz75SrnmtsesTuuOOO1q+W7qr8k8RY6NAAIIIIAAAggggAACCCCAQEoIJDWA/8yMAa9jvR976B8tjBff/EQWLFomu2y3qfz97KMkPz/PCuRTQoqTQAABBBBAAAEEEEAAAQQQQCCJAkmtQj93wVJZa9QwKSkusgg0oNfpb2Z4uRHDB8vkn36TDz/7xlrHfwgggAACCCCAAAIIIIAAAghks0BSn8Dn5+VKbm77KbQFAvK9GfN90IAKK3jXmzJ4lQqpq2+URtNWngkBBBBAAAEEEEAAAQQQQACBbBZI6hP4kasNkXfGTZAJk36S3+cslMVLV8g+u23t3A/t4K6stLcUmWr2TAgggAACCCCAAAIIIIAAAghks0BSA/hjDtnDdGD3hZxw3g3WPdCn8acdu581P3/hUhn/9RTZYJ1R2Xx/uHYEEEAAAQQQQAABBBBAAAEELIGkBvAbrjtK7rvhfHn8+XckzwTvB+29gzNs3MvvfCYDTXX6g/fZgVuFAAIIIIAAAggggAACCCCAQNYL5ATMlPUKWQbQ2NwmTeZVWpLU8pssUxdpammThqZWKSspyLprT+YFNxv3usZWKe+NeyLvQ0trQGrqm6VvH5pAJdK9tS0gVbXNUlGKeyLdtR+fFdXN0q8M90S66zfYZdWN0r+svTPkRB4724+1pLJRBpTjnujPwdKqRulXWiQ5OYk+MsdLJYGEdmJX39AoLS2t3b7+5pYW0TyYEEAAAQQQQAABBBBAAAEEEMg2gYQG8N9MniZnXXaHNHSjV/naugY5/eLb5AcztBwTAggggAACCCCAAAIIIIAAAtkmkNAAPicnVz41Y70fftpVMvG7n31bf/nNj9Y+X3wz1VQZoc6IbzgSIoAAAggggAACCCCAAAIIZIxAQhtBb/OH9eSfF58ktz7wrBx/7vWy87abyAF7bic7bbOJFBUGt09tbGqWjz6fJC+99Yl8/MX30q9vqfzr0lNk843Xzhh8LgQBBBBAAAEEEEAAAQQQQAABvwIJDeD16fnB++wou2y3qdx83zPy8tufWkF6YUG+DB08QIYM7G+d9/xFS0WHkdMgXvc5xOxz4RlHSLkZE54JAQQQQAABBBBAAAEEEEAAgWwUSGov9D/9Mkve//QbGT9xiixcvEyWrqi27kF/87R9yKD+ss0f1pfdtt9M1lpjeFzvzbsfT5Q1Rw6TEcMHdzrOiqoaqwbA73MWyBojVpUdt95I+pQUd0qXTivohT45d4te6JPjTi/0yXGnF/rkuNMLfXLc6YU+Oe70Qp8cdz0qvdAnx55e6JPjnmpHTegT+NCLX2f0aqKvs044MHRTQpa1R/yPxk+SC8bcK5efd2ynAH6eqQVw4vk3yKLFy2W1VQfJw0+9LqNWHyqP3naxVJSXJuQcOQgCCCCAAAIIIIAAAggggAACKpDUAD6Zt2D6b3PkoJOulIAW33pMjz79hqyorJGXx15nBfBTps2Uo8+8Vp5+6QM54/gDPPZiNQIIIIAAAggggAACCCCAAAKxF0hoL/SxP/3u56jV5V97/Hp59sExnpm8/eFXVgd7+vRdp/XXGmF1ovf2RxM892EDAggggAACCCCAAAIIIIAAAvEQyNon8AX5+VaV+Zra+rCu2oHeMtMmf82RqwZt1+XJP85w1ml7w3SbtK2eVjxIx3NPN2v3+baZzwrubpHEzOOeGOfQo1juZiW/Z0Jl4rus3vpXCff4Oofmrn9XdcI9VCa+yx3suMeX2TN3Pu+eNHHdoO7pPqp2Xi7DgvfkQ5K1AXxXaMuWV1lJSop7BSXV5Zq6emluaREtBKiqbQ7ang4L+jVD/+hV1balw+lmzDm2uwfS8jOTzjcB9+TcPdyT465H1cKTdPzblDyx2BxZg3jcY2MZTS7t32fS77tYNNeYqmn5vCf+zujnvbou/T/vFaWFicfLoCMSwHvczMKOcenb2oKD3JbWVsk1xV55ue2tD9LxA0gv9B43Pc6r6YU+zsAe2dMLvQdMnFfTC32cgT2y1ycz+qU6Hf82eVxSWqy2e6HHPbG3S4OZZdWNfN4Ty24dTXuh5/OeeHjthb5vn8K0fwKfeLnMOmLWtoHv6jZWlPexAvWqmrqgpFXVddJXt3UE8EEbWUAAAQQQQAABBBBAAAEEEEAgTgIE8B6wGqCPXH2ITPphelCKSVOmW+PBB61kAQEEEEAAAQQQQAABBBBAAIE4CyQ9gF+yrFL+ddf/ydFnXSu7HX6BfPDZN9Yl/++Nj+WMv98mn02YHBcC7aROh4Wbal466ZjvuqznY08H7rWDfD5xijz23Nvyy8y5cvejL8i0GWb4ub13sJPwjgACCCCAAAIIIIAAAggggEBCBJLaBn7h4mVyoBmLvaq61qqSru3Na+sarAvffKO15epbx1odxW23xYYxx/h9zkI5/NSrnHwfeep10dc5Jx0spx+3v7X++MP2lJmz5sst9z8jN937X8nLy5WTjtxb9v/jts5+zCCAAAIIIIAAAggggAACCCCQCIGkBvD3/uclK3i/+Kw/y59221p2Ovhc0ylD+7ACqw8bJBuuM0q+m/prXBzWGjVMpnw0NmLeGrBfc/FJculfj5a5C5bI8KEDpaijc7uIO7IRAQQQQAABBBBAAAEEEEAAgRgLJLUK/dTpv8uqgwfIcYf+UUr7lHS6tHVGryZLzXBuOmRbMqfiXkUyesSqBO/JvAkcGwEEEEAAAQQQQAABBBDIcoGkBvDaDn3IoP7OU/fQe1FTWy+9zbjrOt46EwIIIIAAAggggAACCCCAAALZLJDUAH7tUcPl6++nyYJFyzrdg2XmyftH4yfJiNUGd9rGCgQQQAABBBBAAAEEEEAAAQSyTSCpAfwRB+4i2uL9tItvlVfe/syy12D+vY+/lmPOuU70Cfwxh+yRbfeE60UAAQQQQAABBBBAAAEEEECgk0BOwEyd1iZwxePPvyO3P/isNDV3bud+2H47y1UXnpDAs8mOQzU2txnvNiktoWlCIu94U0ubNDS1SllJQSIPm/XHajbudY2tUt4b94FCNpMAAEAASURBVER+GFpaA1JT3yx9+xQm8rBZf6zWtoBU1TZLRSnuifwwtJmvUiuqm6VfGe6JdNdvsMuqG6V/WVEiD8uxjMCSykYZUI57oj8MS6sapV9pkWl+nOgjc7xUEkh6BKcd2O2y7Sby+vtfmCHbFkhDY6OMGD5Ett9yQ9l847VTyYpzQQABBBBAAAEEEEAAAQQQQCBpAkkP4PXKdXi2049tH3s9aRIcGAEEEEAAAQQQQAABBBBAAIEUFkiJAF59KqtrpbauoRNVYUG+DOhX3mk9KxBAAAEEEEAAAQQQQAABBBDIJoGkBvDa7v2+sS/Jp19Nlp9+mSXhmuOvMWKovDL2X9l0T7hWBBBAAAEEEEAAAQQQQAABBDoJJDWAf+qF9+TfT74m5WW9ZcetN5bS3sWSmxvcK8PAARWdTpoVCCCAAAIIIIAAAggggAACCGSbQFID+Gdf/VB6FRVaT9ipJp9tHz2uFwEEEEAAAQQQQAABBBBAIBqBpAbwfUqKpaWilTbu0dwx0iKAAAIIIIAAAggggAACCGSlQG4yr3qTDUbL3AVLZN7Cpck8DY6NAAIIIIAAAggggAACCCCAQMoLJDWAP/WY/az279ff9X8yZ/5imT1vUafXwiXLUx6RE0QAAQQQQAABBBBAAAEEEEAg3gJJrUKvndetNWq4fPDZt9Yr3MXSC304FdYhgAACCCCAAAIIIIAAAghkm0BSA/i7H3lBJkz6Sfr1LZVNN1hT+vQuCdMLfd9suydcLwIIIIAAAggggAACCCCAAAKdBJIawH8+cYoU9yqSl8047xrEMyGAAAIIIIAAAggggAACCCCAQHiBpLaBz8vLtQJ3gvfwN4e1CCCAAAIIIIAAAggggAACCNgCSQ3gt9p0XasXeu2JngkBBBBAAAEEEEAAAQQQQAABBLwFkhrAH7zPjlKQny//Mr3Qz5y9IOyL4N775rEFAQQQQAABBBBAAAEEEEAgewSS2gb+wSdekeaWFvno80nWKxw7vdCHU2EdAggggAACCCCAAAIIIIBAtgkkNYDf0lShLywsiGi+Sn96oY8IxEYEEEAAAQQQQAABBBBAAIGsEEhqAH/Q3juIvpgQQAABBBBAAAEEEEAAAQQQQCCyQFLbwEc+NbYigAACCCCAAAIIIIAAAggggIAtkPAn8A8+8arMX7RUxlxwvLz/6Tfy0y+z7HMJ+z6gX7kcecCuYbexEgEEEEAAAQQQQAABBBBAAIFsEUh4AP/uxxPlx+m/yz80gP/ka3nlnc8jWmsndgTwEYnYiAACCCCAAAIIIIAAAgggkAUCCQ/gLzj1MFleWS25OTly2rH7iw4lF2kq7lUUaTPbEEAAAQQQQAABBBBAAAEEEMgKgYQH8AEJSFsgYOGOGD5Y9MWEAAIIIIAAAggggAACCCCAAAKRBRIewI999m2Z/OMM2W+PbSOfGVsRQAABBBBAAAEEEEAAAQQQQMARoBd6h4IZBBBAAAEEEEAAAQQQQAABBFJXgAA+de8NZ4YAAggggAACCCCAAAIIIICAI0AA71AwgwACCCCAAAIIIIAAAggggEDqCiS8DbxSVNfUySa7/8WXyqjVh8oLj1zjKy2JEEAAAQQQQAABBBBAAAEEEMhUgaQE8Io5aGCFL9MB/cp8pSMRAggggAACCCCAAAIIIIAAApkskJQAvrRPibz91M2Z7Mq1IYAAAggggAACCCCAAAIIIBBTAdrAx5STzBBAAAEEEEAAAQQQQAABBBCIjwABfHxcyRUBBBBAAAEEEEAAAQQQQACBmAoQwMeUk8wQQAABBBBAAAEEEEAAAQQQiI9AwtvAX3DqYVJZXRufqyFXBBBAAAEEEEAAAQQQQAABBDJUIOEB/Lprrp6hlFwWAggggAACCCCAAAIIIIAAAvEToAp9/GzJGQEEEEAAAQQQQAABBBBAAIGYCRDAx4ySjBBAAAEEEEAAAQQQQAABBBCInwABfPxsyRkBBBBAAAEEEEAAAQQQQACBmAkQwMeMkowQQAABBBBAAAEEEEAAAQQQiJ8AAXz8bMkZAQQQQAABBBBAAAEEEEAAgZgJEMDHjJKMEEAAAQQQQAABBBBAAAEEEIifAAF8/GzJGQEEEEAAAQQQQAABBBBAAIGYCRDAx4ySjBBAAAEEEEAAAQQQQAABBBCInwABfPxsyRkBBBBAAAEEEEAAAQQQQACBmAkQwMeMkowQQAABBBBAAAEEEEAAAQQQiJ8AAXz8bMkZAQQQQAABBBBAAAEEEEAAgZgJEMDHjJKMEEAAAQQQQAABBBBAAAEEEIifAAF8/GzJGQEEEEAAAQQQQAABBBBAAIGYCRDAx4ySjBBAAAEEEEAAAQQQQAABBBCInwABfPxsyRkBBBBAAAEEEEAAAQQQQACBmAnkxyynDM2oqblFxn89Rb6b8otstuFasuWm60phAWwZeru5LAQQQAABBBBAAAEEEEAgZQWIRCPcmo+/+F7+ds190qd3iay31uryzMsfSlNzs9x93bmy9WbrRdiTTQgggAACCCCAAAIIIIAAAgjEVoAAPoLnzfc/Lf0ryuX1J66X3NxcqatvlD2OuFDuG/sSAXwENzYhgAACCCCAAAIIIIAAAgjEXoA28BFMa2vrZZX+5VbwrslKiotkjRFDpbWtLcJebEIAAQQQQAABBBBAAAEEEEAg9gIE8BFMD9x7e/n6+2ly5qV3yJSff5PPJ06RyT/OkEP22THCXmxCAAEEEEAAAQQQQAABBBBAIPYCOQEzxT7bzMhRaY776/Xy7Q/TxWY6dN+d5Oq/nehcYE19izOfLjOtbQFpM6+CfMpvEnnP2sznqbUV90Sa67HUvcW4F/J5Tyi9/mVpbmk1nX7mJfS42X4wdW8y7kW4J/SjoF+kmppxTyh6x8EajHsvPu8Jp29oMu6F/H5PNHymfN77FNOKuyefHfQi6F36r3/LgkVL5a0nb5L5i5fKQ0+8Ks+/Nk4qykvlvFMOtfbMz8uJkEPqbtIveel67qmrGvnMWkzLCy04wT2yU6y3thp3LTjBPdaykfNTd8nJwT0yU8y3ml8xktOCe8xhu8jQKjgR3LtgivlmdddvYfx+jzmtrwxx98UU00Q5zSJ5uTn655UpiwUI4D1u/rLlVfL6e+OtQH3Y0FVEX5tvtLace+Xd8tSL78kZxx8gRYUFaVn62NjcZmoUtKXluXvcrrRY3WQieA3gKbFO7O1qNu76BB73xLqruT6Bxz2x7lrDqpEnY4lFN0fTmj71jXzeEw2vAXxdYwu/ZxINb46nNVD5/Z54+NqGdncC+MTbp9IRqUPtcTeWLKu0/iBXVtc6KXLMT0tF31Kpb2iS2roGZz0zCCCAAAIIIIAAAggggAACCMRbgADeQ3iNEavKsCGryPOvj5O3PvxKqmvq5MPPvpU3P/hSDv3TTtLPBPJMCCCAAAIIIIAAAggggAACCCRKgCr0HtJ5eblyz7/Olcuvf1guvPo+J9WOW28k55x8sLPMDAIIIIAAAggggAACCCCAAAKJECCAj6C85shh8syDY2TR0hWydFmVDB7YjyfvEbzYhAACCCCAAAIIIIAAAgggED8BAvgubLXd+6ABFdari6Rps3nqVJGZM3PkgP1EcmlEkTb3jRNFAAEEEEAAAQQQQACB7BYgfMui+19dLbLLLiKbbZIrBx+YJ2uuKfLZZ1kEwKUigAACCCCAAAIIIIAAAmkswBP4NL550Z76k0+KfPTRyr1mzBA57TSRs85qfxKvQ1LoE3n75V52z+v2SMt+t0VKF3oMd1r3fGi60OVIaVdKMIcAAggggAACCCCAAAIIpL4AAXzq36OYneGzz3bOasoUkTPP7Lw+G9ZECu7jsU1ytMJLjhSYn7rQgobQZffx3fOh6UKX3Wnd86HpQpcjpXVvc8+H5hG6HCltd7dFOoZXnmZYbGlszpGy3tEXTnnlqecR7lyy4eeGa0QAAQQQQAABBBBIngABfPLsE37kvfYS+fDD4MMOGSJy4IEibW3tr4AJdrqa1+3udKHL8d4WKf9oz6W1VURfiZtMNQemBAtowYm+4j+FC+xDA/3Q5UiFBOm8TavptLTmSUmv4Bo77mtyz0fjEk1av8eIlC4ex/OTp54TEwIIIIAAAggg4BbICZjJvYL5zBVYskRkyy1Ffvut/Rr79BH5739F9t03c6850pVFKgiIx7am5jZpaGqT4sJ8q5DE7zEipYu2wELT2y93vu75VM4z0rl5XUOruebW1oCp+5AT9bVHOl64bZE+b2xDIFoBu1DBfteg30/gLzkByc/LiZg2Up6RjtHd/SLlma7b3Oet5nUNrVLeJ7+Tuztd6HxXy25v93w0+7nTRvsZTPX0+nt/WXWj9C8rSvVTzbjzW1LZKAPKcU/0jV1a1Sj9Sovkp59ECgpERo9O9BlwvFQQ4Al8KtyFBJ3DgAEiv/wi8sqrAdMLfUBOOjFXysoSdPAUPIx+GcrLa38l4vSaWsQE8AEpK0nE0TiGLdDc0iZ1jeaLdW/zly7Okwb19stdoOCeDxf42/vEalukfOJxLuGO12J93lulMD8vqMaO+/ju+dA8Qpcjpc2EbeGuV6+rezWEeHQf5x/1MNmreep/pXIH8zofuhypkCAe2yIdP9Lx3Ps1txZIr8L2a3Gv1/muliMdw73NPR+rPEPz6e4xIu3X3W1+zk1/PzElXmD2rBw59ByRcePaa7ftsYfI2LEigwcn/lw4YvIEUv+vTfJsMvLIbdIiDaNekoaK36Wl4ERzjf0y8jq5KASSIaBfevTFJKb6fEBq6lulbx9TSsbULQG7YMJ+1yA/NNAPXVb3qpoWKS0p6JQ2Uj5+t0VKF3oukdJ2d1ukYyQ6z9Bz0VpWeeYXQOj6rpa7e97d3U8/jN0rGOrWxzgBO/FLNwHIYQ5RZHVo7C4kcM+HFgKELkdKmwnbIl1vd69P83ziyXynQ2r9HfD22yIPPigyZkyYW8SqjBWgCn3G3trOF7aodpFs9uBmMrd6rrWxOL9YnjzkSTlonYM6J2ZNzAWazJPghqZW8wQ+/k+CY37yaZxhIp/ApzFTzE+9PYBvNgG8eTTGlDCBVtNrY1Vts1SU4p4wdHOgNvNNekV1s/QrS233nhQmhO7rLkBwz4emC12OlNa9zT0fmoe9rAUR1fUt0ruovWmarre3hZtP122RztuPUziL7u7nPhfNgyn5AlqNfvr05J8HZ5A4AZ7AJ8466Ud65NtHnOBdT6a+pV7OffNc+WXZL1JSUCK9C3pb79Z8oWu+Y721vbBE8nJ4opb0m8kJIIAAAgggEKWAPsHTSZuPZcKkAeSy6lbTBp6vs4m+n9oGXvseiFQQkOht7sKFSPOx2tbdfCK5dJXn++8HZPbs4GZSO+6Y6LvP8ZItwG+8ZN+BBB7/vRnvdTra7KrZcvG7F3daH2lFUX5RcLBvB/4muA8qBAgJ/DsVEuh2s497ve5fXFAc6fBsQwABBBBAAAEEEEiygFYFt6uDJ/lUsubwr73VIocfXCD19e2XrB1Sn3121lw+F9ohQACfRR+FIzc4Uj747YOgK167/9qy/9r7S11zndQ21658b6pbOW+2OdvN+saWRuu1rH5ZUF6xWtDewjWwD1cY4F7faXtIYYBTMBAmr4I8qrHH6n6RDwIIIIAAAggggED8BbbZts08gW/vuK7QtNg57jiR8vL4H5cjpJYAAXxq3Y+4ns1RGx4l/5v6P3l3xrumvV6brDNgHRl74FjZatWtojquBvBBwb4G+Cawt9c5wX7I+k7bPQoJ6pvrpbap1npFdWJRJC7ILYi+kCBMswJ3c4PQAoUcLZZmQgABBBBAAAEEEEAgRgL9TP/TF14Yo8zIJi0FCODT8rZ176Q1wHzrmLdk6qJpMnP5bNl77V2tsbGjzU2r0OurX3F8erAPiBlP11Ug4AT+rnXuQgIN9nXZvc6Z9ygkaG5tlsqGSusV7fX7Ta+dBLprDBTnl0gv8yor6i29uygMcGoPmL4JnPmQmgS98nv5PRXSIYAAAggggAACCCCAQAYIEMBnwE2M9hLWqBgtw/uM6lbwHu2xupNeq9BrgKuveE0awDsFAyb4D5r3KhAIs97az6OQQDsJ1NdS8y8ek3YmqMG9u5AgqBaAVyFBmL4HvGoS5OfyKyIe9448EUAAAQQQQAABBBDojgDfzrujxj5pL6Bt4Pvm9ZW+vfrG7VqspgAd/QpojYDK+hpZXl8tOblNwQUGrjR2bYKgAgXdHqaQoKGlQaqbqq1XvC6iKK8oZoUEVuFCmH4K4nXu5IsAAggggAACCCCAQKYJEMBn2h3lelJGQHvTd/eoH+tx4FsDrUFNDZxmAyF9DzjrtQlCS/jCgHA1CXRdY6vpsNC8ljcsj5urXWsg6mYFHTUM7P3dTQ2ceVNDIUf4NRe3m0fGCCCAAAIIIIAAAgkV4JttQrk5GAKxE9Aq9KVFpdYrdrkG56TBu7s/AqcwIKSQwE+NgXCFBHZ+um1x3eLgg8doSZsBlJhmA72709zAq5AgJK/cnI7BlWN0zmSDAAIIIIAAAggggEA4AQL4cCqsQwABS0Cr0BcVF0lFcUVcRKwOC0MKA+ygXt/dhQfdLSRoam2SqsZK6xWXizCZaoeCdk2AsDUJQjogtNN69T1gbXc1N6DDwnjdOfJFAAEEEEAAAQTSS4AAPr3uF2eLQEYJWB0WWk/He8sq5l88pvqmRllSUy35BR4dF2rTgo5+COx3pxAhTN8DVpqQ9dofgb6W1senw0J9wu80C/AqDPBYH1oYoPm487Ln6bAwHp8+8kQAAQQQQAABBGIrQAAfW09yQwCBFBPIzy0wQ/eVS3nvgridmY42EFpjwCkEMDUJ7M4J3euc+ZDCAPd6u0BBCwdqmmqsl9TG5zIK8wqdWgTukQ3sAN8K/L0KCcKMeFCUVyzSWijNuX2dAoP4nDm5IoAAAggggAAC2SNAAJ8995orRQCBOAkU55sOC82rf3H/uByhLdDm1BJwNytwgv3uFBJ0DItoFxJoUwN9xbPDQj+FAV6FB35qEmiTDyYEEEAAAQQQQCCTBQjgM/nucm0IIJARAlqFvrTQdFhoXtI7PpekwbsdzEddSNBRGBBaoFBj1jeY2glOvtqvgXnFa2rvsLCk+zUJTHMOLUAIKmgwTQ7swgN9p8PCeN098kUAAQQQQAABPwIE8H6USIMAAghkuIBWoddXRa/YdFjY0hqQmvpm6dun0JFzAnyvZgORahKE1BgIl1d7h4VVpsPCKueYsZ7RDgWDAnyPZgXumgRWAYBH3wNW0wQtJOhohqA1OZgQQAABBBBAAAEvAQJ4LxnWI4AAAgjEVMAOVqUkptk6mbW0tVhP+J0n/qagwJ63363AP0yNAff6oLTawaGrwMHusHBZ/TLnuLGcsTss9FNIYAf97rS98kskp7VIBpaXBRc0uGoSFJh+IZgQQAABBBBAID0FCODT875x1ggggAACIQJahb6sqMx6hWyK2aIG8M7Tf68aA66CA3dadyGBe71VYNBRSKAdIjodFsbsrIMz0poWdmGKUzvAVZPAWeeqGeAuJLDmw3Rc6KQxeekIE0wIIIAAAgggEHsBAvjYm5IjAggggECGCmgVen31K+4XlyvUDgs1uHcC/GgLA0ztgsqGGmlua3BqH7jz0nm7w8IVDSvicg2aqV1A4AT12oQgBoUEVuGCyYcOC+N268gYAQQQQCDFBQjgU/wGcXoIIIAAAtkjoFXo+xT2sV7duerWtoBU1TZLRenKvgdC89EA3gnqtbAgykICa98u+iTQNPqK15SXm7eys0K7eUBIIYG78MAO/N3rrPkwNQnsGgh6DCYEEEAAAQRSTYAAPtXuCOeDAAIIIIBAHAXsDgv79uobt6PYAbzTn0CUhQTuZgVOHqZAwF7f2NpodVYYzw4Li/KLuiwksIP9YlN4kNvWSwaUlnr2PWCntQsRigvosDBuH0AyRgABBDJYgAA+g28ul4YAAggggEAyBDRI1dcA8y8eU2tbq9NEwAnwvQoJXOudtK7CAKtGgXZW2FFrwCkkaGmURvOKV4eF2k+Au1mBHdhb72FqBnimjTD8YUEeHRbG4/NHnggggEAyBQjgk6nPsRFAAAEEEEAgagGt3h7vDgs1eLcDfvvdq7lBjWlSsKy2WgI5K/dxCgZMAYIz7yokqG+ul1qzn77iNemIA56Bf7hCAlPoEm50A6dwwdWPgb0uJ4cOC+N1/8gXAQQQCCdAAB9OhXUIIIAAAgggkNUCWoVeX346LGwLBGRFdbP0K/PueyAUM2D2cQoG7BoBGuC7agy4A38N9INqCbgKA9xDHbrTNLc2m04NK61X6PFjtVycXxxUSBDUVMCrkMCr1kBHence2mkkEwIIIIDASgEC+JUWzCGAAAIIIIAAAgkR0CfXPemw0M9JagAfTSGBVWDQUVDQab9wNQlMWh36UF9Lzb94THk5ee39CngUBuTn9JKKkjB9D4RJbxUMmFoEdu0BfdeXDkHJhAACCKSLAL+x0uVOcZ4IIIAAAggggEAUAtoGvm9eX4lnh4VWU4DQPgQi1STQtOEKA8Ks10IEbcpQ3VRtvaK49KiS6rCEVlAfJuj3aoLgTu+uMeBVSBDVCZEYAQQQiCBAAB8Bh00IIIAAAggggAAC3gLam348e9RvDbRGaFZQJ4uqKiU3v6lzTYMIhQShtQt0VAN9LW9Y7n2hPdxiB/mefQyEKzxw9Ulg728VHIRpgqCjSzAhgEB2CBDAZ8d95ioRQAABBBBAAIG0E9Aq9KVFpdYr9ORNNwKyrLpR+pcVhW6KalmDd6++B9zrQwP/sDUJIvRVoPsvrlsc1bn5TazNAOyn/52CfW0qEKYDQq/CAK/1uTm5fk+HdAggEEcBAvg44pI1AggggAACCCCAQGoLaBX6ouIiqSiuiMuJBiTQ3gGhRweFURcShGlu0NTaJJWNpsNC84rXZHVY2FEYUJRbImW9egf3J+AqJOhUiBCm7wG7wMEuMKDDwnjdOfLNNAEC+Ey7o1wPAggggAACCCCAQMoI5EiO9XRcA9ZVzL94TM1tzZ0KCYJqDESoGRC2JkFHIYE7D6fDwvr4dFioT/idwN9VGGAH+PrurkngpHU1NQhKq+tDmhvQYWE8Pn3kmWgBAvhEi3M8BBBAAAEEEEAAAQRiKFCQWyDlReXWK4bZBmWlAbw1TKGpSTBn+XIpKmoJ7nvAq5Cgi/V2IUFDS8PKDgtrgw4dswXtK8AJ/H0UErgLBEILA6wChTCFBDE72TAZaZ8QL/30otw/8X7RazlzizNlr9F7Cc0bwmBl8CoC+Ay+uVwaAggggAACCCCAAAKxENAq9PrqX9xfimWgDCjvWd8DoefUFmhrLxDw6oDQjG5Q20VhgDUUotYe0LQeTQ20uUE8Oyx0B/3uGgN+1ndVSPDUD8/I+e+d4dC9Pv11eeGIF+SgdQ5y1jGT+QIE8Jl/j7lCBBBAAAEEEEAAAQRSWkCfIpcWmg4LzStekwbv4QJ7J+D3UUhg1xhw9glT4KDbEjXdN+E+AvhEYafIcQjgU+RGcBoIIIAAAggggAACCCAQPwGtdq6vil7x6bBQz9wJ7L0KA7w6M3Sl9yokWNGwwnSJaIZfcE2VDfHruNB1GGZTSIAAPoVuBqeCAAIIIIAAAggggAAC6Stgt42PxxVc99EtcsW4i4KyPmOLlVXqgzawkLECBPAZe2u5MAQQQAABBBBAAAEEEMgUgeM2PEny81vlwa8flIK8Ajl989PlqA2OypTL4zp8ChDA+4QiGQIIIIAAAggggAACCCCQLIESMyzexdtdIhdtd5EZnND8y8lJ1qlw3CQKEMAnEZ9DI4AAAggggAACCCCAAALRCDBsXDRamZc2N/MuiStCAAEEEEAAAQQQQAABBBBAIPMECOAz755yRQgggAACCCCAAAIIIIAAAhkoQACfgTeVS0IAAQQQQAABBBBAAAEEEMg8AQL4zLunXBECCCCAAAIIIIAAAggggEAGChDAZ+BN5ZIQQAABBBBAAAEEEEAAAQQyT4AAPvPuKVeEAAIIIIAAAggggAACCCCQgQIE8Bl4U7kkBBBAAAEEEEAAAQQQQACBzBMggM+8e8oVIYAAAggggAACCCCAAAIIZKAAAXwG3lQuCQEEEEAAAQQQQAABBBBAIPMECOAz755yRQgggAACCCCAAAIIIIAAAhkoQACfgTeVS0IAAQQQQAABBBBAAAEEEMg8gZyAmTLvsrgiBBBAAAEEEEAAAQQQQAABBDJLgCfwmXU/uRoEEEAAAQQQQAABBBBAAIEMFSCAz9Aby2UhgAACCCCAAAIIIIAAAghklgABfGbdT64GAQQQQAABBBBAAAEEEEAgQwXyrjJThl5bxl7Wux9PlLzcXOlb3ifoGmvrGuTjL76T9z/9Rr6ZPE369O4lA/qVB6WJtLCiqkbeGTfRvCbI0uVVMmRQfyksKAjaxU+aoB0yaMHLPfQSv/hmqsyet0iGDx0YuinssnZD8cmXk+WN97+QX2bOlbI+vaVvWfC9xb3z593GrKmrl4nfTbM+u+O/niJrrD5USoqL7M2e77h70lgbIn3em5pb5NMJk+WVtz+T5pZWGTywv+Tl+SsP9uPuJ03ks0+vrW3md8C3P0y3fnd/NH6SqK/+/g017cnvAT+mftKkl2zks/Xj3tO/q35M/aSJfCXpt9XPNftJ43Xlfvb1k8Yr/3Rd39U1+/mZ6Orap/82x/o+88XXU6WltVWGDVklaJeuziEocYYsRHvNM2cvkPHfTLHsCvLzfSng7ospYxLRiV0a3coW80VZv9yd/4975PLzjpUjD9g16OxPvegW+WzCD9Kvb6m1ftmKahm52hB54u7LpKK8fV3QDq6FeQuXyonn3yCLFi+X1VYdJDPnLJBRJhB69LaLnX39pHFlmTGzXbm7L/T198bLxdc+KOuvPVKefXCMe1PYef2lruk1eB8xfLDoPWtqapa7rztXtt18fWsf3MN/3hVn4nc/y4VX3yfLTIHT0MEDpKqmTu67/jzZdIM1w3rbK3G3JTq/d/V5//iL7+Vv19xnCghLZL21VpdvJ083AWf7Z3brzdbrnKFrjR93P2lcWWbE7AtvfCxX3vSoFBUVyiqm0HXO/MVWIdRNV5wuu2y3qXWNPfk94MfUT5qMwHZdhB/3nvxd9WPqJ43rlDNi1s81+0njheFnXz9pvPJP1/V+rtnPz0Sk63/zwy/l79c9ZB5ElEhJSS+ZM2+xHHvoH+XvZx9l7ebnHCLln47bor3mBYuWyZFnXCOLl66Qd56+RVY13226mnDvSigDt5sPFlMaCEybMTuw/s4nBNbb6Xjr9d+X3u901o8993bg+6m/Wuvb2toCz7z8gZX2vrEvdUobuuKfdzwe2HKf0wO/z1lgbfrh598CG+92csC9r580ofmm+7Ifd/sav/7+58Amu58c2HSPvwQOO/Uqe3XE968m/Wjdo6defM9K19DYFDj0lH8EDjjhcmc/3I8PhPu8z5q7MLDRbicFTjr/xsCiJcstr9bW1oAJQB07rxncw8v4+bzve9ylgb2Oujig1jqZJ5SBbfc7K3DsOdeFz9S11o+7nzSuLDNi1jypCrz01qfOZ3f23EWBLfY+LWa/B/yY+kmTEdiui/Dj3pO/q35M/aRxnXJGzPq5Zj9pvDD87OsnjVf+6brezzX7+Znwun79m7DTwedaf5Ptvw93P/qC9R3n15lzrd38nINX/um6PpprrqmtDxx40hXW92/9vm8Kc7u8bNy7JMrIBP7qPGZgwUW6XZI+nX3t8esjPtU9zpRybrjuKOvScnJyZP89txN9n2+ertuTCRCtkj0TFNqrrPe3P/xKdtpmE+vpu65Yf60RsvnGa8vbH01w0vlJ4yTOkBk/7nqpJpiUcy6/Sw7ZdyfZYauNwl79jfc8ZdmbX9DO9reMey/z1O2wfXe21hUVFsjh++0iWhVqxu/zrHW4O1xBMw8+8aq0trbJmAuPl1X697W25ZqmJaHVjnEPYou44OfzXms+v6v0Lxe11kmbK6wxYqi0trUF5d1ddz8/E0EHyoCFrTZbVw4wv6/tz+6woauY37/ryLyFS5yr8/t7AHeHrMsZP+5+/q7qgXDvkttJ4Odn3E8a3B1SXzN+TP38THi5f22abupT46MO3t35+6BP3/V7qP1d0s85+LqYNErk95rNgzerRmGzqYV5ydl/DnuF40wzWX06/97HXzvbcXcosmqGAD5Nbre2gdEv16sPG+z7jLVNpSl2kpGrD3H2MQ/mZfKPM+TXme3BoW5oNL8stOr2miNXddLpjC7bwb+fNEE7Z8iCH/fK6lo54++3y0brjZLLzjna88pnzJpv2Te3tDhptKqU3tf8/Dxn3Zojh1nz8xct9XVvnB0zaMaP+0efT5K1Rg2Xd80fsstveFiuunWs1cQklAH3UBHvZT/uB+69vXz9/TQ589I7ZMrPv8nnE6dYn+tD9tkxKOPuuGsGXf1MBB0kQxf0i9x3U36xmkDpJUbz+xf37n8oQt3D5RTu76qmwz2cVvh1fn7G/aTBPbyv11q/pu79vX4mwn3e5y9cZu3q/i5ZXtpbBpoCdvu7ZHfOwX0+6Tjv95qvu/P/5IeffpP7b7xAykP6QbKvW5sL6nf4Jcsr7VXGFncHI4tm/PWMkEUgmXKpjeZJ+60PPGu1Xz9o7x2cy+rVq1Du/Oc5Tjt53aC/EHQqKe5lvdv/6bJ2EKYBp580+uU/2ya1OfeKu6SosFBuHXOWU+oczuGM4w+Qw/bbWUpN22F7Utfepp2Ye7I7YNNCFdzdMivntSbJ8spq61VYmG+1EZv80wx57tWP5JyTDpbTj9vfSYy7QxGTGfWdMOlnq8PMcaZPDp0ONTVPDg4J4Lvjrnl19TOhaTJ9unfsS6Id1mntEp2i+T2Ae/c/HaHuoTl5/V3VdLiHankv+/kZ95MGd2/jcFv8mrr39fqZ8Pq8676dv0sWyTLz91qn7pyDtWMa/+fnmk1THdH+B/5z+9+tDpAnm0A+3LSV6WdGv8Ovu+bqzmbNXyfcHZKsmMm+iCsLbqv2YHy2CSq1CvYDpiTP3aN5rqnKtPsOfwhSKDTVtnXSklb3pL2Hanrt8d5PGve+2TL/yH/fkB9+nikP33KRVJkn8fqqb2iUZtOpl5a6VpgOBbVavE6brD+6E0tBQX6nqsd2VWQtEMG9E5m1Qgs3dLrw9CPkpCP3tua199wzTU2I+x57SU4063C3WGL+36X/+rf5bC+Vt568SeYvXioPmaYMz782ziosPO+UQ53jdefzrjt39TPhHCBDZ0x/GPLA46/IcYftKX/caQvrKqP5PYB79z4Y4dzdOUX6u6rpcHdrRZ738zPuJw3ukZ1Dt/o1tfeL9DPh9XnXfbWmp3tqMU3d7FqG0Z6DO590ne/qmvW7+k33/tf6PjN4YD/ru+OKjgKPxUtWmA5ji0VrMug0dFB/6+W20Px1wt2tkvnzVKHPsHusQ96cfsmtVs/Q95iezLfcdN0ur7DCDEengbr24O2eqqrrrKHqtK2rnzTufbNlvrKqPWA/+uxrZbfDL7BeOhLAtBlzrPnPzXykqX9FuVSHuGuVfJ369yvD3QNPq+Tp57KuvsFJoZ/hnbfdxGoXP3P2fGd9uBncw6l0vU5L+nWkBR0BQ9tpb2HaaT90899kt+03E/2yp1W9I01dueu+ftJEOkY6b9MCQa1Gqe2uLzlrZRvInv7+9WPqJ00620Y6dy93e5/u/F3Vff2Y+kljn0emvPu5Zj9pvDz87OsnjVf+6bo+mmvu6mcinEH/ijJrdeh3mqqaWmdI42jOIdwx0nFdV9dc3dEv0q0PPON8j9S/Azrpd8vr73oy4mXjHpEnYzcSwGfQrV24ZLkc99d/ybRf58ijt18i226xQaer0zbxCxcvs6oe2xs1ENJ28pNMm3n3NGnKdNM5VXu7eD9p3Ptmy7xW1X7rqZuCXjr8m7Zj1/XbdAwFpx5aJVbt9R7Y02jTz8Bvv88XO2jX9ZNM21fLe/iQ9vcu7o2dVza9a2m+ji2rQ5i5J20bptMq/Suc1bg7FD2eWbKsUrSmg/vzqh0UaU2T+oYm0UDHnrrjrvt29TNh559J71r76V93/Z/c/tBzorUYLukYcsm+xmh+/+Juq3X93pW75uDn76qmw10V/E1+fsb9pNGj4e7PXFP5MfXzM6F5hXO3++/51nx3tCcdz1wfdKxhhiXWyc852PtmyntX16zV4UO/R17cUYD7H/Nd3p5XD23Go98jtRmhPeFuS2TXOwF8mtxvfbI1ZdpMmWpeOumYwLqsX6jt6agz/yk//TJLTjhiL6uK6zvjJoj90rGdddIv2bsedoGcP+Zeezfr/cC9drA6o9J2OL/MnCtm6A/rKbK7/byfNEGZZsBCV+5arWn40IFBL22HpFVedb32MG9Pl5jx3tVe//DZk/Y8rdOVNz4iP/86S7Rjtv88/abVk/0AMx60TriH/7yf/Od95Itvpoq20dMvCU88/47VM+tOW28c1McD7tbHyNd/XX3etUBPC06ef32caM+6+qTlw8++lTc/+FIO/dNOMXH38zPh62LSKNGtDz4rT77wnmnetJnpqHSQ83tbf3/rmPA6+f090N3PO+7h3f38XdX7g7sq+Jv8fNb8pNGj4e7PXFP5MfXzu0jzCueuo5FssM5IuefRF62/zVOn/S5X3fIfqznbn3bbWnfzdQ5Wwgz6ryv3QlMFPvR7pD2yzqrm720/U0BuT2+Yv7X6PdIMO2qvskaBwd3hyJqZHB0cL2uuNo0vVKtkH3TSFZ2uwN1h18a7nyx2oB6acPyr90qZCTa1ffbme51mVa3Xkj170uG4rja9eL9ofiloCawOZ3S8aYN5wWmHW0OAaDo/aez8MuXdj3votZ73j7tlvmn//swDY4I2nX7JbfLJl9/LZ6/cE9QvgQZC/7j5Uefp5SYbjJa7/vlXU/2yvToa7isZ3Z93fRJ8y/3PWIG7fmZ10qrcV190otUe294Ld1ui63c/n3cd4vDy6x+2ChDtHHfceiO57u+nBH3R6K675tnVz4R93Ex51y/Dr5mmCeGmMRccL4fvv4vv37+4h1MMv86Pu5+/q5o77uGNvdb6+Rn3kwZ3L+Hw67sy9fMzoTl7uc9dsETOvuwO6wGQptM+mG7+xxmiNRPtqatzsNNl0nu01/zmh1/K366+X9595tagNu8vvvmJXGEe+Fx5/nFWUzbbCHdbInveCeCz5177ulIN8PUXgZYG2p2Ahe7oJ03oPixHFtBgdPbcRVLapyQoCHLvhbtbY+W8uuhTykEDKqxCqpVbup7DvWujcCm03HeRGe936bIq0U533E8IwqUPXefH3U+a0HyzYbknvwf8mPpJkw3OsbxGP6Z+0sTynFIhLz/X7CeN17X42ddPGq/803V9Iq5Zx4Ovq2+U1VYd6DwEcnsl4hzcx0uF+URcM+6pcKcTcw4E8Ilx5igIIIAAAggggAACCCCAAAII9EiANvA94mNnBBBAAAEEEEAAAQQQQAABBBIjQACfGGeOggACCCCAAAIIIIAAAggggECPBAjge8THzggggAACCCCAAAIIIIAAAggkRoAAPjHOHAUBBBBAAAEEEEAAAQQQQACBHgkQwPeIj50RQAABBBBAAAEEEEAAAQQQSIwAAXxinDkKAggggAACCCCAAAIIIIAAAj0SyLvKTD3KgZ0dgdq6Bnn/06/ll5lzrZdu6F9R5myPNLNoyQo58bwbZORqQ2To4AGRklrbpkybKdNnzDZjbA4Km/anX2bJ86+Nk1lzF8pAMz52SXFR2HSRVur1fPzFd+aavpFvJk+TPr17yYB+5Z12WVFVI++Mm2heE2Tp8ioZMqi/FBYUOOn85mPv0NjYJO9+MlEK8vOlb3kfezXvCCCAAAIIIJAggc8mTBb9rqHfaRYsWiarDwv/fSP0dKL9PqPfId768CtZY8RQycsNfq7U3NIib5ttun3GrHnW95k+JcWhh+xyWcfg/vaH6db3mY/GT5Km5hbru0peXvDxAibdJ19Oljfe/8K67rI+vaVv2crvIX7zcZ/QF99MldnzFsnwoQPdq5lHAAEEui2Q3+092bGTwPIV1XLjPf+11i9eukJOP3Z/WfPkYZ3ShVvR1NRs/aGsqqkNtzlo3czZC+TSfz0k/fqWyXZbbBi0Tf8oHXXmP+W3WfNl843XlnkLl8qYm/8jxxz6R7nkrD8Hpe1q4fwx98hnE34wxym1kt7x7+etAoYn7r5MKsrb12n+J55/gyxavNwqTHj4qddl1OpD5dHbLnbS+MnHPhf943mJubZ3TYHABacdLif/eR97E+8IIIAAAgggkCCB/zz9lhXEVlXXylBTML/DVhv5OnI032c077se/p8888qHstM2GzvfG/RAy8wDgRPM94tfZ86TkcMHy1LzHev2h56Te68/T7bYeB1f52IneunNT+TKmx6VoqJCWcU8iHjwiVetBxs3XXG67LLdplYy/f5x8bUPWsH7CHO8ZeZ4t9z/jNx93bmy7ebrW2n85GMfU99ff2+8lef6a4+UbR5sz8O9nXkEEECgOwIE8N1R89hn2NBV5KP/3WFtXX/nEzxS9Wz1/idcZv0x01z6bdL56f4Tz70tP07/XZ59cIzoHwyd/n7dQ/K4Wf+Xo/7ku0aA7re9+WN9zkkHy4brjhL9w/bcqx/J1bc9Jk+/9IGccfwBmkQeffoNWVFZIy+Pvc4K4LW0/ugzrw1K4ycfKzPzn/5x/twUGjAhgAACCCCAQPIEHr71Iuvg54+516rxF+szuXfsS3KfeXlNN9//tMz4fb7oQ4PNNlxLqmvq5KizrpWrbxkrL/3nOsnPz/PatdP6VQevIv+69BTZd/dtRJ+6z5m3WA7+y5Vypyk8sAP4id//bAXvV5x3rPz5wN2k0TxYOebsa+Wme/9rjnetlaeffOyDa83FK258RIoKV9ZItLfxjgACCPREILjuUE9yYl9PAX1ifuQZ11iBtZ1Iq4zpuvFfT7FX+Xq//4YL5PUnbpBN1h8dNv2SZZWSm5Mjq/SvcLZvtN4oyTHrWlpbnXV+Zo4zT+01eNdJ999/z+2s9/nmqbs9adW2nbbZxKnKv/5aI6wn/29/NMFOIn7y0cRa5f8xU9Bw21VnWfvqMZkQQAABBBBAIHUE/nrFXTL2mbeCTmjMLf+xCuCDVnaxcOwhe1jfZ845+eCwKcd/PdX6rqPBu06lfUqsBxG/me9UM+csCLuP18qtNltXDjDfYewq8/rAZXPzFH/ewiXOLlpNv5d5Qn/Yvjtb6zTwPny/XWT6b3NMQcI8a52ffDShNl885/K75JB9d/Jdc8E6AP8hgAACPgQI4H0g9TRJbV29TP5xhmhbcHtqamqx1mkgH820qmkfr1W7vNq0773b1lJQkG+VGr/54ZeycMlyeeblD2X7LTeUQaYtfE8mbT+mT+JHrj7EykZLp7WK2ZojVw3KVpfdQX7QRrMQmo9u/3ziFLnm9sfkyvOPc6qqhe7HMgIIIIAAAggkV0D72Jm7YGXgq2ej7eR/jzKoLivtbX2fGVDRuW8d+woH9AuuaWi3w9cn6D2Z2tra5Lspv1jNAu18tJ2/fr9yP9lfc2R7M8j5i1Y+uLDT63u4fCpNs4Az/n676MOTy8452p2ceQQQQCAmAgTwMWFMnUw2Mk/Mzz/1MOuP60XXPCC7Hnq+1JgChFvHnNmjk9SO5W594FmrfdpBe+9g5aXt03QqKe5lvdv/6bIeUzufCZ3C5aN/+LWd/AlH7C2H/mmn0F1YRgABBBBAAIEsE9h0gzVl3Pjv5MPPvrUeHtTU1lsPAJRBH4z0ZNLq+/oAxd3Pjn6n6V0S+n2mvQNgfVgRbgrNR7/3nGtqKBQVFprvXWdJbkinfOHyYB0CCCAQrQBt4KMVS/H07338tRVo3/yPM0SD+WdNxzBjn31Ljjbtxp4x7eK70xZLO8Y72/xB0ipkD9x4gdMja2FHuy4tgXZPWlVfq/GH9ibrlc9F/3xA1ho1XI48YFerp1u7qn+l+eO6cPEyGbRKP3f2zCOAAAIIIIBAhgtoW3T93nH25XdagbB+17Cfjg8e2L/bV//Ui+/JA4+/Iscdtqf8cactnHy09mJryPcZe1lHxQmdwuXzyH/fkB9+nikP33KRaAd9+qpvaJTm5mbr+02F6RS4O9/DQo/NMgIIZLdA599I2e0Rk6vXaubhpoCEXx8ubXfXPWn+MK01apjss+tWVhbak/taawyXS0zPqp9+NVl2236zqLLWav/nXHGnfD91htxjemLdctN1nf0rzBBvGqhXmY5l3FNVdZ01/Ju75DlSPpVVtTLt19myxxEXurMR7dFeO9/79t2Hg9azgAACCCCAAALJE2gLBBfcx+NMdBjeF03ncd9P/dU016uSwav0N73Vf2D1l9PdIdk0wL7twWetvnlCR+bpb6ry//r73KBL0erwOvUPqcrvlY9+n9GA/WjT+V3otNvhF1jfo+xO80K3s4wAAgj4FSCA9ysVRTo7oLWfUJeXto8hWlnZ/odAswrE6Y/fItPmvbW1zapuZncCZ49Fv9R0cGdPOsydljMMHNDXXtXpXdvPn2nacS00Q8Q9evsl1hN9dyIN0LU9/CTTNt49TZoy3YznurJdfFf5/N89l5tzXtnBnp7/n479u1W17fD9d3FnzTwCCCCAAAIIJFCgsrpGCk2VcHvScdHd32d0faAtPg8o9CGB3WlvXX2j1Uu8dpzr/u6iVeu1Sn1fM7yt19NtfXp/wz1PyVMvvi/nnXKonHL0vvblOO+jTf897308UTRoLzft83WaZNrJW991hrf3/dNVPqcft78cddBuTp46c40ZvWfx0kozHN1fTQfD3t+5gnZiAQEEEIggQAAfASeaTTp8mgbFZaaX1Bfe+MT6hf+n3be2stDeTnVs9P88+6b1ZHrugsXm6fIb0WTvpNXxUBuamkT/YGmgq8ctNr2mav466R+2x0yVeR0a5aiDdpfFy1ZYVcW0AzvtgVUnHYpl18MuEP1j9eIj/7TWhftPx5PXTl20Tf0C04GLvuxp1+02s6qyHbjXDqbK/jNW7/HbbbGBvPnBlzJtxhxruBY7bVf56Piy7smukq9/jIcNWcW9iXkEEEAAAQQQiKOA9mHz/idfy+rDBlu14775froV9NqH3NGM1661494ZN0GKexXJS299Kt+Zp+R77PgHO4mv90VLVljfUebMb++Q7sfps6S8rLfpGHeYFJrq7Dq9Z85juPkONWvuIuu7TG5Orvw1pNf6C6++Tz4zw8++9vj1Vid04Q5+q3nq/uQL71nnqB3h6bnb03pm9Bz9rqHfkR547GW50gz9dtaJB5rOeJfJf55+0+pFfoAZO14nP/nYwb+dv/YLVFhYZ65joL2KdwQQQKBHAgTwPeJbufPX30+TG03prk5rr7GaXH7uMUHBp46bfocZ4/z4c6+3SogP2HN7q21XjgQPlRa6vPII7XPnXnmX6BAq9nT4qVdZVeZffPRaa9W5fznEanP1iKl+/u8nX7PW6R+mGy4/VYpMoK/TV5N+snpOPcYM4RJp0iHpdNKx2UOn8a/eK9qD7PGmDdnMWfPllvufscZK1SFaTjpyb9n/j9s6u/jJx0nMDAIIIIAAAggkTUCbvF12fXvTtX6mGrt2XHvYfjs756OB7kTzPULHh9dpx603ah9KNmTo166+zzz76odyvwmY7emUv91szepQudobvE4XXHWv9bBCA/qN11tDnn3oKlOwMMjapv9pp3H6/Wvbzdd39nE2umaWmCfgOr1r+gnSl3sac8HxorX99LuS9h/0j5sflfc//cZKsskGo+WfF5/kJPeTj5O4Y0ZZQmhCk7CMAAIIRCWQY9prx6feU1SnkRmJl1dWS0tLq2cVqTZDrcHuMFMKa5cux+vK9Qn9PDPMi5b8Dh0ywGqrbh/r2jufkDff/1I+eP52z+pmdlq/79rmS4eV0RJmrypsfvMiHQIIIIAAAggkT0D/pi+vrDHtzis8e1LX4WKLi4ucjm3jcbb6dL7JDFmrtQHsMdzdx5nw3U9ywrk3yP03XGAVJLi3dXdev6vNNk/8ddz5fqbTOSYEEEAg1QR4Ah/DO1JhqnxHmrQtl13VPVK6WGzr07vY6rwuXF5fmDHXD913p5gG2lqNbrSr3Xu447IOAQQQQAABBFJfQP+m6yvSNCSk+VuktN3d1lUzui8mTrWeyO+w1YbdPUSn/fS7mvspf6cErEAAAQSSLMA48Em+AYk+vLab322HP8jRB0euPp/o8+J4CCCAAAIIIIBANAKrmer0l/31GFNFPbg5YjR5kBYBBBBINwGq0KfbHeN8EUAAAQQQQAABBBBAAAEEslKAJ/BZedu5aAQQQAABBBBAAAEEEEAAgXQTIIBPtzvG+SKAAAIIIIAAAggggAACCGSlAAF8Vt52LhoBBBBAAAEEEEAAAQQQQCDdBAjg0+2Ocb4IIIAAAggggAACCCCAAAJZKUAAn5W3nYtGAAEEEEAAAQQQQAABBBBINwEC+HS7Y5wvAggggAACCCCAAAIIIIBAVgoQwGflbeeiEUAAAQQQQAABBBBAAAEE0k2AAD7d7hjniwACCCCAAAIIIIAAAgggkJUCBPBZedu5aAQQQAABBBBAAAEEEEAAgXQTIIBPtzvG+SKAAAIIIIAAAggggAACCGSlAAF8Vt52LhoBBBBAAAEEEEAAAQQQQCDdBAjg0+2Ocb4IIIAAAgjEQCAQCEh1TZ3U1TfGIDeyQAABBBBAAIFECOQn4iAcAwEEEEAAgUwV2G7/s6Wquta6vJzcHCkp7iV9y/rIHzZaSw7ddyfZdIM1u33pH30+ST6b8IOccMResurgAd3KxyuPWXMXyT7HXCLrjF5N/vfwNd3Km50QQAABBBBAILECPIFPrDdHQwABBBDIMIGW1lYpKMiXg/fZUfbdfRvZeL01pKmpWV5661M55uzr5KH/e7XbV/ztD9PlqRffk8VLVsQ8j+JeRbL1ZutZ59vtzNkRAQQQQAABBBIqwBP4hHJzMAQQQACBTBQo7VMiV190onNpbW1t8va4CXLFDY/IXY+8IMOGrCL77La1sz0VZgYO6CuP3HZxKpwK54AAAggggAACPgUI4H1CkQwBBBBAAAG/Arm5ubL3LltZ1enPufxOufyGh2XHbTaWPiXFVhZffz9N7hv7ksyZv1iWLKu0nuCPHrGqHHvoH2XPnbew0jz5wnvy+vtfWPPX3fWElPXpbc0feeCusseOm1vz75hCgsefe0d+/nWWFBYUyAbrjJSLz/yzrDFiaJd57LTNJnLGJbfJRqbGwLl/OcRK//TLH8i74ybKOScdLM+/Ps5U358sjaY2wXabbyBj/naCVFbVyh0PPSdfTfrJtJ1vkC02WVeuMQUXA/qVW/vb/3V1XnY63hFAAAEEEEAgOgEC+Oi8SI0AAggggIBvgZ223tgE5FvKGyYQn/zjDNnmD+tb+07/bY588c1UK9DeatN1pa6hUSb98ItccNW9csc1Z1sBugbIDQ1NVvqq6jppaWm15us71j3w+Cty96MvSH5+nmy3xYYyb8ES+fSryTLxu5/ltcevlyGD+ltBtlcerabqv56DVv+3p5mzF1jrvvz2R8kxK9cwhQpawPDGB1/KjFnzZfa8RVJvOr3T9Xo+48ZPkvsfe1muPP84Owvxc15OYmYQQAABBBBAICqBlX+1o9qNxAgggAACCCDgR0CfimsA/93UX50AfkcT2L//7G0yeGA/J4tJU36Ro8+6Vl55+zMrgD/l6H2lprZeHn7qdbnx8tNkkw1GO2l/n7PQCpTXGjVMHrn1YulXUWZt0yfo/7z9cWt7e9uWAAAizElEQVQfDaoj5VFvCg28ph232kjGXHi8DFqln9TU1cuBJ14hP/0yS3bZblP5x/nHi1a/13Pb//jL5POJU5xs/J6XswMzCCCAAAIIIBCVAJ3YRcVFYgQQQAABBKITGDF8sLXDr7/NdXYcap6Oa/C+vLLaeuL9sgna9Ql8QX6+aO/wXU1vffiVNLe0WFXu+5b3EW1zr6+9dtlS8vJy5cfpv3eVRcTt55x8sBW8ayKt9v+HDdey0p93yqFW8G6t710sm5n1s+YulIWLl1nb431e1kH4DwEEEEAAgSwW4Al8Ft98Lh0BBBBAIP4CCxa1B7erDRvkHGxFVY1cceMjMs4ME9dmxmN3T6HL7m32/O9zFlizV970qOgrdFqweHnoqh4t9zHBuk5trW1B+fTu3ctarqltMAG/SKLPK+hkWEAAAQQQQCALBAjgs+Amc4kIIIAAAskT+Gn6LOvg9lNsXTj1oltlys+/ybZbbCCH/mknGbX6EKsjuP2Ou8zXidbWNVjpTj1mv04dyOmG3iXtgbWvzHwk0vHtw015prM+95To83Ifm3kEEEAAAQSyQYAAPhvuMteIAAIIIJAUAQ3SX3nnM6ujuY3WX8M6h6XLq6zgfZ3Rq8m/b/5b0Hl5Bco61rx7Wr3jaf6mG6wpO269kXuT53xoHp4Je7ChO+fVg8OxKwIIIIAAAlknEFx0nnWXzwUjgAACCCAQe4GAqRavQ7Cdeekd0tDYZA21Zg8ht2TZCuuA7t7fdcWvM+dJXceTdfuMysv6WLPzFi61V1nv2vZcp3vHvmi1hbcWOv7TTufGffGds8orDydBDGeiOa8YHpasEEAAAQQQyBoBnsBnza3mQhFAAAEE4iVQXVMn/zBt0bVjOX3C/psZcs0Ous8/9TA5YM/tnUOPXG2o9Otbag0rd+6Vd8t6a42QX8ywcu9+/HWnYHx9s00nHXt90ZLl1pjs6689QnbedhPZfssNrWHjtIf4A/fa3qo2r9X1P/z8W1l/7ZGiQ9jp5JWHDl8X6yma84r1sckPAQT+v73zgK+ieOL4BJCiIE16L4J0KXZEEbBQpIkgXVAEFEGwoZQ/0kVROqjUACJVelUREUVAAbHQpFgAkRIbHf7z2+ReLi+vJg/Mcb/hQ/Lelb3d7+xdbnZmZ0mABEjADQRowLtBy2wjCZAACZDAZSMQFRVlDOt5y9aZDPBZM2cyBnqj2tWkSb17pXypogmunVbXXX+jT2d5vv84WfPZFvM/Q/p00rrJ/fLBok9Ei/PIbZVKSZd2jWS+lv2WGvGQnl1amN8j+ncxS8nNmL9a3n53rtmGHwhjr1G1kue7vzIsAz6V7YJoC8T6bRViHeMd4m8dl8o2Rz7Uelll8zcJkAAJkAAJkEDoBKI0zC9h+tvQz+WRJEACJEACJEACSSRwRkPr9x44ZM4uUjC3wIj3J/hTjTXWM2W8VrLHrfluHYt98M6fiPlbsDzd9Zmus3Yl+B2ojAQHRuhLqPWK0OVYDAmQAAmQAAm4ggANeFeomY0kARIgARIgARIgARIgARIgARJwOgEmsXO6Bll/EiABEiABEiABEiABEiABEiABVxCgAe8KNbORJEACJEACJEACJEACJEACJEACTidAA97pGmT9SYAESIAESIAESIAESIAESIAEXEGABrwr1MxGkgAJkAAJkAAJkAAJkAAJkAAJOJ0ADXina5D1JwESIAESIAESIAESIAESIAEScAUBGvCuUDMbSQIkQAIkQAIkQAIkQAIkQAIk4HQCNOCdrkHWnwRIgARIgARIgARIgARIgARIwBUEaMC7Qs1sJAmQAAmQAAmQAAmQAAmQAAmQgNMJ0IB3ugZZfxIgARIgARIgARIgARIgARIgAVcQoAHvCjWzkSRAAiRAAiRAAiRAAiRAAiRAAk4nQAPe6Rpk/UmABEiABEiABEiABEiABEiABFxBgAa8K9TMRpIACZAACZAACZAACZAACZAACTidAA14p2uQ9ScBEiABEiABEiABEiABEiABEnAFARrwrlAzG0kCJEACJEACJEACJEACJEACJOB0AjTgna5B1p8ESIAESIAESIAESIAESIAESMAVBGjAu0LNbCQJkAAJkAAJkAAJkAAJkAAJkIDTCdCAd7oGWX8SIAESIAESIAESIAESIAESIAFXEKAB7wo1s5EkQAIkQAIkQAIkQAIkQAIkQAJOJ0AD3ukaZP1JgARIgARIgARIgARIgARIgARcQYAGvCvUzEaSAAmQAAmQAAmQAAmQAAmQAAk4nQANeKdrkPUnARIgARIgARIgARIgARIgARJwBQEa8K5QMxtJAiRAAiRAAiRAAiRAAiRAAiTgdAI04J2uQdafBEiABEiABEiABEiABEiABEjAFQRowLtCzWwkCZAACZAACZAACZAACZAACZCA0wnQgHe6Bll/EiABEiABEiABEiABEiABEiABVxCgAe8KNbORJEACJEACJEACJEACJEACJEACTidAA97pGmT9SYAESIAESIAESIAESIAESIAEXEGABrwr1MxGkgAJkAAJkAAJkAAJkAAJkAAJOJ1AGqc3gPUnARK4Ogls2b5Lfj92wjQudapUkitHNilXqqikiooK2uCDvx6R73btD3hchdLFJW+u7AGPCXfn/GXrZMHy9RI96pVwT3Xs8Vu/2yM79/4sjWtXkzRpUkekHb8cOirf/viTKStKoiRDhnRSqnghyXlDloiUH0ohi1dvkOszXSf33F4hlMMjfszFixelW5/Rcv7CRRnZv0vE2Ea8olegwF3av3oPmyQPVb9N2jZ98Apc8b+5RKT73AXtO6vWbfI05po0aSRf7huk1I2FPNsu94fjJ/+S1es2y6033yRFCua53JfzWf7e/b9Jz0HvyAP33iLtm9fxeUxK2gi9deszSi5cvCSjBjwrqVPT15aS9MO6kEBKIEADPiVogXUgARJIRODdGUvks43bzcsLXmggBfLmlHFDngv6IvjFlu/lteFTE5Vp3zCo5xNS/4Gq9k3J/nz0WEzQgYNkX+Q/KuDw78elZtMe8na/Z6RmtcqeWuDlfMoHK6ROjdslY5oMnu3J+bBp64/Sa+hESaUDN3LpklzU//jcpskD8nynpskpOtG5/tr19rtzpagaHP+VAT9zwUeyftMOmTW2t6uMd/Slt96dI9vWTPToqkSxAmp83Soj3psr9955sxQukNuzz4kffLUR7Yh0nztz9pw832+cQQQj0HqOYiAUz9GsmTNFFF/zzv0lX54cMqx3R0+5GIzDs7jfC48HfW57Torgh0v67Og3fIr5O9LykfsjWHJkivL1/IGuuj75iDTr+JpMm7tSHm/6UGQuxlJIgASuGgI04K8aVbIhJHDlCWzfLjIu9v1QOnUSKV8+snUoXaKQzHmnn5w9d142bf1Buv9vrPTQF9L5E18LeKEm9e6VRrXv9hzTussgSZ8+nbwzrIdnW5rUkfEWewpMIR+2Hd4mYzePldSpUkvnKp2lbM6yEakZjGi8DOOfXbq0ayTtm9WWjNdFxni3l718+lDJnzeHHD12UoaMnimTP1gu91WtKJXKlbAflqzP/to1f2J/ZfjfeL5+/+OkjJw4Tzq0rCswXt0k6F8X4wbs7O2G533Vp5vktbemyqThL9l3XZ7PF06LHJyj/+eK5KstUriFSJqMEbmWvzZerj7XvUMT43k+c+asLF79hfzvzSkyftoi6dlF2xRBuaBRI5fUa2yXMiUKy2cLRkrGjNfaN1+xzwuWfyaIEgLbdGmvuWLXDfVC/p4/xQvnk05t6suYyR/Kgzp4lSfC0WKh1o/HkQAJpEwCNOBTpl5YKxJI8QSWLROpY4tGHD9eZOlSkdr6rhtpSXtNGrnrlnLS8KG7Zfq81bLjx30yYES0PNWynlS/q6Lnch9//rW8M32JvNGnk+RXT5AlURp2j9B7hJBagjD7QSNnmJe72PLLysv6QptZw6YhePH7cMV6ee2FdjJp1jLZs/9Xafvog1KjaiWZOmelLNEXYXiX8uTMburQ9YnGsUWrkYvzps1ZJb/q/lr3VJEnNGzzSngNF+1cJPVn1Y+th/4ct2mcrGy5Uu4vlnzP07O9Rppyh0+YIxPfX2ZYYqrAyrWbZM7itTJ99Ktmv8UNuvLFIHruKlnxyVcyQQdTMl4bb/QPGjldjp/4S97oqyNBXpIjexZp/1gdc97ufb8aA37/z4flZQ2L7du9jSck+OSff0vHl4YLdHFH5TJy5Ohx6aph6PXvv0vWfrFVtu7YI6V0UKh1k/vlvrsqmav4a9dQHTDIq+HGzzze0Bz30oAJki3r9XJWvZprPtsi6FOYNvBo/eryxthZgqiPXDmySotGNXXwqJqnBV9984N6jueZaQbXqxFT4+7K0v2pJpJBB5T8SbR63VC+t+fNqgPC61ev2yJp1FPXqE41c5xlnGCwC57c1Wrsnoj5W24qXtBELdxcpri/y5ntn3z+jYyatEB+OvCbMRYKF8hldDxSQ3gh4ISBE3sIe983JkuW6zPKc2ogQsZHL5JFKz+XP47H6MSHKClZvIB0ad9Ibqlwk9kfrG9s2vajub9h1DTrFDtId9ctZQWDRLh/oYunXnxTvtmxWyqWvdGUedl+rNWH25GPY4v/dZHITu3/dXbo9+BTeALVKVAb7X0uWN/dve8X6f36pIDPwGxZrk9QlXTp0sojde+R92YuFZxvycwFa2Tdl9tl/NDu1iZZ9vFGvX9XyvsaAYK+GEx3oybOlz16bx789XeP7l7o1EwK5sspXbTvPN+xqVSpUNKUg7Ie1nsSz4JfD/9htg98+QmZu+RTWbhyvfz197/mWY9wd+t5jD6PeqN/4ZwCWu6TLepKvVp3eurs68O4qQvN1AsYxHb57cgxGfB2tGzWPoe/CxX0/jh+8k8Z3PNJEykQChNM8xoyeoYcOnJc/j19RnLr/f9I3XulXbOHzKWC6RAH+Xv+YB+eU5P0WTtl9oqID7agfAoJkIBzCcS/zTq3Daw5CZBABAhUqRJeIXv2JD6+eXOR4oHthEQnbd6caJPfDXixg+e8pHol//zrH+ORtRvwk95frmGiFxIY774K+/vfU9LimYHmVRxh2TFa1ryln8pPBw/JrHF9zAsrvKCbt+2Uhu17S/FCedWYy25CUAePmil4ubuzShlp+nB12fnTz8agtwx4hK2+Of4DafBgVcmkBtukWcvlnBpVQ3s95asqfrdduHhBbnvvNr/7fe3YfXx3os1N5zaVYlmLJdrubwM89xuf2JhoN0LJf9h9QCqULmaMwqhUsYYMvOPWfHWcZHGDIeiLAV7i4U1fuOJzY+ziHISRvv/hx9LNGgTBRi/Z/8ths6VinCH6j+rw2x9+kn/+VU9pnJw9e95sgyEPOXX6rPmOAZ+H7rvNeLRWrP1KYAhvWDzGvLj7axcMHMw/t2SXft+15meBIdxaQ3F37NxvDFYM7tysxuTj+tKO0H8YVXffVl4w6ID+06776/q9nPTt0UZ2//SL9p2PTBRDr66trKIT/f5+1wF54J5bEnkMrTqUvamIPNbgPvlZjSUYTiWK5vcMSPTVueIwvjBfvNSNBeWDRZ9Im66DZeHkgX4HkWBUPvPqCBPt0E1Dd6HbWaoP3EuW/LjnoMlDYX3Hbwxq5ciW2bMJ9+c9d9xs7s/zei7KeLrn2/LR7OHmXgjWN3Jmz2racuToCeN1RMHFi8QbXrjnbtDrgU9YBvy+aDXAR3jqGfQDvO8x3yU8LOZ7kcU6EHFNGGHnRVqKlOyWoJxAbbT3uWB9FwZpsGfgv6fOJLg2vkBHx07ESO0a8c8W3H/f79qf4FgMwuD+gj8dd3ow3ZUvU0wy62AOBnTgMYYgZ8WZM+dMOX/+/Y/ZhnJg+B745Ygx0hEuDiO15qPdJbvqFoNt586f12f7Cj0/q7RsXMucN3TM+4IcIxgYxD2IQcCXB74juXNm8wwQmQNtP/Bch6H+v+cTGvmIRGjz7CAzwNXgoapSWnMCfLT+a1PPf0/FPk9CYYK/I4Xz5zYDdhic+3zTd+bZjzrV1udNMB1i4MDf8wfNwP4Hq99qnru2ZvEjCZAACQgNeHYCEiABQ2DLluSDiIkRiUQ5Vk3OnbsgR/44ISdj/jIeokWrNpi51teoR75ZgxoCj9UuNYpgwOzce9B45uDJCSbzlq5Tb++fMm3kK1K5fGw4dqH8uYxH5ovN38md6vWDYN71hNe7e14QUZcXXhunc+fvkkHqqbHkyeZ1rY/mpWtp9BCTAA0b8QI788OPBB4kM6fbc2TgDwiz3XIo+Uo5eVpfmMMoJ00q338WGqvnDh7WGndXklrVAo/24MXTHwMk0Lq5bHGZtfBjjwE/e/Enyi214Bp2+fTLbWoQXGcGVmbMXyO3ViyVpJDyAS+1N4MJKBu6bdiul8AzjqiOcNoF43TMoK5mgAdGxqfq1X9QDWXkU4A00frfUe9pfZHfYa43etJ8gaE1bki8ZxNecURvBDLgd+mgUN1ad5gyvX/ghX/M4G6mDtj39be7ZO3nW40Bf0iNFYRIP6b3xqtd1XhUgYeyWqOuMlkHkjAP2ZeMn7pIja/rZFn0UE/CrF9+O2ra5+t4f9vgcYVgrvUfaiRCp68Mfs/co9Z9Fqhv4B6Ejtdv/DaBp9+6Hu4fDCAhqV1YcvqIyPHk30vy166wLiu5qic6PlgbvU8I1HdDfQbu1GckDF54mOcuWacDQ2mlbk3f/cv7+vbvgXSHfpkje2YpkCdnAt2hH3kLylkybbAZ1MG+Az8fkY3ffC+Lpw7yRKZgkGb9V98aAx6DhBj46tT6YenctoEpDjkR7m7YRZau+dLzfPa+jtVPKpZNOOVmoXrxYdhjShWeAZBCaoiv3bDVu4iA39Fm/Idg0LC0ThfAM2GrRojAgLckkA6DPX8qlbtRlqz5wiqKv0mABEjAEPD9pkY4JEACriMQjicccKZNExmpUaV2eVajbVu3tm9J3md4pO575DlTCEJo4X158ZnHzPeG6uEeoaHCs9Q47qNh1HjBy5Ylk3qWbg96UYR6IoQZxoAlCLmG7FavomXAY6DACv81+/RFGOG91eJe2swJ+gMeF0tSqUcJ2cstwdxFeMrgKYZHPlSBJ3xzhzDCE7Tgyd9MljGbxiS4xHN3PCctyrVIsC3QF4Q+J1eCMWiuBuaL6gWHEV1RX1DnaOhsHTUo4L2zy5sTZpuv8JjdolmsJw5/0b475M9ZMseXmydOVwh7DVcwmIBwYgiMEOg5c6Z4neI7pmPAewf5Mc7QbPB4L/MdP46pEQUvKLx39ikE1gEwVpC5O2+uG6xNCX6jLVYdsCO3TuGAMQLZq1EPyFNwe+XS5jt+IOz/Rh3gsodMe3bGfcAqAuj/yc12jUiHYeNmmWkp58/He+9Pn4n3BAfrG9518/6O+2nb93u9Nwf+XqSV+DKm/Z506bzI2no6+mYzPlOrnqvrvKFw5sGnz+X3EqHuCNR3Q30Grvhko3yk0z4w/QMrRSzV3BJJWYEjubqz2oxy7M/CG9Twx/1kn1aCwQBEfUAwbQYDoAi9X/Vp/DPxlEYYIJzen6BfY2DqWl3Fwi7YjukEVeKmdtj3hfP5739OCSIDkMgT97QlpzXyxy6BdGg/ztdn9HdcB4NznAfvixC3kYA7CdCAd6fe2WoSSESgcnxi8UT7fG0oprYvImyjNToV0krfkfv1E8kSwZW+imi26SGvPiXXXZvehPfiJc8SvADCS4mllzAXEl7N1hoODwMqmOBFFnOG7QYLrgE5r+Hu/gTh8RCES4YqqeJCzUM93joOhnTlPOEppUiWIiY8O3p7tKTSf60rtJa+9/SVzOniw5yt8q/kb28G9+tyTnjxRWSCMVg1GgJzx71lkYZ958tzg0Y9jBeEvq/Wl3csBWUX76R69n2+PqeOYPJCXxEV1jYY0hh4qHprOamvg03ekl69oL5ETzMSN07g65AE29CHreziZ8/F9k+rL1sHXquDVZjG4U8wHcFuUPk77uKl+CkF3sec0CiZVl0Gyo1F8ssIXfauRNECEqNeyUee7Ot9aILv3n0DO+MQJDjO+oLBC7ANS2BIh2tM3zldZEd/kaPrdRSkkkjpnhoTfk9Ylw10cJgtMEV5991Qn4Fd2zc2SeyQr6JHv7EyfPxsGdanY4KBoLCZao186S5Qm/3ts+4Z+/6oqPgEktYAECIOEMFgl+w6QOVP0CZfA5IYTE2f7ppEU1S8ywnGBCwxmAS+t1S8yQzktug8wLuYBN+9dZhgp48v1mBdUvqLj+K4iQRI4CohkOYqaQebQQIkcIUJwFAfPVpkyJDYC2eMd3JGrCZY/xvzff1J84Y1TOIjJC5DSHMzTSgWiuAlEGGJ8PBYayJ/+fX35lQkR/InGFCAYHk7y0uP7+GGx+OcyyHZMmSTMbXHyJCaQ8yLa8a0kVNK+rgMztYgRnLqj4EYK5nWHo1qQHg1kq35ErzADtQQ9V8OHzVrOSNRHObAZs4U27aYmNi5tTj3UgAD01fZ2BbJdtmvgXoX1mXojqthi8SH1os4jjGGhe73JZg3jOW9Dv0e61X3dYy/bYXyxfbPLzWh3u2VYr3wmAe9Y+c+qanJ8/wJ1gbfppm67eJtrCM6ws4ax9ozjiOxHBLovdC5mYmWwP7TmtgrXMHABvjgfrYP2FnlwBNZUgcHLrvk0cSP+H/qkEiGPBG9XLA2hnOxcJ6BGPza93NDkzcBqzsg3wEEieLg5cVAkDWoeUk93uFKBvVqnz6b0Pscbhm+ji9aMK/ZjIgo734cyMhGrhSEtp/WgbT0WjdL0N9j/vxH9mnOE2ttenu+BxwXjAkisZDzAlFhj+nfoaRKsOcP+jsidZISMZHUOvE8EiCBlE8gfogz5deVNSQBEkiBBGC4Xw7jPZSmlixW0GTGRjKtGlUrJ0qy5a+MBvrSBQ881idG9mV48cdOWWg8KNacRl/nFtVkdpijO0+TKb31zhwz736pDgQ00DnVKUkypc0kkTTe0TaEYiPXwIfL15skYuCWHEECQDhS92k2+RaNYhNV+SsPuho9sKtk1SkSXTTZGubVwgCBPibPXm6SxSF79RPPv+GvCL/bI90u+4XaPvqAyXz/6pD3zMoJCDFH5u1gXukSxfLreXvtRYX0uVjhvCajN7J5T9PrIDndiwPGC8LZm9W/z28ZmL6AXBLIiI250gNHTDcrC9hPqHZHBVm3cZtZyg0DWJb30TqmfKliJjwbuQ2QpAz3BY4JV+7QRHUQrJWOpInbNZGaJTCatv+wN0l5EKwywv4dYeMd1w/UxnDrF+4zsGOrh83893dnLDFJ4XA96BaDLyN06UIkXhw75UMZPXlBuFXRqRtlzPkbNI8I+oA1lSTsgrxOwAoe1W4vLyN1NQfkwsDzHtfAyhWvaySPP7GWYMQycnbBNCsMqCE7/lxNXjpVs7xjSo9dgjHBlC5krke+C8yd36C/e+qqGKhbOBLs+YO6W+0Ip1weSwIkcHUToAF/deuXrSMBRxPwFf7o3aD7dZk2iJWt2Hu/r+/wZgzv97RZBq7Ty8NNNuPUGuoOIxFzIyF+HKQyVEP6MR8bmZMbte9jzrXmK/s6xwoPtXtgfdXJCduwrNMBzQbfpENf6dZnlKky2mXXU6gMcuXIJuVLF5Vcmmna26vmKzQX2cfHavI2eNM6vvSmwLOMdZKPalZrZFnv9+ZUqVK+ZGydtEZ2SWULx/Vstx3is10JWoVM3DjBdhK+mU3e2/R73Kb6D1Q1yeQ+/WKbNO3Yz/wfrvP6EWYeSBAVgikDMKrs4rsOutVWBfRPeBWR4LFt1yGCpIy9urXyeMXt5VmfkUEf2a6xlByM7q3f7TZRDtZ+/EbiRmTrfq7vGLNUH7J1F8yn4cxxF4d+oA8kHmutGb57D5ssxQrFZpC3+oe9nlbZ3vcHjDUszzcherEZ6HhfV3ywBJEFyGJuRc1Y2532218bwcmmStOsYH0XB/l7BnruIy/w/TWpI6JY+ukAJgZ50B8frVddZugSnbiXsAwmBirt4lWE2eWtO2S2R1kdXnjD9IEfNbGoJVbLfJWDbdaqFtbx5rft4MGvdNB2YurNTKnf9lV58vlhZj78TbrSgj9B1AjykyxauSHBIRjowvKT8G731X46YfpiM9XFflAoTDq3rW+Wcnz6lbflSW0zclf4CukPpkNfzx/UBQNvy3VFCawmQSEBEiABO4EoDT/i1Bo7EX4mARJwFIG23YZokrh/Zf7E18KuNzx6WIoL8+bDTRCE+c2HdbkrhHTbwzPDroTDTsCfjEOapC27esOtwY6kNAGGWK1mPaRzmwbyVCtNGJZEgQ73ayhs/rw5Q8p/4O8ykWqXv/Ix1x8v5FgaywpT9ncsPJf12vSUDi3rmfwO/o4LtB2rLCB8GEY2EpeFIkishzrC8IEXHhm1V81KGNUAowdTW7wTDlrl4744+NvvZilHe1Iya3+ovzFQc1Iz9ufU+wveTuinpS79iMz2U0bofPSrQLzbmNQmJecZaL8m9I/QcoSYJ0eOad9DH/fXR5JTNsL8rT7oy1j2LnvO4rUyYES0LJjY30Ts2Peb1RKOnzT35Nff7jaDDrMn9JUyJYt4DguFyd79v5lkeRjESqr4ev4gMmCkLhO5SLPzJ1cnSa0XzyMBEkiZBOiBT5l6Ya1IgARCIIClhjAPsUXjmiEcnfgQGAaYDx+u8Y6SYLziXDcZ72g3PO6IYEiO8Y5yZsxfbQyzJvXuxdckC3SIUPpQkhcGukik2uXvGlgXHv0smPGO8+E1fKZdIxk3bVHA7PH+roXtCM0Fl1CNd5yDubbBjC60IdAx6BfwXibHeEddcF+BA/QLwZSA73bul7492prvV8MP7zYmpU3JfQbarwn9R8JQhGEdqI/YrxnuZ9w/mD4TivGOspFrA3lUer8+KVFEC8pCJFCg6KhQmMCjnxzjHfX0fv5gfj6mMSCqJRI6wTUoJEACVw8BGvBXjy7ZEhJwHYH1X203S8HVDWHpONfBScENhrcJc5sx9x1L/1ESE2jVuJbcrmHMb2rGcCR0u9IC4xmGSUqQnRqKvXjVBunSrqEn6VhKqFdKqAOfgYG1AMO4b/e2cur0WYmes9LvwRhwQj6B9OkSLjnn94TLuAORAcPGfWDyu7R99MHLeCUWTQIk4FQCDKF3quZYbxIgARIgARIgARIgARIgARIgAVcRoAfeVepmY0mABEiABEiABEiABEiABEiABJxKgAa8UzXHepMACZAACZAACZAACZAACZAACbiKAA14V6mbjSUBEiABEiABEiABEiABEiABEnAqARrwTtUc600CJEACJEACJEACJEACJEACJOAqAjTgXaVuNpYESIAESIAESIAESIAESIAESMCpBGjAO1VzrDcJkAAJkAAJkAAJkAAJkAAJkICrCNCAd5W62VgSIAESIAESIAESIAESIAESIAGnEqAB71TNsd4kQAIkQAIkQAIkQAIkQAIkQAKuIkAD3lXqZmNJgARIgARIgARIgARIgARIgAScSoAGvFM1x3qTAAmQAAmQAAmQAAmQAAmQAAm4igANeFepm40lARIgARIgARIgARIgARIgARJwKgEa8E7VHOtNAiRAAiRAAiRAAiRAAiRAAiTgKgI04F2lbjaWBEiABEiABEiABEiABEiABEjAqQRowDtVc6w3CZAACZAACZAACZAACZAACZCAqwjQgHeVutlYEiABEiABEiABEiABEiABEiABpxKgAe9UzbHeJEACJEACJEACJEACJEACJEACriJAA95V6mZjSYAESIAESIAESIAESIAESIAEnEqABrxTNcd6kwAJkAAJkAAJkAAJkAAJkAAJuIoADXhXqZuNJQESIAESIAESIAESIAESIAEScCqB/wMwBPzD6SYE5wAAAABJRU5ErkJggg==",
+      "text/html": [
+       "<div>                            <div id=\"331571e8-9b1d-42f1-9ac4-bf2c8820a2d2\" class=\"plotly-graph-div\" style=\"height:800px; width:1000px;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"331571e8-9b1d-42f1-9ac4-bf2c8820a2d2\")) {                    Plotly.newPlot(                        \"331571e8-9b1d-42f1-9ac4-bf2c8820a2d2\",                        [{\"line\":{\"color\":\"blue\"},\"mode\":\"lines+markers\",\"name\":\"PyTorch\",\"showlegend\":true,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:04:12\"],\"y\":[11.44523000717163,11.552532196044922],\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"line\":{\"color\":\"green\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (no quant)\",\"showlegend\":true,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:04:12\"],\"y\":[10.546698331832886,10.451820135116575],\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"line\":{\"color\":\"orange\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (quant)\",\"showlegend\":true,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:04:12\"],\"y\":[71.7505316734314,72.08225703239441],\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"line\":{\"color\":\"blue\"},\"mode\":\"lines+markers\",\"name\":\"PyTorch\",\"showlegend\":false,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:03:05\"],\"y\":[7.714339017868042,7.563920259475708],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"line\":{\"color\":\"green\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (no quant)\",\"showlegend\":false,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:03:05\"],\"y\":[7.511744976043701,6.604063987731934],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"line\":{\"color\":\"orange\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (quant)\",\"showlegend\":false,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:03:05\"],\"y\":[12.869556903839111,12.067646026611328],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"}],                        {\"template\":{\"data\":{\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"white\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"#C8D4E3\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"white\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"radialaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"yaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"zaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"caxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"matches\":\"x2\",\"showticklabels\":false},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.575,1.0],\"title\":{\"text\":\"Time (s)\"}},\"xaxis2\":{\"anchor\":\"y2\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Datetime\"}},\"yaxis2\":{\"anchor\":\"x2\",\"domain\":[0.0,0.425],\"title\":{\"text\":\"Time (s)\"}},\"annotations\":[{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"x86\",\"x\":0.5,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":1.0,\"yanchor\":\"bottom\",\"yref\":\"paper\"},{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"ARM\",\"x\":0.5,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":0.425,\"yanchor\":\"bottom\",\"yref\":\"paper\"}],\"legend\":{\"orientation\":\"h\",\"yanchor\":\"bottom\",\"y\":-0.2,\"xanchor\":\"center\",\"x\":0.5,\"itemclick\":false,\"itemdoubleclick\":false},\"font\":{\"size\":14},\"margin\":{\"t\":100,\"b\":50},\"height\":800,\"width\":1000,\"showlegend\":true,\"title\":{\"text\":\"Execution Time History\"}},                        {\"displayModeBar\": false, \"responsive\": true}                    ).then(function(){\n",
+       "                            \n",
+       "var gd = document.getElementById('331571e8-9b1d-42f1-9ac4-bf2c8820a2d2');\n",
+       "var x = new MutationObserver(function (mutations, observer) {{\n",
+       "        var display = window.getComputedStyle(gd).display;\n",
+       "        if (!display || display === 'none') {{\n",
+       "            console.log([gd, 'removed!']);\n",
+       "            Plotly.purge(gd);\n",
+       "            observer.disconnect();\n",
+       "        }}\n",
+       "}});\n",
+       "\n",
+       "// Listen for the removal of the full notebook cells\n",
+       "var notebookContainer = gd.closest('#notebook-container');\n",
+       "if (notebookContainer) {{\n",
+       "    x.observe(notebookContainer, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "// Listen for the clearing of the current output cell\n",
+       "var outputEl = gd.closest('.output');\n",
+       "if (outputEl) {{\n",
+       "    x.observe(outputEl, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "                        })                };                });            </script>        </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#| label: fig-time\n",
+    "#| fig-cap: \"Time\"\n",
+    "\n",
+    "def plot_progress_subplot(fig, row, col, df, metric, showlegend):\n",
+    "    '''Plot evolution of execution time using Plotly.'''\n",
+    "    df_pytorch, df_trv, df_trq = split_dataframe(df)\n",
+    "\n",
+    "    fig.add_trace(go.Scatter(x=df_pytorch[\"Datetime\"], y=df_pytorch[metric], mode='lines+markers', name='PyTorch',\n",
+    "                             line=dict(color='blue'), showlegend=showlegend), row=row, col=col)\n",
+    "    fig.add_trace(go.Scatter(x=df_trv[\"Datetime\"], y=df_trv[metric], mode='lines+markers', name='tinyRuntime (no quant)',\n",
+    "                             line=dict(color='green'), showlegend=showlegend), row=row, col=col)\n",
+    "    fig.add_trace(go.Scatter(x=df_trq[\"Datetime\"], y=df_trq[metric], mode='lines+markers', name='tinyRuntime (quant)',\n",
+    "                             line=dict(color='orange'), showlegend=showlegend), row=row, col=col)\n",
+    "\n",
+    "def plot_progress(metric, ylabel, title):\n",
+    "    fig = make_subplots(rows=2, cols=1, subplot_titles=('x86', 'ARM'), shared_xaxes=True, vertical_spacing=0.15)\n",
+    "    \n",
+    "    plot_progress_subplot(fig, 1, 1, df_x86, metric, showlegend=True)\n",
+    "    plot_progress_subplot(fig, 2, 1, df_arm, metric, showlegend=False)\n",
+    "    \n",
+    "    fig.update_xaxes(title_text=\"Datetime\", row=2, col=1)\n",
+    "    fig.update_xaxes(showticklabels=False, row=1, col=1)\n",
+    "    fig.update_yaxes(title_text=ylabel, row=1, col=1)\n",
+    "    fig.update_yaxes(title_text=ylabel, row=2, col=1)\n",
+    "    \n",
+    "    fig.update_layout(height=800, width=1000, showlegend=True,\n",
+    "                      legend=dict(orientation=\"h\", yanchor=\"bottom\", y=-0.2, xanchor=\"center\", x=0.5),\n",
+    "                      legend_itemclick=False, legend_itemdoubleclick=False, font=dict(size=14), margin=dict(t=100, b=50),\n",
+    "                      template=\"plotly_white\", title=f\"{title} History\")\n",
+    "    fig.show(config={'displayModeBar': False})\n",
+    "\n",
+    "plot_progress(\"Time\", \"Time (s)\", \"Execution Time\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "3d292e47-13bb-472e-a800-e102dc6fcd1c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "displayModeBar": false,
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "color": "blue"
+         },
+         "mode": "lines+markers",
+         "name": "PyTorch",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:04:12"
+         ],
+         "xaxis": "x",
+         "y": [
+          44.93835258483887,
+          44.93835258483887
+         ],
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "green"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (no quant)",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:04:12"
+         ],
+         "xaxis": "x",
+         "y": [
+          44.66026306152344,
+          44.66026306152344
+         ],
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "orange"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (quant)",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:04:12"
+         ],
+         "xaxis": "x",
+         "y": [
+          11.949405670166016,
+          11.949405670166016
+         ],
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "blue"
+         },
+         "mode": "lines+markers",
+         "name": "PyTorch",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:03:05"
+         ],
+         "xaxis": "x2",
+         "y": [
+          44.93835258483887,
+          44.93835258483887
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "line": {
+          "color": "green"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (no quant)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:03:05"
+         ],
+         "xaxis": "x2",
+         "y": [
+          44.66026306152344,
+          44.66026306152344
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "line": {
+          "color": "orange"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (quant)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:03:05"
+         ],
+         "xaxis": "x2",
+         "y": [
+          11.949405670166016,
+          11.949405670166016
+         ],
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "x86",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "ARM",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 0.425,
+          "yanchor": "bottom",
+          "yref": "paper"
+         }
+        ],
+        "font": {
+         "size": 14
+        },
+        "height": 800,
+        "legend": {
+         "itemclick": false,
+         "itemdoubleclick": false,
+         "orientation": "h",
+         "x": 0.5,
+         "xanchor": "center",
+         "y": -0.2,
+         "yanchor": "bottom"
+        },
+        "margin": {
+         "b": 50,
+         "t": 100
+        },
+        "showlegend": true,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Model Size History"
+        },
+        "width": 1000,
+        "xaxis": {
+         "anchor": "y",
+         "autorange": true,
+         "domain": [
+          0,
+          1
+         ],
+         "matches": "x2",
+         "range": [
+          "2024-07-18 11:01:03.9559",
+          "2024-07-19 05:03:08.0441"
+         ],
+         "showticklabels": false,
+         "type": "date"
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "autorange": true,
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          "2024-07-18 11:01:03.9559",
+          "2024-07-19 05:03:08.0441"
+         ],
+         "title": {
+          "text": "Datetime"
+         },
+         "type": "date"
+        },
+        "yaxis": {
+         "anchor": "x",
+         "autorange": true,
+         "domain": [
+          0.575,
+          1
+         ],
+         "range": [
+          9.467315574382159,
+          47.42044268062273
+         ],
+         "title": {
+          "text": "Model size (MB)"
+         },
+         "type": "linear"
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "autorange": true,
+         "domain": [
+          0,
+          0.425
+         ],
+         "range": [
+          9.467315574382159,
+          47.42044268062273
+         ],
+         "title": {
+          "text": "Model size (MB)"
+         },
+         "type": "linear"
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA/AAAAMgCAYAAACEYYkhAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAD8KADAAQAAAABAAADIAAAAAAwD/peAABAAElEQVR4AezdB2AUVf7A8V96T0jovQoqKqigYlfsBRUr4CliORtnx/NOxYbn396wIqKeCGJBFJAqIgJSlENAQKV3SEhPNpvd/N+bsGs22UBCdmYzme/TsDuzs6983hD2t+/Nm4gylYSEAAIIIIAAAggggAACCCCAAAL1WiCyXteOyiGAAAIIIIAAAggggAACCCCAgCFAAM+JgAACCCCAAAIIIIAAAggggIANBAjgbdBJVBEBBBBAAAEEEEAAAQQQQAABAnjOAQQQQAABBBBAAAEEEEAAAQRsIEAAb4NOoooIIIAAAggggAACCCCAAAIIEMBzDiCAAAIIIIAAAggggAACCCBgAwECeBt0ElVEAAEEEEAAAQQQQAABBBBAgACecwABBBBAAAEEEEAAAQQQQAABGwgQwNugk6giAggggAACCCCAAAIIIIAAAgTwnAMIIIAAAggggAACCCCAAAII2ECAAN4GnUQVEUAAAQQQQAABBBBAAAEEECCA5xxAAAEEEEAAAQQQQAABBBBAwAYCBPA26CSqiAACCCCAAAIIIIAAAggggAABPOcAAggggAACCCCAAAIIIIAAAjYQIIC3QSdRRQQQQAABBBBAAAEEEEAAAQQI4DkHEEAAAQQQQAABBBBAAAEEELCBAAG8DTqJKiKAAAIIIIAAAggggAACCCBAAM85gAACCCCAAAIIIIAAAggggIANBAjgbdBJVBEBBBBAAAEEEEAAAQQQQAABAnjOAQQQQAABBBBAAAEEEEAAAQRsIEAAb4NOoooIIIAAAggggAACCCCAAAIIEMBzDiCAAAIIIIAAAggggAACCCBgAwECeBt0ElVEAAEEEEAAAQQQQAABBBBAgACecwABBBBAAAEEEEAAAQQQQAABGwgQwNugk6giAggggAACCCCAAAIIIIAAAgTwnAMIIIAAAggggAACCCCAAAII2ECAAN4GnUQVEUAAAQQQQAABBBBAAAEEECCA5xxAAAEEEEAAAQQQQAABBBBAwAYCBPA26CSqiAACCCCAAAIIIIAAAggggAABPOcAAggggAACCCCAAAIIIIAAAjYQIIC3QSdRRQQQQAABBBBAAAEEEEAAAQQI4DkHEEAAAQQQQAABBBBAAAEEELCBAAG8DTqJKiKAAAIIIIAAAggggAACCCAQDYF5Att3ZsrsH3+R5k3S5axTjz3ogqZ/v1h2Z+bIWaccI82bZhxUPl6vVyIiIoyfg8qANyGAAAIIIIAAAggggAACCIRVoEEF8Dpgvv/JNw3QJulp8vITdwYNWHPyCuTOf70i3jIV1Kr/Pnz1IYmMDP1khDXrNsvTr/5Xeh7RpU4B/HufTJEVq9dLh7bNaxXA6/eM+mSy/LZ2o2xTNlGqjU0bpxl5HH/0YdL3lGPl8K7t/SfggNuekKzsPLnnlivlvDOO8+8Px5PX3/9SFixdKVdceJpcdv4pQavw9Yz5Mu6r2dLrqG5GnX0H1bUdK9esl5zcAjm8WwdplJrsy5ZHBBBAAAEEEEAAAQQQQCCsAg0qgC8qdsmyFX/4QfXod9+Tj/Fv+5588uUs+fnXtb5NKSvzP20wT156Z4KMGjvZ35642BjxesuMQF4H87+s+F3e+miSLJ76tiQmxBnHbd2xRzL35kp+QZH/feF6sn7TdqMvT+x1RLVV2LEryzgmPS0l4Ji6tuPp1z428h35n7vl9D49A/JmAwEEEEAAAQQQQAABBBAIl0CDCuArI77z36+rBPAuV4l8/MWMyoc2qO25C5f7g/drLjlTzj/zeOnRvbNERkTKxi07ZPlv6+Tdj7+RDZt3BLRbz1gocZdK5/atAvbbbaOhtMNu7tQXAQQQQAABBBBAAAEEzBVokAG8vk5cjzjrKeTzl6yUE3t19yt+MfUHY5r4cWoK+aJffvPvr/zEq4bl123cJqv/2CRuFdR269xOunZqI9HRUZUPNbbL1PF/quN1maWlHunUvqWUqRHv/aVi9WXCmj83y+/rtkhCfKx06djaKGd/76nJa5NnLjAOO/m4I+WRe64LeEsnFZzrn4vPPlG+UcfFxvx1CrRp2UxcJSWSmpJkvEe3acv23QHvr7yRlBAvGempAbvNaldAIfvZqNyOiofuzsw2vHfszjLq3a5VM8PDd8yWbbuluLjE2Ny1e69s3rbL95K0adk04JIMfSnGb79vFD1boHWLpnLYIe3UJQqN/Mf7nuzcs1dKStzGpQs+bz3TobS0VBKUX05uvjpfY6VZk6rv1XnomQZudWwzlXdcXKwvWx4RQAABBBBAAAEEEEDAYQJ/RW8NqOFRkREy5Jrz5bEXxsg7apq4L4DXC7mN+fRb43r3GwdcUG0Ar6+lH/bU2wHT7DWPDnxfePQ26dq5bYBWlgrGHvrPuzJv0a8B+33BWsDOfRvfqen9jz7/vuj3Vkwn9j5CRjx4U7XBXMVjq3uuLyXQSS9aV12KioqUS849KeDloQ+/YnwB8c5z98lJvY+U3PxCOW/gsIBjKm+ce3pvefGxO/y7zWyXv5ADPKncDn24DoCfePFD+WraPPF4vAE5tGvdXF5Rsw+6qC9ozh34gP+1x1/8wP9cP/nhy1f9X1Z8MnGWPPfGOPWFh9t/TKTyvuXai+X2wZeK9vWl2//5kvFFkHZduWaDjJs4W3RQr9OdN1wm+np//aXJnM9eqhKg60Bf94Gu/5ejnzK+RPLlyyMCCCCAAAIIIIAAAgg4S6BBBvC6Cy8572QZOWaiLP7fGuN676OPOESmqdXc9QjrhWf1kbZq5DVY0sHvoDueMgIsHdhdeNYJEhMdLTN/WCKr1GJwA25/Uqb89xn/YnL6S4Eb73tW1qpR9OTEBLUwXPlK8Xrkeu7C/xlT0iuXM23OYrn3sZHGFwlX9ztDuh/aUX759XfRq83PX7xC/qW+DBj1wl+BZOX3H2hbf9Ewa97PsnDpKvls8vdGoK7bUNukZzFcqhwrJz3yrAN1nbSRL5nRrqIil+Sq8oIl3xcVwV6rvO/FtyfIF1PmSkpyopxzai/p0K6lcTnBTz//Jpu27jT6+xAVwOsvNb5f8D/JVqPivXt0k5bNG/uzio8vXyvgo8+myzOvjzW+ILlInUt6IcCNW3aq/H8w1hXILyySh4YO8r/P9+TuR1+XQtUenfS5UlhULL17HiqN1QwGHahPnrVQ+l9wqu9w43HCN3OM4L2XqoueAUJCAAEEEEAAAQQQQAAB5wrUPqqziZUe/b7uynPlhbfGi74W/s1n7pXRajV3PSp908ALq23F++OmGsFclw6t5eM3HjYCLX3wkAHnix5J1VPyX373M/nPv24x8hg/6TsjeNfTyD969V9qpfgW/rznzF8md/zrZf+2fqKDzv8b+Ymx76kHh6iAsTxAvlwFbveq1d9Pv+JuY/V1vcic/tLhYNKAy/rK2C9nSkFhsQx/7n15ddTn0rN7Fzm0Szs1zbu9HH3kITVaXT1eTdce8c+bAqqgLy24ddgLxj69ur4eQdbJrHa9P36q6J+6pqmzfzKyeOD2a0Rb+5L+AmbS9PlGoK7PjacfulkG3fmUsYjdYDWLo/IidvrLhDc//Mp4++MP3BCQl165/4Z7/k/06PyAS/sGnAv6DR51ScXdN18hOujXXwzo0fsYdUnGlRedbgT+emS+YgCv6/bppDlGWYP6n2U88gcCCCCAAAIIIIAAAgg4V+Cveb4N0ECPbusRV72o22gVmOsR9FNP6LHfkcwZc5cYEjeqIF+PkvqSHsG+Y3B5sDpj7lLfbvEFhnrKfsXg3TggyAz2RctWy051/bUO4C4660R/PvqJ/hKgd49DjX16RP9gk77v/H9ff1iOUCP7OunRXT0ir2ck3PnvV+S0/nfJ3Y++JvpSgdqm1977Qn5UswT0td4vP36nf00As9qVlBhvWGmvyj8V++dA7dCBsk6b1Ei5Dox9Sd8+UM8y0F/Y1CQt+mW1cYs5PfOg8u3t9LoK+nINPUVf3wGhcnr+0Vvl5kEXGe3Qr+kZDrr8q/qdbky5X7l2g/yqFhj0pdnzfjHOlRbNMuQsdcs/EgIIIIAAAggggAACCDhboMGOwOtu1cHfQDUa/fZHXxsj8XrfLddepB+CJr1o26at5YuWHaHuAV456fuC61FaPdq8a0+2cZ26XsBMp+OPPrzy4UG3N+w7fqdamKzvVfdWOWZvTp6xb+sBFo+r8sZKO/R06/FvDTdWmtf3U9cL5a1SC66tUYvy6ZXm9ZcQS9W0/W8+/I+k7Vu0rlIWVTZn/rDUWL1eL+Sng/eKC7aZ1a7rrzpPfXFyaZW66B16JX09G6Im6Rx1rf6Y8d8aq/Prxfv07em6q/7Utxms2I4D5bVRTbfXSU+b19e8V07du3U0Zmno1f4rp6SEv74QqviaXnTxTFWPGd8vUaP3s+XIwzoZL4+dONN41HcS0IE+CQEEEEAAAQQQQAABBJwt0KADeN21115+jlq4bpro28fpa5r1VPLqkp5yrldQ16lRanKVw/S0/Fg1aqrz2puTqxYeSzRWtNcHNs4IXIm9ypv37dihVjbXKb1Ryn5v11bdNfr7sqnxg54VUHFmgL7H+4cTphmj8XoBvc8nzzUW/DtQhnpFfn1tvv6SQ1/frafPV0xWt6ti2TV5/o8h/dX97uPlvbGTjVXd9fXw+udZdTnD1SpAvu/vV/lnE+wvvz1qFXudgp0fen9KUnmQvje7/IsYva8maaCacq8D+G+/+0kevHOAZGbliL4+X4/SX3HRaTXJgmMQQAABBBBAAAEEEECggQs0+AA+QwXK+ppnfU34zfsZfdf9nKyCLz0tWy9CtkcFUJVvj6ZH3nXwrlPTxumirxFPUAub6f05uQWip64fKOlp4Dr1OLyzvDbirgMdHvLXdRv1Kukz1Gj6WnULuy0VbpNWXWHa4x8Pv2pcU6+njesR4cop3O2qXJ/K2/r2a3ok/3q1LsLyVX/K8tXrRC+6pw30Fxq9e3aTM086JvBtQe4CqKez66TPj2Bpb06+sbtpNbeEC/YevU9Pv+/coZX8uWGb8cWC7/KG8888XtLTUqp7G/sRQAABBBBAAAEEEEDAQQKOmJf777uulZVzxhi3RjtQ37ZrU746/U9B7hGvr/PWSQfB+osBnVq1KA/Il6lF52qSOrdvaRz2s5q+rlc6NyPpkeWsA4wA+64f19O395f0iPu/nn5X1m/eoaacd6xyX3nfe61ol6+sujzqvtO36rv1b/3ky/eelH7nlK9DMLPCugYxUeXXyxe5yleMr1he+zblixQuW/lH0DsM+M4R33EV33ug5wMu6Wsc8oGaMTLx23nG80H9zz7Q23gdAQQQQAABBBBAAAEEHCLgiAC+Nn3pW5hs9LgpsrnC6LS+Nv2Vdz83suqvRqF9ybdK+Xvq+B3qunZfWrF6vYxU9/eunHqpRer0lHYdvD+o7jVfOdDWC9z9+5lRMmfBsspvrfH22C9nyfnq3uH6GvHKt2DbraaAv/XRJOMe9/oa7lOOP2q/+b6tVvDXC+DpLyxefXKoMaU72BusaFewcmuyT8+auOLm4fK9uq1f5bR9X58lJJTfIk6/7ptN8MPCXysfLn2OPdy4haAegdf3b6+Y9C37Vq5Zb8zKOO/04yq+VKPn/dQt7PS6DbqP9OUc+jIFfa09CQEEEEAAAQQQQAABBBDQAg1+Cn1tu/nqfmfKhK/nGLeG00GfXrU+OipS3dptlRFYNclIk9uuv8SfrV5kTd82TN9f/uLrH5JundsZx+n7wAdL+prmx++/QW667zmZt+hXI9DWgZoeGdYLzOn7ietbtR0osA6Wd8V9etq7XuBN/+iAtJO67/lmVUd9z3Nfukvd0mx/AeIGNeo+cnR5kKoXvrtn+Ou+t/of26rV2J99+O9GYG9Fu/wF1+KJngn/m1rAT98GUK8toNusL31YuWaD/L5+izFF3XeHAZ3tyccdadxa7qtp89QigNuN691Xq775/L0njGPvv+1qGfbkW8b19IvUTI1undsa/b/w51VGrf7+t4uNBQ6NjVr8oYP3i9WMAH07OZ0Yfa8FHocigAACCCCAAAIIIOAAgQYVwOsV4nWqyYrdvgXEfe/x9XWUCtb1LdiefOlDmaxWK58ya6HvJTUF/wjjvuipFVZtb6zv//7av2Wouj3bNnVbNn3/dp2OObKrWln8aHn+zfFqtfLAiQ691GJ6E99/Sp55faxxz3cdyPuSDuT7nnysHKGmq/uSb7XziEr5+F6v/PjksCGq7gvl2zmLjFvF6eupfddU6/bq1dfvuvFyYyp5xfdWLqegqNj4MkEfoxe/W17hFme+9xUVl68JoLdr2y5fHsEeI6S8L6uu8/7X0b76+h59r/i2fV568cHBV58n38xYYMyqqDizQq/4/uAdA/yXROg8Luh7gvyqZlB8/PkM+Z+6Xl6niufUBeq69FR1e8JHnn3PuO2b79Zvuu/0An/6tnQVU2Sk77zcX2vK33GsOm90AN9MXUN/zqm9KmbDcwQQQAABBBBAAAEEEHC4QIS6xjnIUl0OV9nXfL0ivb4fu1fd17tLx9bGKHl1MppRj57r6c+d1T3FfdfIV3e8b7++Z7gOKLPV4mctm2dIU7UQni8A9R1Tl0c9Er9z1141VT9X1SlV2rRqWu00+LqUU/m9Zrercnk13daXLPhu0de6RZMqCxVWzEcvTrh1xx6jP/SxeiG8ykl/abNZ3XqwedN0ademeZ377sZ7nxU9kj9UrZp/63X9KhfHNgIIIIAAAggggAACCDhYgADewZ1P0+uXwJo/N0n/Gx+VmOhomTXhRdGzO0gIIIAAAggggAACCCCAgE8gcG63by+PCCBguYBefV6n8844juDdcn0KRAABBBBAAAEEEECg/gsQwNf/PqKGDhDQdzmYMusno6WD+p/lgBbTRAQQQAABBBBAAAEEEKitAFPoayvG8QiYJFBa6jFyjo4uvw+9ScWQLQIIIIAAAggggAACCNhUgADeph1HtRFAAAEEEEAAAQQQQAABBJwlwBR6Z/U3rUUAAQQQQAABBBBAAAEEELCpAAG8TTuOaiOAAAIIIIAAAggggAACCDhLgADeWf1NaxFAAAEEEEAAAQQQQAABBGwqQABv046j2ggggAACCCCAAAIIIIAAAs4SIIB3Vn/TWgQQQAABBBBAAAEEEEAAAZsKEMDbtOOoNgIIIIAAAggggAACCCCAgLMECOCd1d+0FgEEEEAAAQQQQAABBBBAwKYCBPA27TiqjQACCCCAAAIIIIAAAggg4CwBAnhn9TetRQABBBBAAAEEEEAAAQQQsKkAAbxNO45qI4AAAggggAACCCCAAAIIOEuAAN5Z/U1rEUAAAQQQQAABBBBAAAEEbCpAAG/TjqPaCCCAAAIIIIAAAggggAACzhIggHdWf9NaBBBAAAEEEEAAAQQQQAABmwoQwNu046g2AggggAACCCCAAAIIIICAswQI4J3V37QWAQQQQAABBBBAAAEEEEDApgIE8DbtOKqNAAIIIIAAAggggAACCCDgLAECeGf1N61FAAEEEEAAAQQQQAABBBCwqQABvE07jmojgAACCCCAAAIIIIAAAgg4S4AA3ln9TWsRQAABBBBAAAEEEEAAAQRsKkAAb9OOo9oIIIAAAggggAACCCCAAALOEiCAd1Z/01oEEEAAAQQQQAABBBBAAAGbChDA27TjqDYCCCCAAAIIIIAAAggggICzBAjgndXftBYBBBBAAAEEEEAAAQQQQMCmAgTwNu04qo0AAggggAACCCCAAAIIIOAsAQJ4Z/U3rUUAAQQQQAABBBBAAAEEELCpAAG8TTuOaiOAAAIIIIAAAggggAACCDhLgADeWf1NaxFAAAEEEEAAAQQQQAABBGwqQABv046j2ggggAACCAQTKCsrk/yComAvVbvPXVpa7Wu8gAACCCCAAAL1RyC6/lSFmiCAAAIIIIDAwQps3LJTnntznCxYslKKXSWSmBAnp53QU+679Spp2bxxQLYej1fe+2SyLPx5laxau1Hy8gvl+qvOk2G3XxNwHBsIIIAAAgggUL8ECODrV39QGwQQQAABBGot4FWj7vcMHymbt+2UgZf1lW5d2sniX1bL51Pmypp1m+XzUU9IbEz5P/lZe3Pl7uGvy9Lla+VQddxFZ/eRMm+ZpKcl17pc3oAAAggggAAC1goQwFvrTWkIIIAAAgiEXGDyzAWy5s9NcsPV56sR96uN/C86q4/sytwrcxcul1VrNkjPI7oY+18Z9bkRvN96XT+584bLJCIiIuT1IUMEEEAAAQQQMEeAa+DNcSVXBBBAAAEE6iww+8ef5bp/PC3/N/KTgLx2Z2bLjfc+a4yke71eyc8vv+a9cUZqwHGHdmlvbJdJmfG4a0+2fDXtRzn+mMNk6JD+BO8BWmwggAACCCBQ/wUI4Ot/H1FDBBBAAAGHCpzep6ea+h4jH06YJp9O+s5Q0Nev3/f4G7Jk+Rq57opzJDIyUk7t00NioqPltfe+kI8+my4udQ383pw8mf79YmnRLEN6dC8ffZ8z/xfRC9bp0fmZPyyV0eOmygcq75Vr1jtUmGYjgAACCCBgL4EItVpt+dfy9qo3tUUAAQQQQMARAtm5+XLlzcNlT1aOfDzyEZk6e6EReD9232C58uLT/QbLf1snQ+75PykqdklyUoLxk5gQL+88e59/EbuX3pkgo8ZONkbe9T//UVGRor8Q0OmKi06Tx++/wZ8fTxBAAAEEEECg/gkwAl//+oQaIYAAAggg4BdolJosLz851Ai6b77/OXl//LdyzaVnBgTvetX5/34+Qx0j8s87B8qpxx8lerG6TVt3ylfTfxS9yJ1O23ZmGo/3q+vkf5j4miyfNVq+HfusHHlYJ/nsm+9l0vT5xuv8gQACCCCAAAL1U4AAvn72C7VCAAEEEEDAL9C9awcZMuAC0aPxOqDXQXrFpINvvZDdk8NulL+pafXPPXqbfDVmhHTr3M6YVr9w6Srj8IS4WOPx7NN6SUajFON521bN5JF7rjOeL1m22njkDwQQQAABBBConwIE8PWzX6gVAggggAACfgE9ff7zyd8b17vra9vfGzvF/5p+8t2PvxjbJxx7uH9/u9bN5Y4bLjW29bXvOrVr09x43LJtt/Ho+0NfP6+T/oKAhAACCCCAAAL1V4AAvv72DTVDAAEEEEBASks9xj3ec3IL5JM3HpEjDu0oI9//UuYt+tWvk5aaZDz/fsH//Pv0k9/XbTG2kxITjEf9Xp2+mjbPePT9MXvez8ZTfV94EgIIIIAAAgjUX4Gox1Sqv9WjZggggAACCDhb4OnXPpYZ3y+RR+6+Ts446Wjpc2x3mfjtPJkxd6mcd8ZxkpqSJDpAnzxzofz625/GonRxsdEyZdZP6nr5qRIVGSWP3nudpKmp921aNpUVq9ep1emXGKvUe71lxqr14yfNlpTkRBnx4I2SkBDnbHBajwACCCCAQD0WYBX6etw5VA0BBBBAwNkC+rr2YU+9LRf0PUGee+RWP8ZMFbzf9ehrokfMJ7zzmDG1/usZ8+X5N8cbq9X7DjzskPYqeL9ejlKL1PlSplrc7rHn35fZ+6bd6/16ZF5fP9+1UxvfYTwigAACCCCAQD0UIICvh51ClRBAAAEEEDgYAX1LuC3bdxtBfOsWTaR503Rj9fpgeeXkFcimLTuN+8Q3bdwo2CHsQwABBBBAAIF6JkAAX886hOoggAACCCCAAAIIIIAAAgggEEyAReyCqbAPAQQQQAABBBBAAAEEEEAAgXomQABfzzqE6iCAAAIIIIAAAggggAACCCAQTIAAPphKA9/ncnslr7C0gbey/jWvpNQruYXu+lexBl4jt3LPKcDd6m4u9ZRJdn6J1cU6vjyPWlV+bx7uVp8I3rIyycrF3Wp3xS6ZuS6ri6U8JbAnB/dwnAj6fNfnPcnZAgTwzu5/Wo8AAggggAACCCCAAAIIIGATAQJ4m3QU1UQAAQQQQAABBBBAAAEEEHC2AAG8s/uf1iOAAAIIIIAAAggggAACCNhEgADeJh1FNRFAAAEEEEAAAQQQQAABBJwtQADv7P6n9QgggAACCCCAAAIIIIAAAjYRIIC3SUdRTQQQQAABBBBAAAEEEEAAAWcLEMA7u/9pPQIIIIAAAggggAACCCCAgE0ECOBt0lFUEwEEEEAAAQQQQAABBBBAwNkCBPDO7n9ajwACCCCAAAIIIIAAAgggYBMBAnibdBTVRAABBBBAAAEEEEAAAQQQcLYAAbyz+5/WI4AAAggggAACCCCAAAII2ESAAN4mHRXqano8oc6R/BBAAAEEEEAAAQQQQMAKAT7LW6FcP8sggK+f/WJKrcrKREaPFulzQqQc2jVaHn1UJDPTlKLIFAEEEEAAAQQQQAABBEIsoD+768/wbduK9OpV/tlef8YnOUcgokwl5zTX2S2dPVukb19lEJ8tkrhHJKuL3HabyFNPOdvFqtaXlHrF5fZISkKMVUVSjhJwK/eiEo+kJuJu5QlR6imTgmK3pCXFWlms48vyeMskr9AtjZJxt/Jk8KqPUjn5bklPwd1Kd/0Jdm9+iWTgbiW7UVZmbok0TuV8txo+K69EXngmVt56S5Wc8YdIYROR4kYya5bImWdaXRvKC5cAAXy45MNQ7uVXlcgXrjtFjhwrEl0osv4skamviOw+LAy1oUgEEEAAAQQQQAABBBColUDT30TOv0uk40yR0kSRXwdI/7iR8vmnfKFSK0cbHxxt47pT9VoKZLX4XKTxu3+9q9MMkQtvl5TlD/y1j2emCujRgogIU4sg8yACuAdBsWAX7hYgBykC9yAoFuzC3QLkIEXgHgTFgl24W4AcpAjtnt/jOZEOc8pfjSkQOWaUZGXq4fcBQd7BroYoQADfEHu1mjYVHfq+Gm2v9KL6BZDn+yVQ6SU2EUAAAQQQQAABBBBAoH4LGJ/xCeDrdyeFsHYE8CHErO9Z9T20t/y0W426V0gpsSlySvtTKuzhqVkC+hpJr7o+NTqKtSPNMg6Wr3bX1wXH4B6Mx7R9enkVfR18TDTnu2nIQTLGPQiKBbu0u1ud77Gc7xZo/1WEYlfuXtz/IrHsWYlbucfw+90y8H0F6fWUftr6o+SV5AUUrT/jk5wjwDXwzulr2ZizUQ4febgUutX17ypFqP9G9RslQ44e4iCF8DVV/9ItZjE1yztAL2JX6PKoxdRYxM5KfB285xexmJqV5ros/WVVbgGLqVntrr8ozM5zSwaLellKrwP4rDyXWkwtztJyKUxkT45LmqThbvW5kJnrkq/+/FhumnSTlKn/dEqMSZRVd6yS9mntra4O5YVJgBH4MMGHo1j9F3vLvVvkvaVjZGP2Jrnz+FulW5Nu4agKZSKAAAIIIIAAAggggEAtBW7oOUROanuSvL30bWmX1k6u73m9pMen1zIXDrezACPwdu69g6y7S0170lOfUhL5/uYgCQ/qbYzAHxRbnd/ECHydCQ8qA0bgD4qtzm9iBL7OhAeVASPwB8VW5zcxAl9nwoPOgBH4g6ar0xv1CHxGShwLItdJ0f5v5uIV+/chLUAAAQQQQAABBBBAAAEEEHCAAAG8AzqZJiKAAAIIIIAAAggggAACCNhfgADe/n1ICxBAAAEEEEAAAQQQQAABBBwgQADvgE6miQgggAACCCCAAAIIIIAAAvYXIIC3fx/SAgQQQAABBBBAAAEEEEAAAQcIEMA7oJNpIgIIIIAAAggggAACCCCAgP0FCODt34e0AAEEEEAAAQQQQAABBBBAwAECBPAO6GSaiAACCCCAAAIIIIAAAgggYH8BAnj79yEtQAABBBBAAAEEEEAAAQQQcIAAAbwDOpkmIoAAAggggAACCCCAAAII2F+AAN7+fUgLEEAAAQQQQAABBBBAAAEEHCBAAO+ATqaJCCCAAAIIIIAAAggggAAC9hcggLd/H9ICBBBAAAEEEEAAAQQQQAABBwgQwDugk2kiAggggAACCCCAAAIIIICA/QUI4O3fh7QAAQQQQAABBBBAAAEEEEDAAQIE8A7oZJqIAAIIIIAAAggggAACCCBgfwECePv3IS1AAAEEEEAAAQQQQAABBBBwgAABvAM6mSYigAACCCCAAAIIIIAAAgjYX4AA3v59SAsQQAABBBBAAAEEEEAAAQQcIEAA74BOpokIIIAAAggggAACCCCAAAL2F4i2fxNC04KFP6+SsrIy6XNs94AMs3PzZe7C5bJxyw7p3KG1nHrCUZKcmBBwDBsIIIAAAggggAACCCCAAAIImC1AAK+EJ89cIMOeelu6d+sofd7+K4DftjNTbrjnGdm1e6+0a91cRo2dLJ3at5LRLw6T9LQUs/uG/BFAAAEEEEAAAQQQQAABBBDwCzh+Cv3Pv66Vh//vPYmLjfGj+J6MHjdFsnPy5asxI4yfsW88Ius3bpdxE2f7DuERAQQQQAABBBBAAAEEEEAAAUsEHB3Ab9q6U4b++1W5/KLT5JTjj6oCPu27RXJan57G6Lt+sXvXDtKrRzeZNmdxlWPZgQACCCCAAAIIIIAAAggggICZAo4N4HPyCuS2f74kRx3eSf41dFAVY1eJW7Ky8+SQjq0DXtPb29XUehICCCCAAAIIIIAAAggggAACVgo48hp4d2mp3PXwq2rafKy8MPwOiYys+j1G1t5cox8SE+ID+kNv5xcWic4jJjpasvJKAl63w4Zaq0+lMlV3rx2q23DqqNzLDHf7nTO27gTtrk56O/5dtbu7F3fru1Cd77hbz65LxD087vozDb/fw2OPu/Xu+nzfm2//z5EZKbHW4zWgEh0ZwL/3yRRZsWaDjHr+AclVI/H6p6jYJW63W3bsypL0RikSu++aeK83MMgt9XgkMiJCovYF/Y2Sql47X9/Pj5LSMikp9UpyfFR9r2qDqp/bUybFbo+kxDvyr13Y+tJwL1HuCbhb2Qml3jIpKC6VtET7/Y600inUZXnUp7v8QuVuw3+bQm1hZX5e9eVsbn6p2PEzgZVOoS5LxTKSrYIZ3EMte+D8dPCO+4GdQn2EDt717/eIUGdMfrYScOQn2pzc8oB90J1PVemsvlfdK6+PuEtd+97DCNRz8wsDjsnNK5RGacn+UfvISPv9FYqIKDP+4tux7gGdYbONCBXQ6LMFd2s7LlK564S7xe6KnfPdWnNdWtm+75w53y22L/81w+8Zq9lxt1g8sDh+zwR6WLWlBxLV/yQHCzgygL/1un4y8LK+Ad3+xIsfyO7MHHltxD+kaeNGRoDesX1LWbbi94Djlq383bgffMBONhBAAAEEEEAAAQQQQAABBBAwWcCRAXxaSpLon4pJX9seG1sobVs18+++9LxT5IW3xssHE6bJSb2PkKmzf5K167bI0w/d7D+GJwgggAACCCCAAAIIIIAAAghYIeDIAD4YrJ6KUnk6yvVXnisbNm2X598cL8+O/ESioiJlyDXnS79zTgyWBfsQQAABBBBAAAEEEEAAAQQQME0gQq3OvO8KItPKsH3GeoG7rTv2GKPzcfsWt7Nzo1xur5Son5REvr+xsh/1woHFajG1VBb1spJd3THCK4UuD4t6WaouUqoWbcwvckujZFaatZLeo9Z8yC1wSzor/FrJbqxAn53nloxUzncr4ctXoHdJ49Q4K4ulLCWwJ8clTdJwt/pkyMx1SUZKXJVBR6vrQXnhFSCCq4F/QnycdOkQeD/4GryNQxBAAAEEEEAAAQQQQAABBBAImUBYA3h9P/UFS1bKwqWrZLu6fVt2Tp5xv+b0RqnSsnmG9Dm2u/GTlBh4L/aQtZ6MEEAAAQQQQAABBBBAAAEEELCJQFgCeI/HKx99Nl1ef/9L4/7r2ipCXYCeoe6/rtOvq9cbgfy4ibNFB+9Dh/SXQf3PMlaGNw7gDwQQQAABBBBAAAEEEEAAAQQcJmB5AL/8t3Xy2PNjZM2fm6RNq6Zy8dknyrmn95b2bVpIbEx5dUrcpbJxyw759rtF8vX0+fLM62Nl0vQf5bH7Bkv3bh0d1kU0FwEEEEAAAQQQQAABBBBAAAE18G3lInbLVvwhfxs6QpKSEuSumy6Xqy85UyIrL/1eqVe8Xq+M/XKWvPbeF1JYVCzj3nqUIL6SUW03WcSutmKhOZ5F7ELjWNtcWMSutmKhOZ5F7ELjWNtcWMSutmKhOd6rVlNjEbvQWNYmFxaxq41WaI9lEbvQetY0Nxaxq6lUwz7O0hH4gqIi6dCupbz73P3SollGjWQjIyPl2svPljNOOlpuvv85FcS7avQ+DkIAAQQQQAABBBBAAAEEEECgIQlYOgK/JytHoqOjpFFq8kEZZu3NNW7W7rtW/qAy4U3CCHx4TgJG4MPjzgh8eNwZgQ+POyPw4XFnBD487ozAh8ddl8oIfHjsGYEPj3t9K9XSEfgmGWl1an9Gemqd3s+bEUAAAQQQQAABBBBAAAEEELCrgKUB/P6Q9Oj6Z5O/lxlzl0hJSan0PvpQufvmKyQ5MWF/b+M1BBBAAAEEEEAAAQQQQAABBBwhEJYAXgfpH38x07iF3Nmn9pIbB1wgw59/X2b/+Isf/Y8NW2XJsjXy2buPG9Pu/S/wBAEEEEAAAQQQQAABBBBAAAEHClgewK9cu0Hue/wN0feC12mFuuf7spV/yHcqeO93zoly/23XiF55fsQrH6nR+KXy5dQf5MqLTzeO5Q8EEEAAAQQQQAABBBBAAAEEnCoQaXXDp876yQjeh91+jcz+7CX5x42XG8G7Xtzu4buvk8bqOvemjRvJo/cONkbeFyxdaXUVKQ8BBBBAAAEEEEAAAQQQQACBeidgeQC/fVemxMXFyqD+Z0vzJulyy7UXSfOmGdJC/SQlxvuB9ErzbVo2lZ279/r38QQBBBBAAAEEEEAAAQQQQAABpwpYHsAXFBZLWkqi/7r2iIgIaanuCR8XF1OlD1KSEyWvoLDKfnYggAACCCCAAAIIIIAAAggg4DQBywN4j7q+PToqKsA5Rk2fj1D/VU6Vj6v8OtsIIIAAAggggAACCCCAAAIIOEXA8kXsNKyrxC2Ll632G+fkFUhBUXHAPv1ibn6B/xieIIAAAggggAACCCCAAAIIIOBkgbAE8Jnqnu+D736minuwfZ07tKpyHDsQQAABBBBAAAEEEEAAAQQQcJqA5QH8GSf2lHatmtXYWa9IT0IAAQQQQAABBBBAAAEEEEDA6QKWB/ADLzvL6ea0HwEEEEAAAQQQQAABBBBAAIFaC1i+iF2ta8gbEEAAAQQQQAABBBBAAAEEEEBALB+BX7l2g2Spa+BrmlKSEqXnEV1qejjHIYAAAggggAACCCCAAAIIINAgBSwP4F9+9zOZv3hFjTH1InaTxjxd4+M5EAEEEEAAAQQQQAABBBBAAIGGKGB5AF8R8dLzTpa01OSKu6o8b5yeWmUfOxBAAAEEEEAAAQQQQAABBBBwmoDlAfyNAy4Ql6tEli5fK9O/XyxX9ztTrr/qXGG1eaederQXAQQQQAABBBBAAAEEEECgNgKWB/AnHHO46J9lK/+Q98ZOljGffisffzFDLj3vFNHBfZtWTWtTf45FAAEEEEAAAQQQQAABBBBAwBECEWUqhbOl6zdtl9HjpsrX0+eLx+uV8888Xv5xY39p05JA3qx+cbm9UqJ+UhIt//7GrCbZIt+SUq8Ul3gkNTHGFvVtKJV0K/dCl0fSknC3sk9LPWWSX+SWRsmxVhbr+LI83jLJLXBLegruVp4MXvVRKjvPLRmpuFvprj/BZuW5pHFqnJXFUpYS2JPjkiZpuFt9MmTmuiQjJU4iIqwumfLqk0DYbyPXsV1Luf+2q+WS804SrwrgJ89cIN8v+F99MqIuCCCAAAIIIIAAAggggAACCIRdIKxDsHuycmTM+G9l/KTZUljkMqbPD7nmAjWd/uSww1ABBBBAAAEEEEAAAQQQQAABBOqTQFgC+K079qhp81Pkyyk/iKvELV07t5WbB14o551xnERGhn1SQH3qH+qCAAIIIIAAAggggAACCCCAgCFgeQA/csxEefujSeLxeOWYI7vKzYMuklNPOIruQAABBBBAAAEEEEAAAQQQQACB/QhYHsDr1ed18K5TQWGxvPzuZ8ZPdXVs17qpvPzE0OpeZj8CCCCAAAIIIIAAAggggAACjhCwPIBPS06SjEYpBu7uzL0HRE5KjD/gMRyAAAIIIIAAAggggAACCCCAQEMXsDyAf374bQ3dlPYhgAACCCCAAAIIIIAAAgggEHIBVowLOSkZIoAAAggggAACCCCAAAIIIBB6AUsD+F17siVrb+5Bt2J3ZrboW8+REEAAAQQQQAABBBBAAAEEEHCagKUB/O/rN8u1Q0fIlu27a+28cctOufbOEbJ+0/Zav5c3IIAAAggggAACCCCAAAIIIGB3AUsD+OSkRNm8bbf0v/ER+WDCNPF6y1ej3x+iXrF+9LipcvlNj8r2XZmSlJiwv8N5DQEEEEAAAQQQQAABBBBAAIEGKRBRppKVLVu1dqM8/uIYWbF6vbRoliEXntVHzj2tl3Ro21IF5+Urzuvby23YskOmfbdIvpmxQHbu2Ss9Du8sj903WLp2bmtldRtkWS63V0rUT0qi5WsYNkjPmjaqpNQrxSUeSU2MqelbOC4EAm7lXujySFoS7iHgrHEWpZ4yyS9yS6Pk2Bq/hwPrLuDxlklugVvSU3Cvu2bNc/Cqj1LZeW7JSMW95mp1P1J/gs3Kc0nj1Li6Z0YOtRLYk+OSJmm41wotBAdn5rokIyVOIiJCkBlZ2FbA8gBeS+l/6MZNnCWvvPu55BcW+fFSkhON53n5hQH77rnlSrny4tMlkrPV71KXJwTwddE7+PcSwB+8XV3eSQBfF72Dfy8B/MHb1eWdBPB10Tv49xLAH7xdXd5JAF8Xvbq9lwC+bn4H+24C+IOVa1jvC8sQrA7EB152lvS/4FRZ+PMqWbh0lezYneVf4C4jPVVaNmssfY7tLscffajExfGNdsM67WgNAggggAACCCCAAAIIIIBAbQXCEsD7KhmvAvPT+/Q0fnz7eEQAAQQQQAABBBBAAAEEEEAAgaoCli5iV7V49iCAAAIIIIAAAggggAACCCCAQE0ECOBrosQxCCCAAAIIIIAAAggggAACCIRZgAA+zB1A8QgggAACCCCAAAIIIIAAAgjURIAAviZKHIMAAggggAACCCCAAAIIIIBAmAUI4MPcARSPAAIIIIAAAggggAACCCCAQE0ECOBrosQxCCCAAAIIIIAAAggggAACCIRZoN4E8N6yMuM+8CXu0jCTUDwCCCCAAAIIIIAAAggggAAC9U8g7AH84v+tlkF3PCXHnnOznHLZP2T694sNpdHjphrbn0+ZW//UqBECCCCAAAIIIIAAAggggAACFguENYBfuXaD3Hjvs7Js5R/Ssnljo+llaiRep/4XnCLFxS75evp8Y5s/EEAAAQQQQAABBBBAAAEEEHCyQFgD+FEfTxaPxytjXvmnfDn6KaMfIiIijMdGqcly1GGdZe26zU7uH9qOAAIIIIAAAggggAACCCCAgCEQ1gD+jw1b5bBD2kvvHocG7Y5O7VtJTm6BuEu5Lj4oEDsRQAABBBBAAAEEEEAAAQQcIxAdzpbGx8WoEfjyKfPB6rFzd5ZkNEqRmOjQV9PlKpGFv/wmf27YJnuzc6VFs8Zy7um9pUlGWkBVsnPzZe7C5bJxyw7p3KG1nHrCUZKcmBBwDBsIIIAAAggggAACCCCAAAIImC0Q+si4FjU+tEt7+UItUvfb7xtFj7ZXTKv/2CRzFiyTXj26VdwdsufDnx8jX8+YLynJidKsSSPZsHmHvPzuBBnz8j+le7eORjnbdmbKDfc8I7t275V2rZvLqLGTjXqOfnGYpKelhKwuZIQAAggggAACCCCAAAIIIIDAgQTCGsDfPOhCmTr7J/nb0Kfl4rNPNOq6+JfV8sf6rfLfz2cY18ffMfiyA7XhoF4/9qiucvlFp/qn76/ftF0uG/KIjP1yloz4501GnqPHTZHsnHz5aswII4DXi+4Nuv0pGTdxttx2/SUHVS5vQgABBBBAAAEEEEAAAQQQQOBgBMJ6Dbwe1X71yaHSOD1VPv36O6P+n03+Xt79+BuJjIyQx+4bLDrQNiNdefHp/uBd55+WkmSUWXFkfdp3i+S0Pj2N4F0f071rB2NGwLQ55be60/tICCCAAAIIIIAAAggggAACCFghENYReN3AE3sfIZM+eFoWL1stehS8xF0q7VVgf/SRhxiBvdkIm7bulIVLV8k3MxdIQnycXHPJmUaRrhK3ZGXnySEdWwdUQW//+tu6gH1sIIAAAggggAACCCCAAAIIIGC2QFgD+ILCYvF6vcZ16Ccfd6Ton4pp45adoheb69q5bcXdIX3+wafTZNxXs9Xoe6TcecNlajG7DCP/rL25xmNiQnxAeXo7v7DIWBlfL66XW+AOeN0OG161bqC3rMyWdbeDb3V1xL06GXP3a3eP+sOOf1fNlTE3d9zN9a0ud70sLL/fq9Mxbz/u5tnuL2ftrj7O8Pt9f0gmvsa/qybiVpO1cb4XuqX8ptvVHGSD3alJMTaoZf2tYlgD+Kde/lAmz1oow24fINdefnYVpRfeGi8b1Orvk8Y8XeW1UO3459CBcsfgS2Xe4hXy6LOjRa86/+AdAyQ2tvzE0l8wVEylHo9EqnvVR6mAX6f4uKiKL9viubu0TEo9XlvW3RbA1VSyVN1xoaTUg3s1Pmbt1ne6cLlxN8u3uny9KoIvcpVxvlcHZNJ+7a7PeTv+22QSiSXZlqlP1fp3PO6WcP9ViAre+TzzF4eVz0pK+RxppbevLLf6/J4Qq2IPu0fwvgbxeFACYQ3gdY096kT8z2sfy4rV6+Xx+wdLXFzsQTXkYN+kR9Ez1DX4/c45UaaoLxNm//izEcCnpyUbgXpufmFA1rl5hdJIv7YvgI+NDusyAgF1q+lGWZlXzXyIEDvWvaZtrJ/HedUHDdyt7hu3eNUXJ7hb7a6DmYgID79nLIbXs01wtxhdFadnPUQI57vV8no0Uic+z5Q7WP0n7laLl5cXo2IPNZZIcrBA2KPPRqnJctoJPYxbug284ynZumOPJd2hvy2vnPQ17wlxccZuHaB3bN9Slq34PeCwZSt/N+4HH7CTDQQQQAABBBBAAAEEEEAAAQRMFgh7AJ+cnCAj/3O3cVu2NX9ulqtueUzmL1lpcrNFLr7uIXnrw0nG4nl69P+JFz+QlWvWy7mn9/aXfel5pxh1+WDCNPljw1Z5bfQXsnbdFrns/FP8x/AEAQQQQAABBBBAAAEEEEAAASsEwj6FXjcyQs0D0QvIHdGtozw44m35+7AX5O6brzC1/R3btZQ3PphoTOHXBUVHR8ngq8+TW6692F/u9VeeKxvUyvjPvzlenh35iURFRcqQa843ptv7D+IJAggggAACCCCAAAIIIIAAAhYI1IsA3tfO00/sKePfGi7/eORVefHtT43dnTu08r0c0sfXRtxl3LJux65MKVULi7Vu2VTi9i1c5ytIB+xPDBsiD/1jkDG1v22rZlWO8R3LIwIIIIAAAggggAACCCCAAAJmCoR9Cn3lxnVo20LGvTlczj6tV+WXQr4dGxMt7dQ95zu1b7XfwFzfH75Lh9b7PSbklSNDBBBAAAEEEEAAAQQQQAABBCoIhHUEXt867vwzT6hQnfKniQlx8vLjdxoL2+nRcRICCCCAAAIIIIAAAggggAACThcIawDfXV3zvr908dkn7u9lXkMAAQQQQAABBBBAAAEEEEDAMQKWB/DjJ30nuzOz5Y7BlxorwK9Ti8TtL6WnpQSsDL+/Y3kNAQQQQAABBBBAAAEEEEAAgYYqYHkAP+HrOfLb7xvldhXAfzn1B5k0ff5+bfUidhVv7bbfg3kRAQQQQAABBBBAAAEEEEAAgQYqYHkAr2/DpkfgIxTogMvOklNO6LFf2pSkhP2+zosIIIAAAggggAACCCCAAAIIOEHA8gD+gr5/LVp31GGdRP+QEEAAAQQQQAABBBBAAAEEEEBg/wKWB/AVq1NY5DKm06enJRu3ctOvZe7NlcmzFkp2Tp6cc1pvObRLu4pv4TkCCCCAAAIIIIAAAggggAACjhQIawA/8dsfZMQr/5V7b7nSCOBdJW654uZHZdeebKMzxoz/Vka98IAcc2RXR3YOjUYAAQQQQAABBBBAAAEEEEDAJxDpexKOx/lLVkpCfJwM7H+WUfwXk+cawfvZp/WS4fdeL3FxsfLa6C/DUTXKRAABBBBAAAEEEEAAAQQQQKBeCYR1BH7bjkzp2qmNEcRrlR+XrDBw7vv7VdK2VTP5+dffZeYPS+sVGJVBAAEEEEAAAQQQQAABBBBAIBwCYR2Bj46O8rfZ6/XK8lV/SvOmGUbwrl9o1qSRFBW7xOUq8R/HEwQQQAABBBBAAAEEEEAAAQScKBDWEfgu6h7vU2b9JPMW/Sobt+w0FrC7+OwT/f2wdt0WSUtNMqbS+3fyBAEEEEAAAQQQQAABBBBAAAEHCoQ1gL/28nPk6xkL5O/DXjDoo6Ii5dbr+hnPt2zfLQuXrpIe3Ts7sFtoMgIIIIAAAggggAACCCCAAAKBAmEN4A/v2l5GPf+AfPT5dImJjpZ+55woHdq2MGo4dfZP0rZ1M7niotMCa8wWAggggAACCCCAAAIIIIAAAg4UiChTyYHtdnSTXW6vlKiflMSwfn/juD4oKfVKcYlHUhNjHNf2cDbYrdwLXR5JS8Ldyn4o9ZRJfpFbGiXHWlms48vyeMskt8At6Sm4W3kyeNVHqew8t2Sk4m6lu/4Em5XnksapcVYWS1lKYE+OS5qk4W71yZCZ65KMlDiJiLC6ZMqrTwJhXcSuPkFQFwQQQAABBBBAAAEEEEAAAQTqswABfH3uHeqGAAIIIIAAAggggAACCCCAwD4BAnhOBQQQQAABBBBAAAEEEEAAAQRsIEAAb4NOoooIIIAAAggggAACCCCAAAIIEMBzDiCAAAIIIIAAAggggAACCCBgAwECeBt0ElVEAAEEEEAAAQQQQAABBBBAgACecwABBBBAAAEEEEAAAQQQQAABGwhYeiPwxctWyz3DR9aKpXOHVvLBKw/V6j0cjAACCCCAAAIIIIAAAggggEBDE7A0gI+Jjpb0Rim1MkxOSqjV8RyMAAIIIIAAAggggAACCCCAQEMUsDSA73lEF/n6g6cboiNtQgABBBBAAAEEEEAAAQQQQMBUAa6BN5WXzBFAAAEEEEAAAQQQQAABBBAIjUDYA/iNW3bKA0++JRdc+6Acc+4t8u13i4yWfTJxllxz2xMy84eloWkpuSCAAAIIIIAAAggggAACCCBgY4GwBvCbtu6U/jc+IlNmLZTdmdnicpWIu7TU4DzjxKNlzR+b5PPJ39uYl6ojgAACCCCAAAIIIIAAAgggEBqBsAbwb4z5SopV0P70QzfLd5+/bLQoIiLCeGzRLEOOPKyTrFizITQtJRcEEEAAAQQQQAABBBBAAAEEbCwQ1gB+zZ+bpEPbFnLJuSeJXqG+cjqkUxvJ2pvrH5Wv/DrbCCCAAAIIIIAAAggggAACCDhFIKwBfFmZSKPU5Gqtc3MLJDUlKWhwX+2beAEBBBBAAAEEEEAAAQQQQACBBigQ1gC+W+e2smzlH7J5264qtNt3ZsrsH3+RTu1aVnmNHQgggAACCCCAAAIIIIAAAgg4TSCsAfx1V54jUVGRMvjuZ+TDCdMM+z/Wb5UJX8+RAbc/aVwfP2TABU7rE9qLAAIIIIAAAggggAACCCCAQBWBiDKVquy1cMdX0+bJ069+LPkFRQGlRkZGyk0DL5S7bro8YD8bdRdwub1Son5SEquuO1D33MmhOoGSUq8Ul3gkNTGmukPYb4KAW7kXujySloS7CbzVZlnqKZP8Irc0So6t9hhe1MgDVQAAQABJREFUCL2Ax1smuQVuSU/BPfS61efoVR+lsvPckpGKe/VKoX9Ff4LNynNJ49S40GdOjvsV2JPjkiZpuO8XyYQXM3NdkpESJ/vW/DahBLK0g0DYI7hLzj1ZTjnuKJmh7ve+YdN2KVKr0ndUC9v16XWEdFWL2JEQQAABBBBAAAEEEEAAAQQQQEAk7AG87oSM9FS5ut8Z9AcCCCCAAAIIIIAAAggggAACCFQjYGkA71Kj6zv37K2mKsF3x8XGSPOmGcFfZC8CCCCAAAIIIIAAAggggAACDhGwNIBfsnyN3PLAC7Wi7dyhlUwa83St3sPBCCCAAAIIIIAAAggggAACCDQ0AUsD+BZNG0v/C071G675c7OsXLNezj71WElJTvLv109WrF4na9dtkZN6Hxmwnw0EEEAAAQQQQAABBBBAAAEEnChgaQCvR9OfHDbE73z3o6/Jth175MXH7hC96nzFtHHLTrlk8L/VKosRFXfzHAEEEEAAAQQQQAABBBBAAAFHCgRGzRYT6Hu+t2vdrErwrqvRvk1z6dm9s0yeucDiWlEcAggggAACCCCAAAIIIIAAAvVPIKwBfHx8nGxVI/D6/qnBUnJyouzJypG8/MJgL7MPAQQQQAABBBBAAAEEEEAAAccIhDWA79WjmxGgPzvyE8namxuAvnT5WlmwZKW0at5YkhLjA15jAwEEEEAAAQQQQAABBBBAAAGnCVh6DXxl3DsGXyqzflgqH302Xf77+Qw57JB20iQjTX79bb3szckzDh9+3+CgU+wr58U2AggggAACCCCAAAIIIIAAAg1ZIKwBfIqaIj/+7cfklVGfqWvdF8qqtRv91voa+L//rZ+cfByr0PtReIIAAggggAACCCCAAAIIIOBYgYgylepD63U1tu/Kknx1vXtLNW1eB/ckcwRcbq+UqJ+UxLB+f2NO4+pxriWlXiku8UhqYkw9rmXDq5pbuRe6PJKWhLuVvVvqKZP8Irc0So61sljHl+XxlklugVvSU3C38mTQa/lk57klIxV3K931J9isPJc0To2zsljKUgJ7clzSJA13q0+GzFyXZKTEqbt0WV0y5dUngbBeA18RQgfwXo9XYmNjJC6OfwAr2vAcAQQQQAABBBBAAAEEEEAAgbAPwW7fmSkvvfuZTJuzSEpLPUaPRKqvlY49qqs8cPs10r1bR3oJAQQQQAABBBBAAAEEEEAAAccLhDWAz1Qrzw+4/UnZnZktbVs1k26d20pEZIRs3rpLFv9vjQy6Y4SMfeMRObxre8d3FAAIIIAAAggggAACCCCAAALOFghrAP/Wh5OM4P2hoYNkUP+z1PUcf13QMW/Rr3Lnv16REa9+JB+//rCze4nWI4AAAggggAACCCCAAAIIOF4grNfAL162Wt06rr1ce/nZAcG77hW9+ny/c06U39TK9B51bTwJAQQQQAABBBBAAAEEEEAAAScLhHUEvtTjkYz0lGr9U1OSxFXiloLCItHPQ5kKCotlwdKVsn7TdiPbU084Sk3hb1eliOzcfJm7cLls3LJDOndoLfq45MSEKsexAwEEEEAAAQQQQAABBBBAAAEzBcIawOtr3ufMXyYbNu+QDm1bBLQzT91ObsbcJdKmZdOQB++6oHuGvy4/Ll4hGY3Kv0B4WS2k17FdS/notX9Jelr5vm1qgb0b7nlGdu3eK+1aN5dRYydLp/atZPSLw/zHBFSaDQQQQAABBBBAAAEEEEAAAQRMEghrAK+ve5/+/RIZeMeTcnW/M41F7KKjo4yAfvxXs0UH0A/cdo0pTT/5+KNk6JD+cuRhnUTfwm7C13Pk8Rc/kHETZ8tt119ilDl63BTJzsmXr8aMMAL4lWs3yKDbnwo4xpTKkSkCCCCAAAIIIIAAAggggAAClQTCGsAfc2RXeXLYEHn2jU/knf9+HVC1mOhouWnghXL9VecG7A/VxnVXnOPPSi+e1+/ck+SJlz4UfVs7X5r23SI5rU9PI3jX+7p37SC9enRTt7xb7A/yfcfyiAACCCCAAAIIIIAAAggggICZAmEN4HXDLj3vZDnzpKPV9eirjOvMS9ylRsCsA+VWzRub2faAvH9Z8bsxEt+xfUtjv772Pis7Tw7p2DrgOL3962/rAvaxgQACCCCAAAIIIIAAAggggIDZAmEP4HUD9QJ1557e2+y2Vpu/y1UiL7z1qXFd+2Xnn2Icl6XuUa9TYkK88ej7Q2/nq0X13KWlomcJFBSX+l6yzaPHUyYeb5kt624b5CAV1eba3o7nTJDm2GaXV7tzvlveX1518xD9w/luLb061UX/4G6tu7oST9T/uFvLrgZecLeYPKA4fs8EcFiy4fs9U+HO25aUG+pCkuLrRQga6mZZlp/lejl5BVKsAuaaptiYaFMXjNMj/nc+/Kqs27hN3vq/e6VRarJRtdjYGOPRqz+BVkh65fxI9bcmKrL8Dnz6ud2SV1U9Qv0GsGPd7WZdsb5l6lTxKHjcK6qY/1y7R6iP1ribbx1QQqT6JaPscQ9QMX1Dn+v6XyXcTacOKKBM/6OqEu4BLOZvGL/fcTcfOngJnO/BXczcq3+/R0XqP0lOFrA8gL//iTdlvlr9vaapi7p1m15EzoykbyU39OFXZPmqdfL6iLvkuKMP8xeTnpZs/EOcq1bDr5hy8wqlkX5tXwCfEBdV8WVbPHe5vVJS5hU71t0WwNVUsqTUq0bGynCvxses3W7lrkfgOd/NEg6eb6mabaLtcQ/uY9Zefa7r3/G4myUcPF/9u73YhXtwHfP26hH4Qlcp57t5xNXmrEff+T1TLY9pL+jzPT42Smw4fmiaiRMztjyAr4h8/DGHqSC5fCS74v6Kz826Dn7nnr1y+z9fkp3qFnGjX3pQjlKr0VdMOkDX18MvU9fGV0zLVv5u3A++4j6eI4AAAggggAACCCCAAAIIIGC2gOUBvL7Wfc0fmyRTXWO+JytHrTR/kVzY9wSJitp/IB9qiIG3Pyk7dmXJPbdcqR4zjR9fGWeedIzo29ldet4p6tr48fLBhGlyUu8jZOrsn2Ttui3y9EM3+w7lEQEEEEAAAQQQQAABBBBAAAFLBCLUPdDLL9yypLjyQvQK7199O0/eH/+tbNq6U1q3aCI3XHO+9L/gVInbd+252dXpcdaNUlrqCVrMgq9HGgvreTxeefyFMfKlqqu+Fl5/yXD9lefKvX+/Sk1dse/1J8YUejXFMiXR8u9vgno7ZaeeQl9c4pHUxPL1FZzS7nC3U0/jLnR5JC0Jdyv7Qk+hzy9yS6PkWCuLdXxZegp9boFb0lNwt/Jk0FPos/PckpGKu5Xu+hNsVp5LGqfGWVksZSmBPTkuaZKGu9UnQ2auSzJS4phCbzV8PSsvLAG8z0D/gzdz7hJ575MpsmL1emmcnmoEyFdfeqYkJyb4Dgv7Y1GxS7bu2CNtWzWz7AsGMxtNAG+mbvV5E8BXb2PmKwTwZupWnzcBfPU2Zr5CAG+mbvV5E8BXb2PmKwTwZuruP28C+P37mPUqAbxZsvbK19p565Vs9OqV55zWWz5581EZcFlfY1r9i+9MkIlT51U6MrybCfFxohfTs2p2QHhbS+kIIIAAAggggAACCCCAAAL1USCsc6j1FPXJsxbKqLHfyJ8bthkBsr4P+9mn9aqPVtQJAQQQQAABBBBAAAEEEEAAgbAJhCWA1/denzj1B2Pq/Jbtu43p8jcNvFCuU9eX62n0JAQQQAABBBBAAAEEEEAAAQQQCBSwPID/ato8efndz2TXnmwjWNerwF9zibrmPan+XPMeSMQWAggggAACCCCAAAIIIIAAAuEXsDyA/2bmQiN4100/9qhuaur8VhnxykfVSjRrkm7c6q3aA3gBAQQQQAABBBBAAAEEEEAAAQcIWB7AVzSd/v3iiptBn3fu0IoAPqgMOxFAAAEEEEAAAQQQQAABBJwkYHkA/+Lw26XYVVJj4+joqBofy4EIIIAAAggggAACCCCAAAIINFQBywP4lORE0T8kBBBAAAEEEEAAAQQQQAABBBCouUBY7wNf82pyJAIIIIAAAggggAACCCCAAALOFiCAd3b/03oEEEAAAQQQQAABBBBAAAGbCBDA26SjqCYCCCCAAAIIIIAAAggggICzBQjgnd3/tB4BBBBAAAEEEEAAAQQQQMAmAgTwNukoqokAAggggAACCCCAAAIIIOBsAQJ4Z/c/rUcAAQQQQAABBBBAAAEEELCJAAG8TTqKaiKAAAIIIIAAAggggAACCDhbgADe2f1P6xFAAAEEEEAAAQQQQAABBGwiQABvk46imggggAACCCCAAAIIIIAAAs4WIIB3dv/TegQQQAABBBBAAAEEEEAAAZsIEMDbpKOoJgIIIIAAAggggAACCCCAgLMFCOCd3f+0HgEEEEAAAQQQQAABBBBAwCYCBPA26SiqiQACCCCAAAIIIIAAAggg4GwBAnhn9z+tRwABBBBAAAEEEEAAAQQQsIkAAbxNOopqIoAAAggggAACCCCAAAIIOFuAAN7Z/U/rEUAAAQQQQAABBBBAAAEEbCJAAG+TjqKaCCCAAAIIIIAAAggggAACzhYggHd2/9N6BBBAAAEEEEAAAQQQQAABmwgQwNuko6gmAggggAACCCCAAAIIIICAswUI4J3d/7QeAQQQQAABBBBAAAEEEEDAJgIE8DbpKKqJAAIIIIAAAggggAACCCDgbAECeGf3P61HAAEEEEAAAQQQQAABBBCwiQABvE06imoigAACCCCAAAIIIIAAAgg4W4AA3tn9T+sRQAABBBBAAAEEEEAAAQRsIkAAb5OOopoIIIAAAggggAACCCCAAALOFiCAd3b/03oEEEAAAQQQQAABBBBAAAGbCBDA26SjqCYCCCCAAAIIIIAAAggggICzBQjgnd3/tB4BBBBAAAEEEEAAAQQQQMAmAgTwNukoqokAAggggAACCCCAAAIIIOBsAQJ4Z/c/rUcAAQQQQAABBBBAAAEEELCJAAG8TTqKaiKAAAIIIIAAAggggAACCDhbgADe2f1P6xFAAAEEEEAAAQQQQAABBGwiQABvk46imggggAACCCCAAAIIIIAAAs4WIIB3dv/TegQQQAABBBBAAAEEEEAAAZsIEMDbpKNCWc2I/D8las9clWVZKLMlLwQQQAABBBBAAAEEEDBdQH2G3/W9iPpMT3KeQLTzmuzgFpcWiMy7QmK3T5fYMq9I2mEiJ4wRaXycg1FoOgIIIIAAAggggAACNhHIXCTy02CRnN9EItRYbMtzRE7+TCQ6ySYNoJp1FYgoU6mumfB+mwj88a7IolsCK5veQ+SQ2wP3sWWKQKm3TEpLvRIfG2VK/mQaXMCj3EuUewLuwYFM2utV3xEWuz2SGMf5bhJx0GzV6S7FLuUej3tQIJN26g9ShcUeScLdJOHg2Za7lyp3xqOCC5m3N7+oVJITcDdPOHjOBcXqfN/8jsje/wUecJza1+XmwH1sNVgBAvgG27VBGjarr8jO2UFeYBcCCCCAAAIIIIAAAgjYUqD5mSJ9Z9my6lS69gJ8dVZ7M/u+o0WQAD6+uUibS+zbJhvV3KtH4NVPbDRLT1jZbYa7R7nH4G6pu5rcpWecxMYwEmylu55Up2ecxOFuJbsY7m7lzkwfS931Uj56pg8z26xl16UVl+Buvfo+913fqCc7A4vXn/FJjhEggHdMV6uGdr5JZO1IkaJt5a2Oihfp/aZI28ucpBC2tupgRv+DF5sYE7Y6OLFgj3IvUlOKY5Nwt7L/vepLk8Iit8Qmx1pZrOPL0l9YFRa4JS4FdytPBh3AF+Qp91TcrXUX5e6S+NQ4K4ulLCWQn6Pc03C3+mQoyHVJXM6FEjF/oIinuLz4hFbln/GtrgzlhU2AAD5s9GEoOL6ZyCUbxL3xS/HmbZK4bjeIxDUOQ0UoEgEEEEAAAQQQQAABBGot0EYNvF26RWT9ByKJ7cpn0kYySFFrRxu/gQDexp13UFVXf8G9ba6QEj3VL47uPyhD3oQAAggggAACCCCAQLgE9ADcofeGq3TKDbMAF4WGuQMoHgEEEEAAAQQQQAABBBBAAIGaCBDA10SJYxBAAAEEEEAAAQQQQAABBBAIswABfJg7gOIRQAABBBBAAAEEEEAAAQQQqIkAF0ErpRlzl8ghHdtIh7Ytqphl5+bL3IXLZeOWHdK5Q2s59YSjJDkxocpx7EAAAQQQQAABBBBAAAEEEEDATAFHB/ClpR6Zs2CZ3Dt8pPz77r9VCeC37cyUG+55Rnbt3ivtWjeXUWMnS6f2rWT0i8MkPS3FzH4hbwQQQAABBBBAAAEEEEAAAQQCBBwbwP++fotcNuQR0fdurS6NHjdFsnPy5asxI4wAfuXaDTLo9qdk3MTZctv1l1T3NvYjgAACCCCAAAIIIIAAAgggEHIBx14Dr6fLf/Phf+TTt4dXizrtu0VyWp+eRvCuD+retYP06tFNps1ZXO17eAEBBBBAAAEEEEAAAQQQQAABMwQcOwIfEx1tTJnPLygK6uoqcUtWdp66Nr51wOt6+9ff1vn3FZd4/M/t8qTUUyYeb5nYse52MQ5WT23uxT0Yjan7cDeVt9rMvV4Rdbrze6ZaIXNe0OZ6Yhm/383xrS5XRS76B/fqhMzdj7u5vtXljnt1Mubud7ntF3tUFomPjaq8i+1aCDg2gD+QUdbeXOOQxIT4gEP1dn5hkbhLS0V/CaCDYbslHdDoSwfsWHe7WVesrxFIqtMF94oq5j/XX5rov6W4m29dsQSvjiL5PVORxJLn+ne7/o/z3RJufyHGbxnOd7+HVU/073b9q4bz3SrxwHJwD/SwYkuf724Ve0RYURhl1FsBAvhquiY2NsZ4xauHkSqkUo9HIiMiJCqy/OqD5AT7EbrcXilRP3ase4WusN3TklKvMTqDu7Vd51buhS4P57u17MYH6nyvG3eL3fUXhaUFuFvMrmablInbjbvV7jqYKVGjkfy7arV8+WwT3K1316PvyfHRokIRkoMFHHsN/IH6PD0t2QjUc/MLAw7NzSuURvq1fQF8wItsIIAAAggggAACCCCAAAIIIGCSAAF8NbA6QO/YvqUsW/F7wBHLVv5u3A8+YKfNNqIiIyQ2hq63utu0exzuVrOrL9twtxxdFajYhWvcrJfXM8Rwt949Qk1ojY/jmk6r5fUoZEKc/WZCWu1kRnmJnO9msB4wT+N8Z/T9gE4N/QDHRnF6kTp9W7hV6kcnfc93vb0nK8fY1n9cet4pMn/JSvlgwjT5Y8NWeW30F7J2nbr93Pmn+I+x45PoKAKacPRbeQDPBzyr7bU7AY3V6iqAx916dFVieUDD7xmr8bU7AY3V6uXl4R4mdzWNm2S9gD7fid+td69vJUaoBW/0GiCOS0YgPuThKu0eOqS/3HpdP2O/x+OVx18YI19+O0+tHu6VqKhIuf7Kc+Xev1+lPiTx16cKHjsQQAABBBBAAAEEEEAAAQRME3BsAF8b0aJil2zdsUfatmomcfsWt6vN+zkWAQQQQAABBBBAAAEEEEAAgboKEMDXVZD3I4AAAggggAACCCCAAAIIIGCBgGOvgbfAliIQQAABBBBAAAEEEEAAAQQQCJkAAXzIKMkIAQQQQAABBBBAAAEEEEAAAfMECODNsyVnBBBAAAEEEEAAAQQQQAABBEImQAAfMkoyQgABBBBAAAEEEEAAAQQQQMA8AQJ482zJGQEEEEAAAQQQQAABBBBAAIGQCRDAh4ySjBBAAAEEEEAAAQQQQAABBBAwT4AA3jxbckYAAQQQQAABBBBAAAEEEEAgZAIE8CGjJCMEEEAAAQQQQAABBBBAAAEEzBMggDfPlpwRQAABBBBAAAEEEEAAAQQQCJkAAXzIKMkIAQQQQAABBBBAAAEEEEAAAfMECODNsyVnBBBAAAEEEEAAAQQQQAABBEImQAAfMkoyQgABBBBAAAEEEEAAAQQQQMA8AQJ482zJGQEEEEAAAQQQQAABBBBAAIGQCRDAh4ySjBBAAAEEEEAAAQQQQAABBBAwT4AA3jxbckYAAQQQQAABBBBAAAEEEEAgZAIE8CGjJCMEEEAAAQQQQAABBBBAAAEEzBMggDfPlpwRQAABBBBAAAEEEEAAAQQQCJkAAXzIKMkIAQQQQAABBBBAAAEEEEAAAfMECODNsyVnBBBAAAEEEEAAAQQQQAABBEImQAAfMkoyQgABBBBAAAEEEEAAAQQQQMA8AQJ482zJGQEEEEAAAQQQQAABBBBAAIGQCRDAh4ySjBBAAAEEEEAAAQQQQAABBBAwT4AA3jxbckYAAQQQQAABBBBAAAEEEEAgZAIE8CGjJCMEEEAAAQQQQAABBBBAAAEEzBMggDfPlpwRQAABBBBAAAEEEEAAAQQQCJkAAXzIKMkIAQQQQAABBBBAAAEEEEAAAfMECODNsyVnBBBAAAEEEEAAAQQQQAABBEImQAAfMkoyQgABBBBAAAEEEEAAAQQQQMA8AQJ482zJGQEEEEAAAQQQQAABBBBAAIGQCRDAh4ySjBBAAAEEEEAAAQQQQAABBBAwT4AA3jxbckYAAQQQQAABBBBAAAEEEEAgZAIE8CGjJCMEEEAAAQQQQAABBBBAAAEEzBMggDfPlpwRQAABBBBAAAEEEEAAAQQQCJkAAXzIKMkIAQQQQAABBBBAAAEEEEAAAfMECODNsyVnBBBAAAEEEEAAAQQQQAABBEImQAAfMkoyQgABBBBAAAEEEEAAAQQQQMA8AQJ482zJGQEEEEAAAQQQQAABBBBAAIGQCRDAh4ySjBBAAAEEEEAAAQQQQAABBBAwT4AA3jxbckYAAQQQQAABBBBAAAEEEEAgZAIE8CGjJCMEEEAAAQQQQAABBBBAAAEEzBMggDfPlpwRQAABBBBAAAEEEEAAAQQQCJkAAXzIKMkIAQQQQAABBBBAAAEEEEAAAfMECODNsyVnBBBAAAEEEEAAAQQQQAABBEImQAAfMkoyQgABBBBAAAEEEEAAAQQQQMA8AQJ482zJGQEEEEAAAQQQQAABBBBAAIGQCRDAh4ySjBBAAAEEEEAAAQQQQAABBBAwT4AA3jxbckYAAQQQQAABBBBAAAEEEEAgZAIE8CGjJCMEEEAAAQQQQAABBBBAAAEEzBMggDfPlpwRQAABBBBAAAEEEEAAAQQQCJkAAXzIKMkIAQQQQAABBBBAAAEEEEAAAfMECODNsyVnBBBAAAEEEEAAAQQQQAABBEImQAAfMkoyQgABBBBAAAEEEEAAAQQQQMA8AQJ482zJGQEEEEAAAQQQQAABBBBAAIGQCRDAh4ySjBBAAAEEEEAAAQQQQAABBBAwT4AA3jxbckYAAQQQQAABBBBAAAEEEEAgZAIE8CGjJCMEEEAAAQQQQAABBBBAAAEEzBMggDfPlpwRQAABBBBAAAEEEEAAAQQQCJkAAXzIKMkIAQQQQAABBBBAAAEEEEAAAfMECODNsyVnBBBAAAEEEEAAAQQQQAABBEImQAAfMkoyQgABBBBAAAEEEEAAAQQQQMA8AQJ482zJGQEEEEAAAQQQQAABBBBAAIGQCRDAh4ySjP6fvfsAbKL8Gzj+66alA0rZe4giihNFHKjg3ltx4N4TX/fAAe4tKC4EByr6FxRFEBTEAQoiIjhAkL0pXbSkSZr3eQ4SkjZpr21y1yTf05C755577u5zaXK/u+d5DgEEEEAAAQQQQAABBBBAAIHICRDAR86WkhFAAAEEEEAAAQQQQAABBBAImwABfNgoKQgBBBBAAAEEEEAAAQQQQACByAkQwEfOlpIRQAABBBBAAAEEEEAAAQQQCJtActhKoiAEEEAAAQQQCLvA/z38qixduVZ67dFFHr7jsirlX3/387JuU76RniAJkt4oVbp1bivnnnKk9Ny9c0D+9/43Vf43aaZkNU6Xt567U1KSA08DPpjwjYybOEOVkiCfvPmwJCYkBCzPBAIIIIAAAgjYK8AdeHv9WTsCCCCAAAIhBVat3ShfTf9ZFi9dJeMnfy/5W4uq5NXB/YpV66Vtqzxp1bypbHeUyydffCcDbxgqM2cvCMi/aUuBUdavCxbL51//FDDP6XLJ6+9NNOb/s3SliMcTMJ8JBBBAAAEEELBfgADe/mPAFiCAAAIIIBBUwBtkn3bcoeJ2V8gX38wOmq95syYyfNgt8soTt8n/3nxEnrr/GnG53DJm3OSg+TMz0mXUB5Okwi9I/2LqLNm4uUAy0tOCLkMiAggggAACCNgvQABv/zFgCxBAAAEEEAgqMFHdJW/VIlfuvnGgpKYky8Svfwyar3LiSQMOkazMDPl3+ZrKs4zpyy84UZaru/ZTv5trTHtUIP/2R1/JAb26y/57dw+6DIkIIIAAAgggYL8AAbz9x4AtQAABBBBAoIrA/IX/iq5Cf1L/PpKd1ViO6LOP/Ll4hSxdvrZK3soJ20q3S9l2h+zdo0vlWcb0Kcf2lZbNc+WN978wpmf+vMAo9+qLTgman0QEEEAAAQQQaBgCBPAN4ziwFQgggAACCAQIfL7zbvvJ6m66Hk4a0Md496YbE37/6LvojnKnLPlvtfzfI68YVeiP7dfbL8eu0ZTkJLn0vOPlryUr5Mc5f8jbqjr9Ht06yGEH7b0rE2MIIIAAAggg0OAEArufbXCbxwYhgAACCCAQfwK6Q7nJM36R3Tq3k+5d2xsA/Q7ZV3Tb9S+mzZJbrzpbEvx6iF+9bpPsddSuHup1O/Yn7rtaTjmmb0i8c07uJ6+987k8+PTbsn5jvjw75PqQeZmBAAIIIIAAAg1DgAC+YRwHtgIBBBBAAAGfwHezfpfCom3SKC1NbrrvRV96QmKCEWzPmf+3HLRfD1+6bu9+/aWnS4Xq6O411ZO8vhPfsV0r3/xgI+mN0mTgmQPkldETVN6WcuyRwe/WB1uWNAQQQAABBBCwR4Aq9Pa4s1YEEEAAAQRCCujO6/Qd9rzcHNmgeob3vlq3bGYs4+2d3ltAjmojf8nZxxrV4l985EbVY71bbrjneVm9dpM3S9D3C1UAv3vXDkbwzzPfgxKRiAACCCCAQIMS4A58gzocbAwCCCCAQLwLFBZvE30HXvcIP+bFewI49GPfBpx7u3z93Rx54NaLJS0tNWC+ntB35h+6/VK5/8m35Jq7npX3R9wvTbIzq+TTCTr907ceCTqPRAQQQAABBBBoeALcgW94x4QtQgABBBCIY4Gvvv1ZdBt4b+d1/hT6LvlJ/Q8W3cv8Nz/M858VMH7GCYfLVReebDwq7sZ7XzSq1AdkYAIBBBBAAAEEolKAAD4qDxsbjQACCCAQqwKTvpktKcnJclyINuknH7OjV/ovVT49JCUmBnRo53W55cqzjDJ+W7jEuBuv070d33nfvXn936ub55+PcQQQQAABBBCwXiBBPXbGY/1qWSMCCCCAAAIIIIAAAggggAACCNRGgDvwtdEiLwIIIIAAAggggAACCCCAAAI2CRDA2wTPahFAAAEEEEAAAQQQQAABBBCojQABfG20yIsAAggggAACCCCAAAIIIICATQIE8DbB27lal9sjDmeFnZsQl+t2V2h3d1zuu507rd23l+Nu9TGowN1qcmN9ulebMgefd6vxtXsp7lazG+vD3RZ2Kd3usmfFcb5W/Xmn87I4/xCo3SeAj8PPgA5oygngLT/yOwJ4LpxYDa8DSS5YWa0uoti5cGI9u3LngpUN7OqEWrkTwFtOv+OCFYGk5fBqhVw4sUNdX6BVn3cieHvwG9BaCeAb0MFgUxBAAAEEEEAAAQQQQAABBBAIJUAAH0qGdAQQQAABBBBAAAEEEEAAAQQakAABfAM6GGwKAggggAACCCCAAAIIIIAAAqEECOBDyZCOAAIIIIAAAggggAACCCCAQAMSIIBvQAeDTUEAAQQQQAABBBBAAAEEEEAglAABfCgZ0hFAAAEEEEAAAQQQQAABBBBoQAIE8A3oYLApCCCAAAIIIIAAAggggAACCIQSIIAPJUM6AggggAACCCCAAAIIIIAAAg1IgAC+AR0MNgUBBBBAAAEEEEAAAQQQQACBUAIE8KFkSEcAAQQQQAABBBBAAAEEEECgAQkQwDegg8GmIIAAAggggAACCCCAAAIIIBBKgAA+lEyMprtcIuPHJ8iI4YmSnx+jO8luIYAAAggggAACCCAQgwLbtom8/rrI6NEiZWUxuIPsUo0CBPA1EsVOho0bRTp1ErngvAS5565EaddOB/Oxs3/sCQIIIIAAAggggAACsSowd86O8/drrhG57DKR9u1FFi6M1b1lv0IJJIeaQXrsCbz1lsiasqUix44UyVklZXOvkeuuO1K+/joh9na2Ae6RuyJB3BVJkspfnaVHp0K5O91JkpZi6WrjfmU73JNxt/iTUOFRn3enck+1eMVxvjqPcnco90a4W/pJ8HgEd0vFd62szJEs6Wm7phmzRmDK18lS2HiOyJGvirhTZcuc62X48F4yUp3aM8SPQIJHDfGzu/G9p4ec8rfMPqCnSELFLogpz4rMGrxrmjEEEEAAAQQQQAABBBBoeAJ7fiJy7jkB29Vm2lRZ8/2AgDQmYluAe4GxfXwD9q5xP3V5bptf8K7mJhxzr7Q96Z2AfExERkBfKdPXyxITqPEQGeHgpeIe3CXSqbhHWjh0+RV8z4TGieAc3COIW03RuFeDE8FZuEcQt5qi1zmWirvS/KyjR6gUAvhKLDE9SQAf04c3cOdSWv4rsiwwzZPokNWu3wMTmUIAAQQQQAABBBBAAIGGJZBUdXMS8lTzWIa4EiCAj6PDfd1BV8vkZV8G7PGZPc6UB/s9GJDGRGQEnC6PlDvd0jidP7vICAcv1aXctyv3TNyDA0Uo1e32SKnDJVkZdD4QIeKgxVZUeKSkzCXZjXEPChShRF27qmibS3IycY8QcdBidSPQom3lyp3OB4ICRTCxoKRcmuAeQeHgRb88a6S89Xtgg/cbDr46eGZSY1aANvAxe2ir7pjb45ZHv3tUXv/1Ddm6PV/O2+s8eeTIR6RDToeqmUkJu0C5q0K2l7slm4Am7LbVFehU7qUOt+QQ0FTHFPZ5LhXAl5Q5OcELu2z1BbpVAF+0zSlNswhoqpcK71xdnbig2Cm52biHV7b60nQAn1/skGbZ9KZWvVT4524udEheDu7hl62+xH83rpcX5w6Tdxa8I8mJyXLpvpfKQ0c+JFmpWdUvyNyYEiCAj6nDaW5ntjkckr+tWNrn5plbgFxhESCADwtjrQshgK81WVgWIIAPC2OtCyGArzVZWBYggA8LY60LIYCvNVnYFiCADxtlrQraUuSQ3Kw02eYskaSEJElPSa/V8mSODQHq8sbGcazVXiQnpkiTRk1qtQyZEUAAAQQQQAABBBBAwH6BzNRM+zeCLbBNING2NbNiBBBAAAEEEEAAAQQQQAABBBAwLUAAb5qKjAgggAACCCCAAAIIIIAAAgjYJ0AAb589a0YAAQQQQAABBBBAAAEEEEDAtAABvGkqMiKAAAIIIIAAAggggAACCCBgnwABvH32rBkBBBBAAAEEEEAAAQQQQAAB0wIE8KapyIgAAggggAACCCCAAAIIIICAfQIE8PbZs2YEEEAAAQQQQAABBBBAAAEETAsQwJumIiMCCCCAAAIIIIAAAggggAAC9gkQwNtnz5oRQAABBBBAAAEEEEAAAQQQMC1AAG+aiowIIIAAAggggAACCCCAAAII2CdAAG+fPWtGAAEEEEAAAQQQQAABBBBAwLQAAbxpKjIigAACCCCAAAIIIIAAAgggYJ8AAbx99qwZAQQQQAABBBBAAAEEEEAAAdMCBPCmqciIAAIIIIAAAggggAACCCCAgH0CBPD22bNmBBBAAAEEEEAAAQQQQAABBEwLEMCbpiIjAggggAACCCCAAAIIIIAAAvYJEMDbZ8+aEUAAAQQQQAABBBBAAAEEEDAtQABvmoqMCCCAAAIIIIAAAggggAACCNgnQABvnz1rRgABBBBAAAEEEEAAAQQQQMC0QLLpnDGecfa8P8Xj8cghB/QM2NOCohKZOXuBrFi9Xrp2aitH9OklmRnpAXmYQAABBBBAAAEEEEAAAQQQQCDSAgTwSvjLabPkzqGvSc/dO8shr+0K4Ndu2CKX3faEbNy0VTq0bSlvjv1SunRsI6Oeu1Oa5mRF+thQPgIIIIAAAggggAACCCCAAAI+gbivQj/vj8Vy/5NvSVpqig/FOzLqw0lSUFgin40eZrzGvvKA/LdinXw44VtvFt4RQAABBBBAAAEEEEAAAQQQsEQgrgP4lWs2yE33vSRnndxPDj+4VxXwKdN/kX6H7Gvcfdcze3bvJAfus7tMmTGnSl4SEEAAAQQQQAABBBBAAAEEEIikQNwG8IXF2+S6u5+XXnt2kXtvurCKsaPcKfkFxbJb57YB8/T0OlW1ngEBBBBAAAEEEEAAAQQQQAABKwXisg280+WSW+5/SVWbT5Vnh9wgiYlVr2Pkby0yjkNGeqOA46GnS0rLRJeRkpws28vdAfOjYcLl9oi7whOV2x4NvqG20aXMK3APxROxdP1Zxz1ivCELdleIKHq+Z0IKRWaGNlf9seIeGd6QpWpz9T/uIYUiM0O76yEaz8V2bHl0/4u7PcdPuyck2LPucK21UWpSuIqKy3LiMoB/64NJsvCf5fLmM3dIkboTr19l2x3idDpl/cZ8adokS1J3tomvqFBnoX6Dy+2WRPVXk7Qz6NfBcLQNOqDRPe5H47ZHm7X/9lYoc32ygbu/SuTHDXe1Gtwjb+2/BuPEmu8ZfxJLxrW7+qbh826J9q6V7DgTwH2XiHVj2p7vd+u8/deEu7+GNeP6867P4xniWyAuA/jCoh0B+4U3Dq1y9PufO1iGD7tFtX3fxwjUi0pKA/IUFZdKk5xM3137zPToI3Q4K6RcvaJx2wMORpRNlLsqjLsEuFt74JzKvdTh5vNuLbtxQu1WF0D5vFsLr0/sXNtwt1Zd1zbxqJsAuFvtri9YOZx8v1vtrten7wLz/W69vP68N26UHPV34K2Xi601Rl/0GQb/ay85VQae0T+gpEeeGyObthTKy8NulubNmhgBeueOrWX+wiUB+eYvWmI8Dz4gkQkEEEAAAQQQQAABBBBAAAEEIiwQlwF8TlZj0S//QbdtT00tlfZtWviSTz/+cHl25Ecy5uMpcmjvveSrb3+WxctWy2P3XOXLwwgCCCCAAAIIIIAAAggggAACVgjEZQAfDFZ3BlG5Q4hB5xwny1euk2de/UieGvGBJCUlyuXnnyCnHts3WBGkIYAAAggggAACCCCAAAIIIBAxgQTVmRk9IdTAqzu4W7N+s3F3Pm1n53Y1LNKgZ3vbwGdlcP3GygPlbQOfnZFi5Wrjfl3eNvA5jXG38sOgOzcqKXNKk8xUK1cb9+vSbeCLtjmlaRbuVn4YdBv4gmKn5GbjbqW7PoPNL3ZIs+w0K1fLupTA5kKH5OXgbvWHYUuRQ3Kz0qrcdLR6O1ifvQJEcCb80xulSbdOgc+DN7EYWRBAAAEEEEAAAQQQQAABBBAIm0CDCOA3bMqXderxbQWFJcbjzfRj3Fq3bCYt85qGbUcpCAEEEEAAAQQQQAABBBBAAIFoFrAtgC9Wj2d7Y+yX8s33v8ryVeuDGnbu0FqOOeJAuWLgiZKZkR40D4kIIIAAAggggAACCCCAAAIIxIOALQH8l9NmyZOqU7gtW4uMwPzE/n2kU/tW0rpFrmGu78broP67WfPl9fcmyvivvpe7bxwoxx91UDwcE/YRAQQQQAABBBBAAAEEEEAAgSoClgbwm/ML5e5hr8usXxcZHcLpoLz/YftLWlrwTl+2O8pl6sy5MnzUeLn94VeMQP7xe6+WXFXFngEBBBBAAAEEEEAAAQQQQACBeBKwNID/Z+lKI3i/cuBJcv2lp0tNPbo3UoH9Kcf0lWNVNfqXRn0qoz+aLEuXr5HcffeIp2PEviKAAAIIIIAAAggggAACCCAglgbwjdPT5eE7LpOzT+pXK3p9h/6O686Xdq2bi+4RngEBBBBAAAEEEEAAAQQQQACBeBOwNIDfd69uol91HS44vX9dF2U5BBBAAAEEEEAAAQQQQAABBKJawNIAviapsu0OmTl7gZQ7nbL/3t2lbau8mhZhPgIIIIAAAggggAACCCCAAAJxIWBLAK8D9Xl/LJaysnI55MCe0jijkXw6aaYMffE9caiO6/SQlJRo9Dw/8IwBcXEg2EkEEEAAAQQQQAABBBBAAAEEqhOwPIAvLXPIpbc+IYv++c/YLh28j3xysDw7cpxkqPbt55zcTzwej0yY/IM8/tL7ctB+PaRbp7bV7QPzEEAAAQQQQAABBBBAAAEEEIh5AcsD+IlTfzKC9906t5MD991dvv95gVxy8+NG0P7uy/caVee1+pGH7CtX3fGMjP10mjw4eFDMHwh2EAEEEEAAAQQQQAABBBBAAIHqBCwP4OcvXGJsz2tPDZaWzXNly9YiGXDuYMlsnO4L3nWGvr33kmZNs2XVuk3VbT/zEEAAAQQQQAABBBBAAAEEEIgLAcsD+JJtZZLbJMsI3rWwDtK7dW4rump95SEvt4ls3lJQOZlpBBBAAAEEEEAAAQQQQAABBOJOINHqPd5e7hT9XHf/ISO9kdFpnX+aHs9ITxN3RUXlZKYRQAABBBBAAAEEEEAAAQQQiDsBywN4LZxQiVlPJ1RJrZSJSQQQQAABBBBAAAEEEEAAAQTiWMDyKvTaetOWQrngukd87Ev+WyMVqud5/zQ98+9/V0r7ti18+RhBAAEEEEAAAQQQQAABBBBAIF4FbAngnS6XLPhrWRXzYGlVMpGAAAIIIIAAAggggAACCCCAQBwKWB7ADx96szhdbtPUiYm21PI3vX1kRAABBBBAAAEEEEAAAQQQQMAKAcsDeN2BXVqaFbvGOhBAAAEEEEAAAQQQQAABBBCIHQFub8fOsWRPEEAAAQQQQAABBBBAAAEEYljA8jvwjz7/jsxbuMQ0aad2reT5h28wnZ+MCCCAAAIIIIAAAggggAACCMSigOUB/Mq1G2Xx0lWmLd1u8+3lTRdKRgQQQAABBBBAAAEEEEAAAQSiTMDyAL5tqzyDKCU5Wc499UgZdO7x0jKvaZSxsbkIIIAAAggggAACCCCAAAIIWCuQ4FGDtasUmb/wX3nzgy9lxk/zJSU5SU47/jC54oITpX0bnvluxbFwOCukXL2yMiy/fmPF7jXYdZS7KmR7uVuyM1Ia7DbG4oY5lXupwy05jXG38vi63B4pKXNKk8xUK1cb9+tyV3ikaJtTmmbhbuWHoUKdShUUOyU3G3cr3fUZbH6xQ5pl0zuyle56XZsLHZKXg7vV7luKHJKblSYJCVavmfU1JAFbAngvwLIVa2XUh1/JF1NnibuiQo4/srdcdeHJ0r1re28W3iMgQAAfAVQTRRLAm0CKQBYC+AigmiiSAN4EUgSyEMBHANVEkQTwJpAikIUAPgKoJoskgDcJFeZsBPBhBo3S4mzthb5LxzYy9K4rZMqHT8upx/aVSd/+LGdc8YBMnPpTlHKy2QgggAACCCCAAAIIIIAAAghERsDWAF7v0sbNBTJm3BSZMmOOsYft2jSXdq2bR2ZvKRUBBBBAAAEEEEAAAQQQQACBKBWwrRH06nWb5K2xk2TC5O9Ve2yX7N61g1w58EQ5/qiDJDHR9usKUXo42WwEEEAAAQQQQAABBBBAAIFYFbA8gNft3l9/7wtVXX62uN0VckCv7ipwP1mO6NMrVo3ZLwQQQAABBBBAAAEEEEAAAQTqLWB5AP/48LHy05yFxoYPPGOA7Lf3blJSWma0fw+2NzlZGXJo772DzSINAQQQQAABBBBAAAEEEEAAgbgRsDyA95cdO36a6Fd1Q9dObeTz0QTw1RkxDwEEEEAAAQQQQAABBBBAIPYFLA/gLzv3eDlBtXM3O2RnNjablXwIIIAAAggggAACCCCAAAIIxKyA5QF83957xSwmO4YAAggggAACCCCAAAIIIIBApATo7j1SspSLAAIIIIAAAggggAACCCCAQBgFLA3g58z/W954/4s6b/4royfIbwuX1Hl5FkQAAQQQQAABBBBAAAEEEEAgWgUsDeDLnU554Y1P5MGnRklxSalps8LibXLPY6/LCBXAu1xu08uREQEEEEAAAQQQQAABBBBAAIFYEbC0Dfxee3SRE/v3kf9NmikzZs2Xqy86xZjObZIV1DN/a5FMnDZL3lDPjd9aWCynHttX9ujWIWheEhFAAAEEEEAAAQQQQAABBBCIZYEEjxqs3sGf5i6SR54bI6vWbpSkpETpvc8e0qlDK2nTopmxKWs3bpEVqzbIL/P/Ere7Qjq1byVDBg+Sg/brYfWmxuT6HM4KKVevrAxLr9/EpGVtdqrcVSHby92SnZFSm8XIW08Bp3IvdbglpzHu9aSs1eIut0dKypzSJDO1VsuRuX4C7gqPFG1zStMs3OsnWbulK9SpVEGxU3Kzca+dXP1y6zPY/GKHNMtOq19BLF1rgc2FDsnLwb3WcPVcYEuRQ3Kz0iQhoZ4FsXhUC9gSwfU9sKd8NnqY8Qz4b76fpwL1v2X2vD8DIHVgv2/PbtL/8APkgtP7S2qKLZsasE1MIIAAAggggAACCCCAAAIIIGCXgG1RcVpqilx23gnGq2y7QzZtKZD8rcWGQ27TLGmR11QapXEl264PButFAAEEEEAAAQQQQAABBBBoWAK2BfD+DOmN0qRD25bGyz+dcQQQQAABBBBAAAEEEEAAAQQQ2CFgaS/0oCOAAAIIIIAAAggggAACCCCAQN0ECODr5sZSCCCAAAIIIIAAAggggAACCFgqQABvKTcrQwABBBBAAAEEEEAAAQQQQKBuAgTwdXNjKQQQQAABBBBAAAEEEEAAAQQsFSCAt5SblSGAAAIIIIAAAggggAACCCBQNwEC+Lq5sRQCCCCAAAIIIIAAAggggAAClgo0iMfIzZg1Xxb9s1w2bMyXc045Uvbu0UV+nveXLF62Sg4/uJd0at/KUhRWhgACCCCAAAIIIIAAAggggEBDE7A1gC93uuTq/3ta5vz+j8+l9357GAG82+2WJ4aPlf9WrpMHBw/yzWcEAQQQQAABBBBAAAEEEEAAgXgUsLUK/Zvvf2EE70cfup88/eB1hn9CQoLx3rf3XtKlYxv5ce7CeDwu7DMCCCCAAAIIIIAAAggggAACAQK23oGf9eufkpmRLs/o4H1n4O6/dXvv0Vm+mDZLKioqJDHR1msN/pvFOAIIIIAAAggggAACCCCAAAKWC9gaFW/aUiD79OwqaWmpQXc8NTVFEhNs3cSg20UiAggggAACCCCAAAIIIIAAAlYL2HoHvnOHVvLLb39LaZlDkpICA3WXy210ZNehXYuI3H13OMpl9m9/ydLla2VrQZG0atFMjjuyt+Tl5gQcg4KiEpk5e4GsWL1eunZqK0f06WXUGgjIxAQCCCCAAAIIIIAAAggggAACERawNYA/qu9+RnA87MV35eqLTvHtanFJqTz6wruycs2GgHRfhjCMDHlmtEyc+pNkZWZIi7wmsnzVennhjY9l9At3S8/dOxtrWLthi1x22xOycdNW6dC2pbw59kujXf6o5+6UpjlZYdgKikAAAQQQQAABBBBAAAEEEEDAnICtAbx+ZNyMWb/LhMk/yOdTfjS2+NHn3pF7tjuMdu+6E7trLt4V2JvbJXO5DujVXc46+Qjpvc8exgK6t/szLn9Axo7/RobdfaWRNurDSVJQWCKfjR5mBPCLFi+XC68fKh9O+FauG3SauRWRCwEEEEAAAQQQQAABBBBAAIEwCNgawOse50c8dosRwI//6nv5T90F366C9x7dOhjPf7/6opNDto+v777riwf+Q05WY1VVPyHgzvqU6b9Iv0P2NYJ3nbdn905y4D67y5QZcwjg/fEYRwABBBBAAAEEEEAAAQQQiLiArQG83jsdxJ9xwuHGK+J7G2QFupr+bNUbvu7tPr1Rmpx/2tFGLke5U/ILimW3zm0DltLTf/y1zJfmdFX4xqNlxF3hkQqPR6Jx26PFONh2ut0eUey4B8OJYJoL9wjqhi7arb4a+byH9onUHPX1Lup/vmciBRyiXG2OewicCCZrcz1wPrPDwep/cbdafMf6nOoHdsdDt+1ZfzjWmpIc2PdZOMqMpzJsDeA/nTRT/lm6Sq695NSAO9/eAzD87fGyfmO+DL3rCm9S2N/HjJsiH372rdFR3o2XnaE6s8s11pG/tch4z0hvFLBOPV1SWqZ+LFySkpwspQ53wPxomNDBu0edXEfjtkeDb6ht1O7qiYi4hwKKULpHuetgks97hIBDFKuDd/2Zxz0EUISStbv+zOMeIeAQxepAEvcQOBFO1p95Pu8RRg5RPO4hYCKYrD/vZVEYe1QmySGAr0xSq2lbA/g58/+Wz7/+Sb79YZ68+OjNsmf3jgEbv1gF98tV7++RHO6+aaDccOnp8sOchfLgU6NE9zp/1w0XiH6EnR70M+j9B5fbrR5tlyBJO59Ln9N4Rz7/PA193OGskHL1ysqw9fA3dKawb1+5qq2xvdwt2RnR95kJO4aFBeo7BPokIxr/Vi1kCvuqdM2HkjIn7mGXrb5AXcOqaBvu1SuFf66+WFVQjHv4ZasvUQcz+cUOvmeqZ4rI3M2FuEcEtoZCtxQ5jPNIFYowxLGA7fUXdDC8Ob9QLrpxqHy2syM7K4+Hvoue2zRbTj22r/Q5YE/59sd5xuqb5mQagXqR6hHffygqLpUmet7OAN5/HuMIIIAAAggggAACCCCAAAIIRErA9gC+Tes8GfPSvdIkO1PuffwNGfbie6KfAR/pQVd1qzzoNu/paWlGsg7QO3dsLfMXLgnINn/REuN58AGJTCCAAAIIIIAAAggggAACCCAQYQHbA3i9f716dJGP33jY6OF97PhpcvngJ2XLzjbokdr/Uy65R0a+87noavwL//5PHnlujCz65z857sjevlWefvzh8tPcRTLm4yny7/I18vKoT2XxstW2dbjn2zBGEEAAAQQQQAABBBBAAAEE4k6gwTSCbqaqsY967i556pUP5L3/TZWzr3rQaIeetrMteriPTOcOreWVMRPErXu3UkNycpJcet7xcvVFu547P+ic42S5ej78M69+JE+N+ECSkhLl8vNPMKrbh3t7KA8BBBBAAAEEEEAAAQQQQACB6gQaTACvN1IHyPfcdKHstUdnGfLMaHE4ylV19TbVbX+d57087BbVkZtL9XK/xaiy37Z1c6l8sUBvzyN3Xi733HyhrFm/Wdq3aVElT503gAURQAABBBBAAAEEEEAAAQQQqIWArQF8m1Z5Uli0rcrmnnJMX/X89XZyx6MjJatxRpX54UpITUmWDm1b1licfj58t06Bz4OvcSEyIIAAAggggAACCCCAAAIIIBBGgQTVmVvV3tzCuAKKangCPEbOnmPCY+Tscecxcva4ex8j1yQz1Z4NiNO1eh8j1zQLdys/At7HyOVm426lu/cxcs2yd3RAbOW6431d+jFyeTm4W/050I+Ry81KEx4jZ7V8w1qf5Z3Y6Wrr21XVeAYEEEAAAQQQQAABBBBAAAEEEDAvYHkV+oHXPyp/LVkhf0x/Wx597h2Z9M3sare2W+e28v6I+6vNw0wEEEAAAQQQQAABBBBAAAEEYl3A8gC+aU6m5DbJMlz1u+48rrqhebOc6mYzDwEEEEAAAQQQQAABBBBAAIG4EKANfFwc5sCdpA18oIdVU7SBt0o6cD20gQ/0sGqKNvBWSQeuhzbwgR5WTdEG3irpwPXQBj7Qw8op2sBbqb1rXbSB32URz2OWt4E3g63byW8r3W4mK3kQQAABBBBAAAEEEEAAAQQQiAsBWwP4+Qv/lYtvekzeGvulD/vltz6VI864WQ4+6Tq55YGXpWy7wzePEQQQQAABBBBAABTUAOYAAEAASURBVAEEEEAAAQTiVcDWAP7zr3+UeX8slj4H9jT8/1y8Qka++7lUVFSotvF5Mu37X2XkO5/H67FhvxFAAAEEEEAAAQQQQAABBBDwCdgawP+7fI20a9NcenbvZGzQJ1/MMN4fu/sq+eq9J2XfvbrJxK9/MtL4BwEEEEAAAQQQQAABBBBAAIF4FrA1gN9aWCId2rTw+S/8+z9JS02RI/vuK4mJibJfz91k45YCcbpcvjyMIIAAAggggAACCCCAAAIIIBCPArYG8K1b5Iq+C697b127YYvxfPgeu3WU5OQk41gUFJVIUlKieu2YjscDxD4jgAACCCCAAAIIIIAAAgggoAUsfw68P/thB/eSH+cslPOueUi2O5xGIH/68YcZWXQ7+Lm//yNtWuZJYkKC/2KMI4AAAggggAACCCCAAAIIIBB3ArbegT//tKPlsIP2Ft153bIVa2W/vXaTs046wjgIEyb/IKvWbpRDD9or7g4KO4wAAggggAACCCCAAAIIIIBAZQFb78CnpiTLyCcHy1IVvCepNu+dO7T2bd/uXdvLS0Nvlr336OJLYwQBBBBAAAEEEEAAAQQQQACBeBWwNYDX6Amqeny3Tm2r+PfcvbPoFwMCCCCAAAIIIIAAAggggAACCIjYWoWeA4AAAggggAACCCCAAAIIIIAAAuYECODNOZELAQQQQAABBBBAAAEEEEAAAVsFCOBt5WflCCCAAAIIIIAAAggggAACCJgTIIA350QuBBBAAAEEEEAAAQQQQAABBGwVIIC3lZ+VI4AAAggggAACCCCAAAIIIGBOgADenBO5EEAAAQQQQAABBBBAAAEEELBVwNLHyK3bsEW+njm3Vjuc2yRLTjmmb62WITMCCCCAAAIIIIAAAggggAACsSZgaQC/bOVaeWrEB7Uy7NqpDQF8rcTIjAACCCCAAAIIIIAAAgggEIsClgbwPXbrJC8NvblWjo0zGtUqP5kRQAABBBBAAAEEEEAAAQQQiEUBSwN4XR2+/2H7x6Ij+4QAAggggAACCCCAAAIIIIBARAUsDeBD7ck/S1fKon+Wy4ZNW+WYfgdKt05t5a8lK2TN+s3Sq0dXaZHXJNSipCOAAAIIIIAAAggggAACCCAQFwK2BvAVHo/c+9gbMnHqTz7sdm2aGwH8itUb5PaHX5FB5x4vd15/vm8+IwgggAACCCCAAAIIIIAAAgjEo4Ctj5F7739TjeC9V48ucvu15wX4H3dkb2nXurnMnP17QDoTCCCAAAIIIIAAAggggAACCMSjgK0B/PQff5O0tFR549k75MIzBxj+CQkJvncd2K9eu0n0nXoGBBBAAAEEEEAAAQQQQAABBOJZwNYAfu2GzXJAr+6SmZEe9BhkZzVWwXuFeCoI4IMCkYgAAggggAACCCCAAAIIIBA3ArYG8B3atJA//lom5U5XFXCPuus+b+ESoxp9UpKtm1ll20hAAAEEEEAAAQQQQAABBBBAwGoBWyPjPvvvKcUlpfLK6AlSWrbdt+8ul1ueHTlOFi9dJX177+VLZwQBBBBAAAEEEEAAAQQQQACBeBVIUHe6baufrgP1i24aZtyF19XoS0rLjDvupdsdkr+1SPJyc+TzMY9JjqpKzxA+AYezQtV6qJCsDFsfQhC+HYqSkspdFbK93C3ZGSlRssWxsZlO5V7qcEtOY9ytPKIut0dKypzSJDPVytXG/brcqslZ0TanNM3C3coPg+6rp6DYKbnZuFvprs9g84sd0iw7zcrVsi4lsLnQIXk5uFv9YdhS5JDcrDTZ2WWY1atnfQ1EwNY78MnJSTLmxXvkhktPl+ysDPVhTJDV6zaJqG/k0447VMaPGkrw3kA+KGwGAggggAACCCCAAAIIIICAvQK234JNS02R61UAr18OR7k4yp0qmOeOu70fC9aOAAIIIIAAAggggAACCCDQ0ARsD+D9QfQj5fSLAQEEEEAAAQQQQAABBBBAAAEEAgUsDeB1p3Qj3/08cAtqmGrTMk/+77rzasjFbAQQQAABBBBAAAEEEEAAAQRiW8DSAH5TfoFMmTGnVqJdO7UhgK+VGJkRQAABBBBAAAEEEEAAAQRiUcDSAL7P/j1l5viXfI768XHjPp8uE94eJk1yMn3pemTSN7PlieFjVQd3ZwSkM4EAAggggAACCCCAAAIIIIBAPApY2gt9UlKiNGua7Xst/Oc/6dalnei77P7pevzCs46Rtq3yZNSHk+LxuLDPCCCAAAIIIIAAAggggAACCAQIWBrAB6xZTRQUlUiC+i/YkKgeKddz987y15IV6pnlrmBZSEMAAQQQQAABBBBAAAEEEEAgbgRsDeC7dWor/y5fLYuXra4C7nZXyNIVa6SiwiMul7vKfBIQQAABBBBAAAEEEEAAAQQQiCcBS9vAV4Y979Sj5btZv8vltz0p/Q/bXw47eG/Jy82RBX8ulek/zZely9fK+acdLRnpaZUXZRoBBBBAAAEEEEAAAQQQQACBuBKwNYA/ok8vueP68+XFN/8nn3z5nfHy19dt42+75hz/JMYRQAABBBBAAAEEEEAAAQQQiEsBWwN4LT7onOPk2CMOlKnf/yrLVqyVkpIyad0yV/bu0UUGqHTdFp4BAQQQQAABBBBAAAEEEEAAgXgXsD2A1wegdctmcsnZx8b7sWD/EUAAAQQQQAABBBBAAAEEEAgp0CAC+MVLV8mUGXNkxeoN4qpwS7tWzaXvgT2lb++9Qm44MxBAAAEEEEAAAQQQQAABBBCIJwHbA/hnXv1IxoybLBUeT4D72x99Jf367CMvDr1JUpJt38yAbWMCAQQQQAABBBBAAAEEEEAAAasFbI2Mv5g2S3SgvlvndnLNJafIHl07SGJioqxcs8FI/2727/KS6uDu9mvPs9qF9SGAAAIIIIAAAggggAACCCDQoARsDeAnfv2T5GQ3lrdfuEua5mT5YDq2aymHHNBTBl7/qOggnwDeR8MIAggggAACCCCAAAIIIIBAnAok2rnfS1Wv8z137xwQvHu3Jzk5SQ5R7eA3bi6Qkm1l3mTeEUAAAQQQQAABBBBAAAEEEIhLAVvvwLdrlSer124y2r8He1zcitXrJS0tVb1Swn5wtpVul1m/LpL/Vq4zytbPpN9dVeGvPBQUlcjM2QtUB3vrpWuntqLzZWakV87GNAIIIIAAAggggAACCCCAAAIRFbA1gO+9Xw95ZfQEefS5d+S2q8+W7KzGxs46yp3y3v+mytSZvxod2UWiE7vbhgyXH+cslNwmO6ruv/DGJ9K5Q2t59+V7fTUC1m7YIpfd9oRs3LRVOrRtKW+O/VK6dGwjo56705cnokeHwhFAAAEEEEAAAQQQQAABBBDYKWBrAH/VhSfL9B9/k3ETp8v4r76XVi1yRVedX6cC5+2OcmmSnSn33XpxRA7WYQf3kpsuP1P27tFFPKoH/I8nzpCHnxsjH074Vq4bdJqxzlEfTpKCwhL5bPQwI4BftHi5XHj90IA8Edk4CkUAAQQQQAABBBBAAAEEEECgkoCtbeBTU5Ll/RH3q7vv56jq6W1ky9ZCo0p965bN5MIzB8jEdx6XtqqafSSGS84+1gjeddkJCQly6nGHGu/64oF3mDL9F+l3yL5G8K7TenbvJAfus7vxzHpvHt4RQAABBBBAAAEEEEAAAQQQsELA1jvwegfTUlPkyoEnGS89re+G64Da6uG3hUuMdXfu2NpYta7Gn19QrB5x1zZgU/T0H38t86VVfn69b0YDHlHEov43+h5owJsZc5um3fUQjZ+ZHVsenf/ibs9xwx13ewTsWSufd9ztEbB3rZzP2OOv3a2PlMK7r8H6PgvvGmK7NNsD+Mq8dgTvDlVd/9mR44x27WeccLixSflbi4z3jPRGAZuop0tKy8Tpcolum19Q7AyYHw0TRhyp/vgLXBXRsLkxs43aXV+gKnBF32cmmg+Czz0K/1Zxj2YBe7adz7s97nqt+qQ6Gs8J7BMLz5oVO+7hoax1KXzea01W7wX0572wJPrPI3OzU+ttEc8FWB7Aj/5osixetsq0eesWzeSmK840nb+2GcudLrnx/pdkmXqk3cgnBxvt7nUZqapmgB4qKgKDXJfbLfqqUVLijtYH0fgBdDgrpFy9sjIsP/yGabz+U64umGwvd0t2RvifqhCvpmb226ncSx1uyWmMuxmvcOVxuT1SUuaUJpn8SIfL1Ew57gqPFG1zStMs3M14hSuPN3iPxnOCcBnYUY4OZvKLHYK79fqbC3G3Xl1kS5HD+H63obKyHbvLOkMIWB7B/Th3ofyken83O+i28ZEK4PWj5G66/0VZ8OcyGT7sFjlI9YrvHZrmZBqBelFJqTfJeC8qLpUmet7OAD5gJhMIIIAAAggggAACCCCAAAIIREjA8gDe/5FwuqO6E4/uY/Q8H2r/IvEMeL2uDZu3yvV3Py8b1CPiRj1/l/RSvdH7DzpA1+3h56u28f7D/EVLjOfB+6cxjgACCCCAAAIIIIAAAggggECkBZIeUkOkV+Jf/oDD95fmeU1k2cp18uMvC+XneX9K29bN5dCD9pY2qvf5FnlNA17Nmmb7Lx628dMuvU+Wr1pvPDIuKSlRlqoq9N5Xx3atjDvsZdvLZdzn0yWzcbrxev/TaUYP9Ddedobs0a1D2LbF6oJ0FUv9Skux9SEEVu+27evT5rpacVpKku3bEk8bUKHcncq9USruVh53xS662QjuVqrrfjZEdDOp9DQ+71bKK3bVRAp3K8296ypTTdMy0iy/H+Vdfdy+66ZpGY1wt/oDUKbc09XnnSr0Vss3rPUlqE619O+O5YNuWz55xhwZ9cEk+WvJCtGB+qBzjpPzTj9aMjPSI749+wy4Qlwud9D1zJo4QrKzGovbXSEPPztaxk/+wWgLrwN9vY2DrznXlp7yg25sHRJpA18HtDAsQhv4MCDWoQjawNcBLQyL0AY+DIh1KII28HVAC8MitIEPA2IdivC2gW+WnVaHpVmkPgK6DXxeDu71MazLsroNfG5WGgF8XfBiaBnbAnh/w5/mLpI3x36h7sb/JVmZGfLskOvk0N57+2exdbxsu0PWrN8s7du0MB57Z+vGhGHlBPBhQKxDEQTwdUALwyIE8GFArEMRBPB1QAvDIgTwYUCsQxEE8HVAC8MiBPBhQKxjEQTwdYSr52IE8PUEjJHFba/7ou9yb84vlE1bCg1S/Ui37Y6G9XiE9EZp0q1T2xg55OwGAggggAACCCCAAAIIIIBANArYFsDrx7eN/+p7owr96nWbjGrzV1xwolyiqqjn5eZEoyXbjAACCCCAAAIIIIAAAggggEDEBCwP4HV19I8+my6jx01Wd90LJFe1fb/lyrNk4BkDjI7iIranFIwAAggggAACCCCAAAIIIIBAFAtYHsDf/tAr8t3s3w0yHbSfeeLh0igt1QjmdUBfeUhJSZZ2qpd6BgQQQAABBBBAAAEEEEAAAQTiWcDyAN7p3tXz+9jx00S/qhu6dmojn49+rLoszEMAAQQQQAABBBBAAAEEEEAg5gUsD+D7H7a/dG7fyjQs7eFNU5ERAQQQQAABBBBAAAEEEEAghgUsD+DPP+3oGOZk1xBAAAEEEEAAAQQQQAABBBCIjEBiZIqlVAQQQAABBBBAAAEEEEAAAQQQCKcAAXw4NSkLAQQQQAABBBBAAAEEEEAAgQgJEMBHCJZiEUAAAQQQQAABBBBAAAEEEAinAAF8ODUpCwEEEEAAAQQQQAABBBBAAIEICRDARwiWYhFAAAEEEEAAAQQQQAABBBAIpwABfDg1KQsBBBBAAAEEEEAAAQQQQACBCAkQwEcIlmIRQAABBBBAAAEEEEAAAQQQCKcAAXw4NSkLAQQQQAABBBBAAAEEEEAAgQgJEMBHCJZiEUAAAQQQQAABBBBAAAEEEAinAAF8ODUpCwEEEEAAAQQQQAABBBBAAIEICRDARwiWYhFAAAEEEEAAAQQQQAABBBAIpwABfDg1KQsBBBBAAAEEEEAAAQQQQACBCAkQwEcIlmIRQAABBBBAAAEEEEAAAQQQCKcAAXw4NSkLAQQQQAABBBBAAAEEEEAAgQgJEMBHCJZiEUAAAQQQQAABBBBAAAEEEAinAAF8ODUpCwEEEEAAAQQQQAABBBBAAIEICRDARwiWYhFAAAEEEEAAAQQQQAABBBAIpwABfDg1KQsBBBBAAAEEEEAAAQQQQACBCAkQwEcIlmIRQAABBBBAAAEEEEAAAQQQCKcAAXw4NSkLAQQQQAABBBBAAAEEEEAAgQgJEMBHCJZiEUAAAQQQQAABBBBAAAEEEAinAAF8ODUpCwEEEEAAAQQQQAABBBBAAIEICRDARwiWYhFAAAEEEEAAAQQQQAABBBAIpwABfDg1KQsBBBBAAAEEEEAAAQQQQACBCAkQwEcIlmIRQAABBBBAAAEEEEAAAQQQCKcAAXw4NSkLAQQQQAABBBBAAAEEEEAAgQgJEMBHCJZiEUAAAQQQQAABBBBAAAEEEAinAAF8ODUpCwEEEEAAAQQQQAABBBBAAIEICRDARwiWYhFAAAEEEEAAAQQQQAABBBAIpwABfDg1KQsBBBBAAAEEEEAAAQQQQACBCAkQwEcIlmIRQAABBBBAAAEEEEAAAQQQCKcAAXw4NSkLAQQQQAABBBBAAAEEEEAAgQgJEMBHCJZiEUAAAQQQQAABBBBAAAEEEAinAAF8ODUpCwEEEEAAAQQQQAABBBBAAIEICRDARwiWYhFAAAEEEEAAAQQQQAABBBAIpwABfDg1o6Gsjd9LyuyBkjGzn8h/74q4HdGw1WwjAggggAACCCCAAALxLeBxi6weL/LtsSIzThZZO0nEUxHfJnG498lxuM/xu8v580SmHSG+qzazfhIpWSay95D4NWHPEUAAAQQQQAABBBCIAoG01e9Lwu9X79rStV+KHP6pSPszdqUxFvMCCR41xPxesoM7BH6+UmTpW4EaCSqcT20amMZUZATUX5r+Y0tIiEzxlBpCAPcQMBFONtw96vPOBz7C0lWK1z/ruFdhiXgC7hEnDroC3IOyRDwR94gTB19BeaE6mXQFzms1QOToqYFpTMW0AHfgY/rwVto5/UdfedDVbhxbKqcyHSEBQpkIwdZQLO41AEVoNu4Rgq2hWNxrAIrQbNwjBFtDsbjXABSh2bhHCLYuxTqDnN/XpRyWiRoBAvioOVRh2NDu14ms+iSwoN2uFek1NDCNqYgION0Vsr3cLVnpKREpn0KDC2j3ModbsjNwDy4UmVRXhUe2lbkkpzHukREOXqpb3X0v3uaSJpm4BxeKTGqFci8scUnTLNwjIxy8VF2HdGtJueRmpQbPQGrEBLYUlUuzbNwjBhyi4NKFIyTjnyGBc3dT5/cMcSVAAB9Ph7vlUSIHvyGexa+IlK6VhN2uEtn9FpG0ZvGkYNu+elwVqgq96nwkjRM8Sw+CdtedvuBuKbu4PeJxO5U7J3iWwqsLJx4n7paa65WpSNJTjrv17oq+XHXGm5Zm+arjfYWeVNzt+Axs73KjZKSrz/u/r6k2mep8Ut+I6zTQjk1hnTYK0AbeRny7Vu1wVki5OtHIaswPnpXHoFwFkvoOPHeCrVQXcSr3UnUHnjvB1rq7VABfUuZUd4IJ4K2Ud6sAvmibU90Jxt1Kd30HvqDYKbnckbSSXV83kfxih7oTzPmMpfBqZZsLHZKXg7vV7luKHKrGSZokiGoCa/QxQ2MGq49BQ1gfd+AbwlGwYxsSkuxYK+tEAAEEEEAAAQQQQACB+gjoTqgZ4laAox+3h54dRwABBBBAAAEEEEAAAQQQiCYBAvhoOlpsKwIIIIAAAggggAACCCCAQNwKUIVeHfqpM+fKbp3bSaf2rap8EAqKSmTm7AWyYvV66dqprRzRp5dkZqRXyUcCAggggAACCCCAAAIIIIAAApEUiOsA3uVyy4xZ82XwkBFy360XVwng127YIpfd9oRs3LRVOrRtKW+O/VK6dGwjo567U5rmZEXyuFA2AggggAACCCCAAAIIIIAAAgECcRvAL/lvtZxx+QOqB1PVhWmIYdSHk6SgsEQ+Gz3MCOAXLV4uF14/VD6c8K1cN+i0EEuRjAACCCCAAAIIIIAAAggggED4BeK2DbyuLv/FO4/LuNeGhFSdMv0X6XfIvkbwrjP17N5JDtxnd5kyY07IZZiBAAIIIIAAAggggAACCCCAQCQE4jaAT0lONqrMd2xXtd27hnao56TnFxSrtvFtA9z19DpVtZ4BAQQQQAABBBBAAAEEEEAAASsF4rYKfU3I+VuLjCwZ6Y0CsurpktIycbpcoi8C5BeVB8yPhgmj0YBqOpBfVBENmxsz26jddZONaPzMRPNBwN2eo4c77vYI2LfWCr7fbcHXLSH5XbWFHncb2PXnfWtx9MUelalys1MrJzFdCwEC+BBYqakpxpyKisAg1+V2S2JCgiQl7qi80CRrR74QxTTI5HKnR8pdFZKZntQgty9WN8rp8ojD6Vbu/NlZeYxdyr2s3C1ZGbhb6a6+KmXbdqdkN46+70grncK9Lv2TVVzqlJxM3MNtW115+qS6sMQp0XhOUN1+NfR52r2gpBx3Gw6UvmjC5916eB286+93FYowxLEAZ7QhDn7TnEwjUC8qKQ3IUVRcKk30vJ0BvA7mo21ISPCI3upo3PZos/bfXu2uB9z9VSI/jnvkjYOtoYLPezCWiKd5cI+4cbAVVAjf78FcIp22Q53f1Ug7hyqf85lQMpFN1+5RGH5EFiXOSo/bNvA1HWcdoHfu2FrmL1wSkHX+oiXG8+ADEplAAAEEEEAAAQQQQAABBBBAIMICcRvA607q9GPh/lQvPehnvuvpzfmFxrT+5/TjD5ef5i6SMR9PkX+Xr5GXR30qi5epx8+dcLgvTzSOpKUkUp3YhgOXmpwo2RlUa7WaPkW551CN22p2SU5KkCaZtHGzGj4pMUGaZuFutbu+I0abTqvVxbgL2Sw7zfoVs0bJy8Hdjo+B/rxz990O+Ya1zgTVqZa3BlLD2rIIb40RiF9+f5W13HT5mXLtJaca6W53hTz87GgZP/kH0W3hk5ISZdA5x8nga85VfzzRV3W+ys6SgAACCCCAAAIIIIAAAgggEDUCcRvA1+YIlW13yJr1m6V9mxaStrNzu9osT14EEEAAAQQQQAABBBBAAAEE6itAAF9fQZZHAAEEEEAAAQQQQAABBBBAwAKBpIfUYMF6WEUYBabOnGs8xk73hu8/bCvdLjNn/y7f/DBP5v2xWDIbN5K83Bz/LNWOFxSVyNffzVWvObJla5G0btlMUlMC22ybyVPtSqJ4Zij3yrs0e96fsmrtRqPGRuV5waZ1K5bvf/5DJn0z2+hrITuzsTTJDjy2uCcaT38I5ldSWiZzf19sfHZn/bpIunZsIxnpNbfNwz2Y5q606j7v5U6X/DDnD/l8yo/idLmlVYtmRhOjXUuHHjPjbiZP6DVE3xz9/PDfVIep+rt7xqz5on31969utuU/1Od7wIypmTz+2xPt42bc6/u7asbUTJ5ot668/Wb22UyeyuV6p80sayaPt7xYea9pn838TdRkseS/1cb5zOxf/xT96OV2rZsHLFLTNgRkjpGJ2u7z8lXrZda8RYZdSrK5B4bhHiMfFpO7wR14k1ANIZtLnSjrk7vbHhwu9916sZx/2tEBm3X1Hc/Ij3MWSm6TLCM9v6BYOndoLe++fK80zdmRFrCA34TuxO+y256QjZu2Soe2LWX56vXSRQVCo56707esmTx+RcbMaE3u/jv65bRZcufQ16Tn7p1l3GtD/GcFHddf6jq/Dt47tW8l+piVqw4WXx52i/Q9sKexDO7BP+8aZ+7v/8jtD78i+eqCU5tWeaIf+/jK47fKfnvtFtTbm4i7V6Lqe02f95mzF8j/PfKKukCYIXt27yi//bFEBZw7PrN99t+zaoF+KWbczeTxKzImRj+dNFMeeGqUpKWlSnN10XX1uk3GRain7r9Wjjp0P2Mf6/M9YMbUTJ6YwPbbCTPu9fldNWNqJo/fJsfEqJl9NpMnFIaZZc3kCVV+tKab2WczfxPV7f9X03+Wu4e9LtmZGZKR0UhWr90kF599rNx940BjMTPbUF350Tivtvu8fmO+nH/dI7JpS4F8/eEz0lad29Q04F6TUAzOVx8shigQWLxslafnkZd69uw3yHh9MOGbKlutesv3LPhzqZGuOt3zfPTZt0beV0ZPqJK3csKjL7zjOejEaz0rVq83Zi385z/PPv2v8PgvayZP5XKjfdqMu3cff13wj2ffAVd49jvmSs85Vz/kTa72/Zf5fxnHaOz4aUa+7Y5yz9lXPeg57dL7fMvhPsgT7PO+cs0GT6/+l3suv+1Jz8bNWw0vt9vtUQGozy7UCO7BZcx83k++5B7P8QPv9GhrPag7lJ6+p9zgufimYcEL9Us1424mj1+RMTGq7lR5Jkz+wffZXbVmo6f3CdeE7XvAjKmZPDGB7bcTZtzr87tqxtRMHr9NjolRM/tsJk8oDDPLmskTqvxoTTezz2b+JkLtv/5N6HfmLcZvsvf3QT29yTjHWbp8jbGYmW0IVX60ptdmn0u2lXlOv/x+4/xbn++ri7k17jbuNRLFZIbA+nkxeIEiVnZJ35394p3Hq72re4m6yrl3jy7GLute8k897lCjt/x16u66d1ABonFlTwWF3iTjfcr0X6TfIfsad991Qs/uneTAfXaXKTPm+PKZyePLHCMjZtz1rqpgUm667yU56+R+cvjBvYLu/ZPDxxr26gvaN3+ycm+k7rqdc/KRRpruJPHcU44SXRVq2Yq1RhruPq6AkdfenSj6SRFDbh8kzZs1MeYlJiZWqXaMewBbtRNmPu/b1Oe3ebMc0dZ60M0VunZqI271pA7/oa7uZv4m/NcTC+MH799DTlPf194q8+3aNFffv3uox5tu9u2e2e8B3H1kNY6YcTfzu6pXhHuN3L4MZv7GzeTB3UdqasSMqZm/iVDuv6qmm/qu8cAzB/h+H/Tdd30+6j2XNLMNpnYmijKZ3Wf9tCtdo9CpamHedeMFQffwO9VMVt+dnzbzV9983H0UcTVCAB8lh1u3gdEn1x3btTK9xbpNpbrsJJ07tvYto27Myx9/LZOly3cEh3qGQ31Z6Krbu3Vu68unR/S0N/g3kydg4RiZMONeWLxNrrv7eem1Zxe596YLQ+75spXrDHuny+XLo6tK6eOanJzkS9utcztjfN3GLaaOjW/BGBox4z7jp/nSvUt7map+yO574k15SD3yUTcxqTzgXlkk9LQZ99NPOEx+XbBYrr/nBVn0z3/y09xFxuf6rBOPCCi4Lu66gJr+JgJWEqMT+kTu90X/Gk2g9C7W5vsX97p/KCq7Bysp2O+qzod7MK3gaWb+xs3kwT24b6hUs6b+y4f6mwj2eV+3Id9Y1P9cMiersbRQF9i955J12Qb/7YnGcbP7POzF92Th3//Jq08OlpxK/SB591s3F9Tn8Ju3FnqTlC3uPow4GjHXM0IcgcTKrjrUnfZnR44z2q+fccLhvt1q1ChVXnz0Jl87eT1DfyHoISO9kfHu/UdP6w7CdMBpJo8++Y+3Qdvccv9L6vGCqfLskBt8V52DOVw36DQ555QjJUu1HfYO2rWxaifmP3g7YNMXVXD3l9k1rmuSbC0sNl6pqclGG7E//l4mH0+cITddfqZce8mpvsy4+yjCMqJ958z/x+gw87udF0zOVjVPzqwUwNfFXW9gTX8TYdmJBl7IiNETRHdYp2uX6KE23wO41/3gVnavXFKo31WdD/fKWqGnzfyNm8mDe2jjYHPMmvovG+pvItTnXS9b9VwyTfLV77Ue6rINxoJR/I+ZfVZNdUT3P/D283cbHSD/oQL5YMPBqp8ZfQ7fY7eOvtm6fD3g7iOJi5H4i7ji4LDqHoxvVEGlroI9Ul3J8+/RPFFVZRpw+AEBCqk7n22vr7T6D7r3UJ0/SVWVNZPHf9l4GX/rg0my8J/l8uYzd0iRuhOvX2XbHeJUnXrpq65NVYeCulq8Hvbt2a0KS0pKcpWqx96qyPqCCO5VyIwEfXFDD7dfe55cfv4JxrjuPfd6VRPilTET5DKVhrvBEvZ/7nnsDfXZ3iKT339K1m3aIq+rpgyffPGdcbHw1qvO9q2vLp93vXBNfxO+FcToiOoPQ0a+87lccs5xcmy/3sZe1uZ7APe6fTCCufuXVN3vqs6Hu79W9eNm/sbN5MG9eufKc82aeper7m8i1OddL6trevoPLtXUzVvLsLbb4F9OtI7XtM/6XP2pER8Y5zOtWuQa544FOy94bNpcoDqMTRddk0EPbVo2M17+Frp8PeDurxL741Shj7FjrB95c+1dzxo9Qw9XPZkftF+PGvewqXocnQ7UdQ/e/kNRcanx6C7d1tVMHv9l42W8sGhHwH7hjUOl/7mDjZd+EsDiZauN8Z/UeHVDs6Y5UlzJXVfJ10Oz3GzcQ+DpKnn6c1latt2XQ3+Gj+y7r9Eufvmqdb70YCO4B1OpOU1f6ddPWtBPwNDttHurdtqvP/1/0v+w/UWf7Omq3tUNNbnrZc3kqW4d0TxPXxDU1Sh1u+u7btjVBrK+379mTM3kiWbb6rY9lLt3mbr8ruplzZiayePdjlh5N7PPZvKE8jCzrJk8ocqP1vTa7HNNfxPBDJo1zTaSK5/TFJVs8z3SuDbbEGwd0ZhW0z4X7+wX6dmRH/nOI/XvgB70ueXjL71f7W7jXi1PzM4kgI+hQ7th81a55ObHZPHS1TLq+bukb++9quydbhO/YVO+UfXYO1MHQrqd/HzVZt5/mL9oieqcake7eDN5/JeNl3FdVXvy2KcCXvrxb7odu04/ZOej4LSHrhKr7fUx8A7dVD8D/61YJ96gXafPV21fDe/2rXe813BsvGXF07u+mq+fLasfYeY/6LZhemjerKkvGXcfRb1HNucXiq7p4P951R0U6ZomZdvLRQc63qEu7nrZmv4mvOXH0ruu/fTYS+/J869/LLoWw107H7nk3cfafP/i7lWr+b0md12Cmd9VnQ93rWBuMPM3biaPXhvu5sx1LjOmZv4mdFnB3L399/ymzh29g36eub7R0VU9llgPZrbBu2ysvNe0z7o6fOXzyDt3XsB9W53Le8e1h27Go88jdTNC74C7VyK+3gngo+R46ztbixYvlz/VSw/6mcB6Wp9Qe4eB1z8qf/+7Ui4973ijiuvX380R70s/21kP+iT76HMGy21DRngXM95PP/5wozMq3Q7n3+VrRD36w7iL7N9+3kyegEJjYKImd12tqX2bFgEv3Q5JV3nV6bqHee9wl3reu7bXP3zeQfc8rYcHnnxL/lm6UnTHbG9/+JXRk32eeh60HnAP/nm/4oITZfa8P0W30dMnCe9+8rXRM2u/PvsE9PGAu/ExMvVPTZ93fUFPXzj55MvvRPesq++0TP/xN/nq25/l7JP6hcXdzN+EqZ2JokzPvjZO3v90mmretL/qqLSl73tbf3/rZ8Lrwez3QF0/77gHdzfzu6qPD+5awdxg5rNmJo9eG+7mzHUuM6Zmvot0WcHc9dNI9tqjswwfNd74bf5z8Qp56Jm3jeZsJ/XvoxcztQ1Gxhj6pyb3VFUFvvJ5pPfJOm3V722uukDuHSap31p9HqkeO+pNMp4Cg7uPI25GEvTD8eJmb6N4R3WV7DMuv7/KHvh32LXPgCvEG6hXzjhr4gjJVsGmbp994PHXGFXr9ZU976Afx/Ww6sV7vPpS0Fdg9eOMBqk2mIOvOdd4BIjOZyaPt7xYeTfjXnlfb33wZVmn2r9/NHJIwKxr73pOvv95gfz4+fCAfgl0IPTg06N8dy/33aubvPTozar65Y7qaLjvYvT/vOs7wc+8+pERuOvPrB50Ve6H77jMaI/tXQp3r0TN72Y+7/oRh/c9/qZxAdFb4hF9esmwu68KONGoq7sus6a/Ce96Y+Vdnwx/oZomBBuGDB4k5556lOnvX9yDKQZPM+Nu5ndVl457cONQqWb+xs3kwT2UcPD0mkzN/E3okkO5r1m/WW689wXjBpDOp/tgevrB60TXTPQONW2DN18svdd2n7+a/rP838OvytSPng1o8z7+q+/lfnXD54HbLjGasnmNcPdKxM87AXz8HGtTe6oDfP1FoK8GejsBq7ygmTyVl2G6egEdjK5as1GyMjMCgiD/pXD319g1rl30XcqWeU2Ni1S75tQ8hnvNRsFy6Ou+G9XzfrfkF4nudMf/DkGw/JXTzLibyVO53HiYrs/3gBlTM3niwTmc+2jG1EyecG5TQyjLzD6byRNqX8wsayZPqPKjNd2KfdbPgy8tc0iHti18N4H8vazYBv/1NYRxK/YZ94ZwpK3ZBgJ4a5xZCwIIIIAAAggggAACCCCAAAL1EqANfL34WBgBBBBAAAEEEEAAAQQQQAABawQI4K1xZi0IIIAAAggggAACCCCAAAII1EuAAL5efCyMAAIIIIAAAggggAACCCCAgDUCBPDWOLMWBBBAAAEEEEAAAQQQQAABBOolQABfLz4WRgABBBBAAAEEEEAAAQQQQMAaAQJ4a5xZCwIIIIAAAggggAACCCCAAAL1Ekh6SA31KoGFfQLbSrfLNz/8Kv8uX2O89IxmTbN986sb2bi5QC679Qnp3KG1tGmVV11WY96ixctlybJV6hmbLYPm/fvflfLJF9/JyjUbpIV6PnZGelrQfNUl6v2ZOft3tU/zZN4fiyWzcSPJy82pskhBUYl8/d1c9ZojW7YWSeuWzSQ1JcWXz2w53gUcjnKZ+v1cSUlOliY5md5k3hFAAAEEEEDAIoEf5/wh+lxDn9Os35gvHdsFP9+ovDm1PZ/R5xCTp/8iXTu1kaTEwPtKTpdLpqh5ev6ylWuN85nMjPTKq6xxWj+D+7eFS4zzmRmz5ku502WcqyQlBa7Po/J9//MfMumb2cZ+Z2c2libZu85DzJbjv0Gz5/0pq9ZulPZtWvgnM44AAgjUWSC5zkuyYBWBrQXF8uTwD4z0TVsK5NqLT5XdrmhXJV+whPJyp/FDWVSyLdjsgLTlq9bLPY+9LrlNsuXQ3nsHzNM/SgOvf1T+W7lODtxnd1m7YYsMefptuejsY+WuGy4IyFvTxG1DhsuPcxaq9WQZWV944xPjAsO7L98rTXN2pOnyL7vtCdm4aatxMeHNsV9Kl45tZNRzd/rymCnHuy36x/MutW9T1QWBwdecK1dccKJ3Fu8IIIAAAgggYJHA2x9ONoLYouJt0kZdmD/84F6m1lyb8xld9ktv/k8++ny69DtkH995g15RvrohcKk6v1i6fK10bt9KtqhzrOdf/1hGPH6r9N5nD1Pb4s004avv5YGnRklaWqo0VzciXnt3onFj46n7r5WjDt3PyKbPP+4c+poRvHdS68tX63vm1Y/k5WG3SN8Dexp5zJTjXad+/3LaLKPMnrt3lkNe21GG/3zGEUAAgboIEMDXRS3EMu3aNJcZ/3vBmNvzyEtD5Kpf8qmX3mv8mOlScvetenf/3Y+nyF9LVsi414aI/sHQw93DXpd3VPqVA08yXSNAL3eY+rG+6fIzZe8eXUT/sH08cYY8/NwY+XDCt3LdoNN0Fhn14SQpKCyRz0YPMwJ4fbX+wuuHBuQxU45RmPpH/zj/pC4aMCCAAAIIIICAfQJvPnuHsfLbhowwavyFe0tGjJ4gr6hXqOHpVz+UZSvWib5psP/e3aW4pFQG3jBUHn5mtEx4e5gkJyeFWrRKettWzeWxe66SkwccIvqu++q1m+TMKx+QF9XFA28AP3fBP0bwfv+tF8sFp/cXh7qxctGNQ+WpER+o9Q01yjRTjnfluubi/U++JWmpu2okeufxjgACCNRHILDuUH1KYtmQAvqO+fnXPWIE1t5MusqYTpv16yJvkqn3V58YLF+++4Ts27Nb0Pyb8wslMSFBmjdr6pvfa88ukqDSXG63L83MyCXqrr0O3vWglz/1uEON93Xqrrt30FXb+h2yr68qf8/unYw7/1NmzPFmETPl6My6yv8YdaHhuYduMJbV62RAAAEEEEAAgYYjcPP9L8nojyYHbNCQZ942LsAHJNYwcfFZxxjnMzddcWbQnLN+/dM419HBux6yMjOMGxH/qXOq5avXB10mVOLB+/eQ09Q5jLfKvL7hcqC6i792w2bfIrqafiN1h/6ck4800nTgfe4pR8mS/1arCwlrjTQz5eiMuvniTfe9JGed3M90zQVjBfyDAAIImBAggDeBVN8s20rL5I+/loluC+4dystdRpoO5GsztFXt43XVrlBt2k/o30dSUpKNq8ZfTf9ZNmzeKh99Nl0OO2hvaanawtdn0O3H9J34zh1bG8Xoq9O6itlundsGFKun/YP8gJlqonI5ev5PcxfJI8+PkQduu8RXVa3yckwjgAACCCCAgL0Cuo+dNet3Bb56a3Q7+RW1DKqzsxob5zN5Tav2rePdw7zcwJqG3nb4+g56fYaKigr5fdG/RrNAbzm6nb8+v/K/s79b5x3NINdt3HXjwptfvwcrp1A1C7ju7udF3zy596YL/bMzjgACCIRFgAA+LIwNp5Be6o75bVefY/y43vHISDn67NukRF1AeHbI9fXaSN2x3LMjxxnt08444XCjLN0+TQ8Z6Y2Md+8/elqvU3c+U3kIVo7+4dft5C897wQ5+6R+lRdhGgEEEEAAAQTiTGC/vXaT72b9LtN//M24eVCyrcy4AaAZ9I2R+gy6+r6+geLfz44+p2mcUfl8ZkcHwPpmRbChcjn6vOcWVUMhLTVVnXfdIImVOuULVgZpCCCAQG0FaANfW7EGnn/azF+NQPvpB68THcyPUx3DjB43WS5U7cY+Uu3i69IWS3eMd6P6QdJVyEY+OdjXI2vqznZd+gq0/6Cr6utq/JV7kw1Vzh2PjpTuXdrL+acdbfR0663qX6h+XDdsypeWzXP9i2ccAQQQQAABBGJcQLdF1+cdN973ohEI63MN793xVi2a1Xnvx46fJiPf+VwuOec4ObZfb185uvaiu9L5jHdaPxWn8hCsnLc+mCQL/1kubz5zh+gO+vSrbLtDnE6ncX7TVHUKXJfzsMrrZhoBBOJboOo3Unx7hGXvdTXzYINHgqcHy1vXtPfVD1P3Lu3kxKMPNorQPbl379pe7lI9q/7wyx/S/7D9a1W0rvZ/0/0vyoI/l8lw1RPrQfv18C3fVD3iTQfqRapjGf+hqLjUePyb/5Xn6sopLNomi5eukmPOu92/GNE92uvO936b+mZAOhMIIIAAAgggYJ9AhSfwwn0ktkQ/hne86jxuwZ9LVXO9ImnVvJnqrf5bo7+cuj6STQfYz702zuibp/KTeZqpqvxLV6wJ2BVdHV4PzSpV5Q9Vjj6f0QH7harzu8pD/3MHG+dR3k7zKs9nGgEEEDArQABvVqoW+bwBrfcOdU7WjmeIFhbu+CHQRXki9OO3UbV5d7srjOpm3k7gvM+i36I6uPMO+jF3+jpDi7wm3qQq77r9/PWqHdcG9Yi4Uc/fZdzR98+kA3TdHn6+ahvvP8xftEQ9z3VXu/iaynlv+H1qm3d1sKe3/6SL7zaqtp176lH+RTOOAAIIIIAAAhYKFBaXSKqqEu4d9HPR/c9ndLqnIjI3KPRNAm+nvaVlDqOXeN1xrv+5i65ar6vUN1GPtw11d1vfvX9i+FgZO/4bufWqs+WqC0/27o7vvZvqv2fazLmig/Yc1T5fD/NVO3njXKf9jr5/airn2ktOlYFn9PeVqUceUU/v2bSlUD2O7mbVwXDoc66AhZhAAAEEqhEggK8Gpzaz9OPTdFCcrXpJ/XTS98YX/kkD+hhF6N5O9bPR3x73lXFnes36Teru8qTaFO/Lq5+Hur28XPQPlg509XrTVa+punw96B+2MarKvH40ysAzBsim/AKjqpjuwE73wKoH/SiWo88ZLPrHavxbjxppwf7Rz5PXnbroNvXrVQcu+uUdjj50f6Mq2+nHH66q7H9k9B5/aO+95Ktvf5bFy1Ybj2vx5q2pHP18Wf/BWyVf/xi3a93cfxbjCCCAAAIIIBBBAd2HzTff/yod27UyasfNW7DECHq9qzxCPa9d1477+rs5kt4oTSZM/kF+V3fJjzniAG8WU+8bNxcY5yir1+3okO6vJSslJ7ux6hi3naSq6ux6mKa2o706h1q5ZqNxLpOYkCg3V+q1/vaHX5Ef1eNnv3jncaMTumArf1bddX//02nGNuqO8PS2e4c91dNz9LmGPkcaOeYzeUA9+u2Gy05XnfHmy9sffmX0Ip+nnh2vBzPleIN/b/m6X6DU1FK1Hy28SbwjgAAC9RIggK8X366Ff12wWJ5UV3f1sHvXDnLfLRcFBJ/6uekvqGecD7rlceMK8WnHHWa07UqQwEelVZ7etYYdY7c88JLoR6h4h3OvfsioMj9+1FAj6ZYrzzLaXL2lqp+/8f4XRpr+YXrivqslTQX6evhl/t9Gz6kXqUe4VDfoR9LpQT+bvfIwa+II0T3IDlJtyJavXCfPvPqR8axU/YiWy88/QU49tq9vETPl+DIzggACCCCAAAK2Cegmb/c+vqPpWq6qxq47rj3nlCN926MD3bnqPEI/H14PR/TpteNRspUe/VrT+cy4idPlVRUwe4er/u9pY1Q/Klf3Bq+HwQ+NMG5W6IB+nz27yrjXH1IXFloa8/Q/utM4ff7V98CevmV8M/1GNqs74HqYqvoJ0i//YcjgQaJr++lzJd1/0INPj5JvfphnZNl3r27y6J2X+7KbKceXeeeIZqlEUzkL0wgggECtBBJUe+3I1Huq1WbERuathcXicrlDVpGqUNQ62G2nrsJ6ry5Has/1Hfq16jEv+spvm9Z5Rlt177qGvviufPXNz/LtJ8+HrG7mzWv2Xbf50o+V0VeYQ1VhM1sW+RBAAAEEEEDAPgH9m761sES1O28asid1/bjY9PQ0X8e2kdhafXe+XD2yVtcG8D7D3X89c37/Wy695Ql59YnBxoUE/3l1HdfnaqvUHX/93Plc1ekcAwIIINDQBLgDH8Yj0lRV+a5u0G25vFXdq8sXjnmZjdONzuuClTVbPXP97JP7hTXQ1tXouvm1ew+2XtIQQAABBBBAoOEL6N90/apuaF2p+Vt1ees6r6ZmdLPn/mnckT/84L3ruooqy+lzNf+7/FUykIAAAgjYLMBz4G0+AFavXreb73/4AXLhmdVXn7d6u1gfAggggAACCCBQG4EOqjr9vTdfpKqoBzZHrE0Z5EUAAQSiTYAq9NF2xNheBBBAAAEEEEAAAQQQQACBuBTgDnxcHnZ2GgEEEEAAAQQQQAABBBBAINoECOCj7YixvQgggAACCCCAAAIIIIAAAnEpQAAfl4ednUYAAQQQQAABBBBAAAEEEIg2AQL4aDtibC8CCCCAAAIIIIAAAggggEBcChDAx+VhZ6cRQAABBBBAAAEEEEAAAQSiTYAAPtqOGNuLAAIIIIAAAggggAACCCAQlwIE8HF52NlpBBBAAAEEEEAAAQQQQACBaBMggI+2I8b2IoAAAggggAACCCCAAAIIxKUAAXxcHnZ2GgEEEEAAAQQQQAABBBBAINoECOCj7YixvQgggAACCCCAAAIIIIAAAnEpQAAfl4ednUYAAQQQQAABBBBAAAEEEIg2AQL4aDtibC8CCCCAAAJhEPB4PFJcUiqlZY4wlEYRCCCAAAIIIGCFQLIVK2EdCCCAAAIIxKrAoafeKEXF24zdS0hMkIz0RtIkO1MO6NVdzv7/9s4CTqrqi+OHku7ulO4QEAQRVESQEAQlBUFB+RNiICUpiCANBh2iIEinCggoAkpLSnd3w//87u4b3s7O7MzsDrjD/A4fdl/cd+N733v7zj3nnlu9ohQr+GSkm75i7SZZs36bNKtfVTKmSxWpfNzlcejoKanW6CPJmyuL/Phtr0jlzYtIgARIgARIgAQeLQFa4B8tb5ZGAiRAAiTwmBG4c/euxIkTW+pUqyDVq5SVIvlzyq1bt+Wnxaul0Xt95esp8yLd4r+37ZFps5fL6TMX/J5H/HhxpUzx/Ka+kc6cF5IACZAACZAACTxSArTAP1LcLIwESIAESOBxJJA4UQLp+cGbjqbdu3dPlqxcL137j5VhY2dJpvSppVrlMo7z0WEjTapkMnbwh9GhKqwDCZAACZAACZCAlwSowHsJislIgARIgARIwFsCMWPGlJcqlTbu9G27DJUu/b+VCmWLSKIE8U0WG7fsllETfpIjx0/LmXMXjQU/V7aM0rjuC/Lis6VMmqmzlsuCn/8w232HTZYkiRKa7Qa1npPnK5Q020t1kGDSjKWya98heSJOHCmYN7t82OZ1yZktg8c8KpYtKq0/GiyF1WOg3VuvmvTT5/wiy1ZukLbN68jMBSvVfX+r3FRvgnIlC0qPTs3k4qWrMuTrGfLnpp06d/6GlCqaT3rpwEWqFEnN9dYPT/Wy0vE3CZAACZAACZCAbwSowPvGi6lJgARIgARIwGsCFcsUUYX8KVmoivjWf/6VsiUKmGv37D8if/y1wyjapYvlk2s3bsqmbXul46cjZUiv94yCDgX5xo1bJv2ly9fkzp27Zvt66LExk+bK8HGzJHbsWFKuVCE5duKMrP5zq2zYvEvmT/pM0qdNaZRsd3ncVdd/1AHu/5YcOHzCHFv39z8SQw/m1EEFDDAs/GWd/HvouBw+dkqua9A7HEd9Vv6+SUZPnCPdOjSxshBv6uVIzA0SIAESIAESIAGfCDz4q+3TZUxMAiRAAiRAAiTgDQFYxaHAb96xz6HAV1DF/ucfBku6NCkcWWzavlcavttH5i5ZYxT4lg2ry5Wr1+XbaQtkQJe3pWjBXI60B4+cNIpy7hyZZOygDyVF8iTmHCzovb+cZK6BUh1RHtd10MCdVChdWHq831TSpk4hV65dl1pvdpWdew9JpXLFpHuHpgL3e9TtlaafyNoN2x3ZeFsvxwXcIAESIAESIAES8IkAg9j5hIuJSYAESIAESMA3AtkypzMX7Nt/1HFhBrWOQ3k/f/GysXjPUaUdFvg4sWMLosN7ksW//im379wxLvfJkiYSzLnH/6qVnpJYsWLKP3sOesoiwvNtW9QxyjsSwe2/RKHcJn37lnWN8m6OJ4wvxfX4oaMn5eTpc+b8w66XKYQ/SIAESIAESCCICdACH8Sdz6aTAAmQAAk8fAInToUot1kypXUUduHSFek6YKys1GXi7ul67HZx3refs7YPHjlhNrt9Pk7w31lOnD7vfChK+4lUWYfcu3svTD4JE8Yz+1eu3lCFX+RR1ytMZbhDAiRAAiRAAkFAgAp8EHQym0gCJEACJPDfEdi555Ap3LJiY6fVB4Nk+6798nSpglL35YqSI2t6EwiuRpNPvKro1Ws3TLpWjWqECyCHEwkThCjWXmXmRSKsb+9KYmmwPrs86nrZy+Y2CZAACZAACQQDASrwwdDLbCMJkAAJkMB/QgBK+tyla0ygucIFcpo6nD1/ySjveXNlkW8GdgpTL3eKMtaat0vWUGt+sYJPSoUyhe2n3G475+E2YRRORKZeUSiOl5IACZAACZBA0BEIO3QedM1ng0mABEiABEjA/wTuq1s8lmBr03mI3Lh5yyy1Zi0hd+bcBVOgPfo7Duw7cEyuhVrWrRolTZLIbB47edY6ZH5j7jlk5ITZZi682Qn9gaBzK//Y7DjkLg9HAj9u+FIvPxbLrEiABEiABEggaAjQAh80Xc2GkgAJkAAJPCwCl69ck+46Fx2B5WBh369LrllKd4dW9aTmi+UdRWfPkkFSJEtslpVr12245M+dTfbqsnLLVm0Mp4wX0HMQrL1+6sx5syZ7gTzZ5Nmni0r5pwqZZeMQIb5W1fLGbR7u+r+u/VsK5MkuWMIO4i4PLF/nb/GlXv4um/mRAAmQAAmQQDDCHevgAAAfcElEQVQQoAIfDL3MNpIACZAACTw0AjFixDCK9Y8LV5kI8MmTJjYKep1qFaRejWelcL4cYcp+Qtdd/6J7G+nUe7Qs/22j+R8/XlxpUu8F+X7ur6LZOaR08XzStnkdmaV5f6lKPKRz24bm99Debc1SclNnLZMh38w0x/ADbuyVyxd37LvLw1LgY9oKRFsg1m8rEyuNs4u/lS6mbY68t/Wy8uZvEiABEiABEiAB7wnEUDe/sOFvvb+WKUmABEiABEiABCJJ4Ka61u87eNxcnT1LOoES707wpxprrCdOlEBShq75bqXFOVjnz1+8IlieLknihNapML8jyiNMQj/teFsvPxXHbEiABEiABEggKAhQgQ+KbmYjSYAESIAESIAESIAESIAESIAEAp0Ag9gFeg+y/iRAAiRAAiRAAiRAAiRAAiRAAkFBgAp8UHQzG0kCJEACJEACJEACJEACJEACJBDoBKjAB3oPsv4kQAIkQAIkQAIkQAIkQAIkQAJBQYAKfFB0MxtJAiRAAiRAAiRAAiRAAiRAAiQQ6ASowAd6D7L+JEACJEACJEACJEACJEACJEACQUGACnxQdDMbSQIkQAIkQAIkQAIkQAIkQAIkEOgEqMAHeg+y/iRAAiRAAiRAAiRAAiRAAiRAAkFBgAp8UHQzG0kCJEACJEACJEACJEACJEACJBDoBKjAB3oPsv4kQAIkQAIkQAIkQAIkQAIkQAJBQYAKfFB0MxtJAiRAAiRAAiRAAiRAAiRAAiQQ6ASowAd6D7L+JEACJEACJEACJEACJEACJEACQUGACnxQdDMbSQIkQAIkQAIkQAIkQAIkQAIkEOgEqMAHeg+y/iRAAiRAAiRAAiRAAiRAAiRAAkFBgAp8UHQzG0kCJEACJEACJEACJEACJEACJBDoBKjAB3oPsv4kQAIkQAIkQAIkQAIkQAIkQAJBQYAKfFB0MxtJAiRAAiRAAiRAAiRAAiRAAiQQ6ASowAd6D7L+JEACJEACJEACJEACJEACJEACQUGACnxQdDMbSQIkQAIkQAIkQAIkQAIkQAIkEOgEqMAHeg+y/iRAAiRAAiRAAiRAAiRAAiRAAkFBgAp8UHQzG0kCJEACJEACJEACJEACJEACJBDoBKjAB3oPsv4kQAIkQAIkQAIkQAIkQAIkQAJBQYAKfFB0MxtJAiRAAiRAAiRAAiRAAiRAAiQQ6ASowAd6D7L+JEACJEACJEACJEACJEACJEACQUGACnxQdDMbSQIkQAIkQAIkQAIkQAIkQAIkEOgEqMAHeg+y/iRAAiRAAiRAAiRAAiRAAiRAAkFBgAp8UHQzG0kCJEACJEACJEACJEACJEACJBDoBKjAB3oPsv4kQAIkQAIkQAIkQAIkQAIkQAJBQYAKfFB0MxtJAiRAAiRAAiRAAiRAAiRAAiQQ6ARiB3oDWH8SIIHHk8DGLbvl1NnzpnGxYsaUtKlTSKF8OSRmjBgeG3zo6EnZvvtAhOmK5M8lGdKmjDCNrydnLVwlsxetlsnDP/H10oBNv2n7Xtm177C8Wq2CxI4dyy/tOHL8tGzd+a/JK4bEkPjx40q+XFklTapkfsnfm0zmLVsrSRInlIpliniT3O9p7t27J+27j5A7d+/JsN5t/cbW7xV9BBnu1vur28Bx8lKl0tKsftVHUOJ/U4S/77m7eu8sXbXe0Zg4sWNLxnSpJN+TWR3HHvbGuQuXZdmqDfJU0bySPUv6h12cy/z3HTgmnft9LS8+W0pavPGyyzTR6SD6rX334XL33n0Z3ud/EisWbW3RqX9YFxKIDgSowEeHXmAdSIAEwhH4Zup8+W3dFvPxgg8aSOYMaWR0/w4ePwR/37hDeg2eGC5P+4F+nd+Smi+Wtx+K8vbpsxc9DhxEuZD/KIMTp85Jlfrvy5Ce70mVCiUctcDH+YTvF8vLlctIotjxHcejsrF+007pOmCsxNSBG7l/X+7pf2w3rfeidGpdPypZh7vWXbuGfDNTcqjC8V8p8NNm/yyr12+T6aO6BZXyjnvpy29myOblYx19lTtnZlW+npKh386UZ58uKtkyp3OcC8QNV21EO/x9z928dVs69RxtEEEJtN6jGAjFezR50sR+xfdGm96SMX1qGdjtHUe+GIzDu7jnB296fG87LvLjxn19d/QcPMH8HWlU9wU/5uyfrFy9f9BX7VrWlQbv9JJJM5fIm/Vf8k9hzIUESOCxIUAF/rHpSjaEBB49gS1bREaHfB9K69YihQv7tw75c2eVGV/3lFu378j6Tf9Ix09Hyfv6QTprbK8IC6pX41mpU+0ZR5ombftJvHhx5euB7zuOxY7lH2uxI8NosrH5xGYZtWGUxIoZS9qUbCMF0xT0S82gRONjGP/s0rZ5HWnRoJokSugf5d2e96IpAyRThtRy+uwF6T9imoz/fpE8V76YFC+U254sStvu2jVrbG9l+N9Yvk6duSDDxv4orRpVFyivwSS4v+6FDtjZ2w3L+9KV66XXlxNl3OCP7KcezvbdGyKHZuj/mSIZq4lkaygSO5FfynLXxod1z3VsVc9Ynm/evCXzlv0unw6aIGMmzZXObbVNfpS76jVyX63GdimQO5v8NnuYJEqUwH74kW3PXvSbwEsIbOM+EeeRlettQe7eP7myZZTWTWvKyPE/SVUdvErvZ28xb+vHdCRAAtGTABX46NkvrBUJRHsCCxeKvGzzRhwzRmTBApFq+q3rb3kiTmwpV6qQ1H7pGZny4zLZtnO/9Bk6Wd5uVEMqlSvmKO6XNX/J11PmyxfdW0smtQRZEkPd7uF6DxdSS+Bm32/YVPNxF5J/QflYP2iTqts0BB9+Py1eLb0+aC7jpi+UvQeOSrPXqkrl8sVl4owlMl8/hGFdSp8mpalDu7deDclalVxcN2nGUjmq55+vWFLeUrfNR2E1nLtrrtScXjOkHvpz9PrRsqTREnkhZ9QtT//rOszkO/irGTL2u4WGJaYKLFmxXmbMWyFTRnQx5y1u6CtXDCbPXCqLf/1TvtLBlEQJHij9/YZNkXPnL8sXPXQkyElSp0wmLV5/2Vy3Z/9Ro8AfOHxCPla32B4dmzpcgi9cuiLvfDRY0BdlSxSQk6fPSTt1Q6/5QjlZ8fsm2bRtr+TTQaEm9V6Q58oVN6W4a9cAHTDIoO7G771Z26T7qM9XkiJ5ErmlVs3lv20U3FOYNvBazUryxajpAq+PtKmTS8M6VXTwqIKjBX/+/Y9ajn800wySqBJT+ZkS0vHtehJfB5TcyWS1uiF/Z8ubVQe41y9btVFiq6WuzssVTDpLOcFgFyy5y1TZPX/xiuTNlcV4LRQtkMtdceb4r2v+luHjZsu/B48ZZSFb5rSmj4epCy8EnDBwYndh7/HFeEmWJJF0UAURMmbyXJm7ZI2cOXdRJz7EkDy5MkvbFnWkVJG85ryne2P95p3m+YZS06B1yCBduVIFBYNEeH7RF29/OEj+3rZHihV80uT50H6s0JfbyV9Csj86V2SX3v8vb9N9z1N4IqpTRG2033Oe7t09+49It8/HRfgOTJEsSZiqxI37hNStXlG+nbZAcL0l02Yvl1V/bJExAzpah2ThL+v0+V0i36kHCO5FT303fOws2avP5qGjpxx990HrBpIlYxppq/dOp3fqS8kieUw+yOsVfSbxLjh64ow53vfjt2Tm/JUyZ8lquXzlmnnXw93deh/jnke9cX/hmsyab8uG1aXG80876uxqY/TEOWbqBRRiuxw7eVb6DJksG/Sew9+FIvp8nLtwST7r3NJ4CnjDBNO8+o+YKsdPnpNrN25KOn3+61Z/Vpo3eMkU5akPkcjd+wfn8J4ap+/aCT8s9vtgC/KnkAAJBC6BB1+zgdsG1pwESMAPBEqW9C2TvXvDp3/jDZFcEesJ4S7asCHcIbcH8GEHy3ketUpeunzVWGTtCvy47xapm+jdMMq7q8yuXLsuDd/raz7F4ZZ9UfP6ccFK+ffQcZk+urv5YIUVdMPmXVK7RTfJlTWDKnMpjQvqZ8OnCT7uni5ZQOq/Ukl2/XvYKPSWAg+31UFjvpdaVctLYlXYxk1fJLdVqRrQ9W1XVXF77O69u1L629Juz7s6sefcnnCH68+sLzmT5wx33N0BWO7XvbUu3Gm4kv+z56AUyZ/TKIUxYoYoMrCOW/PVcZHFDYqgKwb4iIc1fc7iNUbZxTVwI/3up1+kvTUIgoNOcuDICXOkWKgielX7cOs//8rVa2opDZVbt+6YY1DkIddv3DL7GPB56bnSxqK1eMWfAkV47byR5sPdXbug4GD+uSW7dX/38sMCRbiJuuJu23XAKKwY3CmqyuSb+tEO138oVc+ULiwYdMD907zj57pfSHq831T2/HtE752fjRdD13aNrazD/d6x+6C8WLFUOIuhVYeCebPL67Wek8OqLEFxyp0jk2NAoofOFYfyhfni+Z7MIt/P/VWatvtM5ozv63YQCUrle12GGm+H9uq6i76drv2BZ8mSnXsPmTgU1j5+Y1ArdYqkjkN4PiuWLWqezzt6LfJ4t/MQ+fmHweZZ8HRvpEmZ3LTl5OnzxuqIjHNlf6B44ZlLpeWBj08K/P7JqoAPddTT4was7xe3h012cYfIPB2IiOOD23n2RiJ52ofJJ6I22u85T/cuFFJP78Br12+GKRs76KOz5y9KtcoP3i14/nbsPhAmLQZh8HzBno4n3VPfFS6QU5LqYA4GdGAxhiBmxc2bt00+l65cNceQDxTfg0dOGiUd7uJQUqu81lFSat9isO32nTv6bl+s1yeXRq8+b64bMPI7QYwRDAziGcQg4Md9v5Z0aVI4BohMQtsPvNehqH/aKaySD0+Epv/rZwa4ar1UXvJrTICfV/9l6nntesj7xBsm+DuSLVM6M2CHwbk167ebdz/qVE3fN576EAMH7t4/aAbOV630lHnv2prFTRIgARIQKvC8CUiABAyBjRujDuLiRRF/5GPV5Pbtu3LyzHm5cPGysRDNXbrWzLWOoxb5BrUqCyxWu1UpggKza98hY5mDJceT/LhglVp7L8mkYZ9IicIh7thZM6U1FpnfN2yXp9XqB8G8668+7+j4QERdPug1WufOl5N+aqmxpOUb1a1N89G1YHJ/EwANB/EBO+2nnwUWJDOn25Ey4g242W48HvVOuXBDP5h9yCd2TNd/Fl5Vyx0srJWfKS7PV4h4tAcfnu4YIIBW0YK5ZPqcXxwK/A/zflVusQRl2GXlH5tVIUhoBlamzlouTxXLFymX8j4ftTCDCcgbfVu7eVeBZRxeHb60C8rpyH7tzAAPlIyVatWvqooy4ilA6mn9y9Z4Vz/kt5nyRoybJVC0Rvd/YNmEVRzeGxEp8Lt1UKj682VNns4/8ME/8rP2pg4499fW3bJizSajwB9XZQUu0q/rs9GlnSqPKrBQVqjTTsbrQBLmIbuSMRPnqvKVUBZOHuAImHXk2GnTPlfp3R2DxRWCudZnVElEn37y2bfmGbWes4juDTyD6OPV67aGsfRb5eH5wQASgtr5JDdOipyL+rMkl3f7VKykrRQuvac2Ol8Q0b3r7Ttwl74jofDCwjxz/iodGHpCqldxfX85l2/fj6jvcF+mTplUMqdPE6bvcB85C/KZP+kzM6iDcwcPn5R1f++QeRP7OTxTMEiz+s+tRoHHICEGvlo3eUXaNKtlskNMhGdqt5UFy/9wvJ+dy7Huk2IFw065maNWfCj2mFKFdwAkqyriK9Zucs4iwn20Gf8hGDTMr9MF8E7YpB4iUOAtiagPPb1/ihd6UuYv/93Kir9JgARIwBBw/aVGOCRAAkFHwBdLOOBMmiQyTL1K7fI/9bZt0sR+JGrbsEg9V7eDyQQutLC+fPje62a/tlq4h6qr8HRVjrurGzU+8FIkS6yWpTIeC4WrJ1yYoQxYApdryB61KloKPAYKLPdfc04/hOHeWyH0o81coD9gcbEkplqUEL3cEsxdhKUMlmJY5L0VWMI3tPLBPUEzHv/3eBm5fmSYIjqU7SANCzUMcyyiHbg+R1U8MXhDFcwP1QoOJbqYfqDOUNfZl1WhgPXOLoO++sHswmJWSqNYjx38of2019vJkj7IN31oX8Ht1VfBYALciSFQQtDPSRM/6FPsYzoGrHeQnaGKZq03u5p9/DirShSsoLDe2acQWAmgrCByd4a0qaxDYX6jLVYdcCKdTuGAMgLZp14PiFNQpkR+s48fcPt/Uge47C7TjpOhG1hFAPd/VKNdw9Nh4OjpZlrKnTsPrPc3bj6wBHu6N5zr5ryP52nzjn3OhyPez95YXCnTbi+6f0dkRQ0dfbMpn7G0nyvpvCFf5sHHS+u2CG9PRHTvevsOXPzrOvlZp31g+gdWiligsSUiswJHVPvOajPysb8LU6nij+fJPq0EgwHw+oBg2gwGQOF6v3Tlg3fidfUwgDu9O8F9jYGpBLqKhV1wHNMJSoZO7bCf82X7ytXrAs8ABPLEM23JDfX8sUtEfWhP52ob9zvKweAc58G7IsRjJBCcBKjAB2e/s9UkEI5AiQeBxcOdc3Ugp+q+8LCdrN6pkMb6jdyzp0gyP670lV2jTffv8rYkTBDPuPfiI88SfADCSomllzAXElbNJuoODwXKk+BDFnOG7QoLyoDcUXd3dwL3eAjcJb2VmKGu5t6mt9JBkS6R3rdOyZ4su3HPnrxlssTUf02KNJEeFXtI0rgP3Jyt/B/lb2cGL+hyTvjwhWeCUVjVGwJzx51lrrp9Z0yfSr0exghc35fpxzuWgrKLc1A9+zlX27H8GLzQlUeFdQyKNAYeyj9VSGrqYJOzxFMrqCvRy4yEjhO4ShLmGO5hK7r4rdsh96d1L1sJE+hgFaZxuBNMR7ArVO7S3bv/YEqBc5rz6iXTuG1feTJ7Jhmqy97lzpFZLqpVsm7LHs5Jw+w73xs4GYogTDprB4MXYOuTQJH2VZl+eorItt4ip1frKEhxkfyd1Se8ok/FRpTYxxaYrJzvXW/fge1avGqC2CFexfs9R8ngMT/IwO7vhBkI8pmp1shV30XUZnfnrGfGfj5GjAcBJK0BIHgcwIPBLil1gMqdoE2uBiQxmBovbpxwU1Sc8/HEBCwxmAS+pYrlNQO5Ddv0cc4mzL5zH4Y56WLHGqyLzP3iIjseIgESeEwIxH5M2sFmkAAJPGICUNRHjBDp3z+k4EQPjJx+qwnW/8Z8X3fyRu3KJvARApfBpbmBBhTzRvARCLdEWHisNZH/+GuHuRTBkdwJBhQgWN7OstJj31f3eFzzMCRF/BQystpI6V+lv/lwTfSE/zolXmgEZ2sQIyr1x0CMFUxrr3o1wL0awdZcCT5g+6qL+pETp81azggUhzmwSROHtO3ixZC5tbj2fgQKpqu8ccyf7bKXgXpn02Xozqlii8CH1oc40hjFQs+7EswbxvJex0+FWNVdpXF3LGvGkPvzDw2oV6Z4iBUe86C37dovVTR4njvB2uCbNVK3XZyVdXhH2FkjrT3iOALLIYDeB20aGG8JnL+hgb18FQxsgA+eZ/uAnZUPLJF5dHDgoUt6DfyI/9ePi8RP79fiPLXRl8J8eQdi8Gv/4dombgJWd0C8AwgCxcHKi4Ega1Dzvlq8fZX4atW+cSus9dnXPFylz5ElgzkMjyjn+zgiJRuxUuDafkMH0uJp3SzB/X7x0lXZrzFPrLXp7fEekM4TE3hiIeYFvMJe179DkRVP7x/c7/DUiYzHRGTrxOtIgASiP4EHQ5zRv66sIQmQQDQkAMX9YSjv3jQ1T84sJjI2gmlVLl8iXJAtd3nU0o8uWOCxPjGiL8OKP2rCHGNBseY0uro2hwazwxzdHzWY0pdfzzDz7hfoQEAtnVMdnSTxE4nFn8o72gZXbMQa+GnRahNEDNyiIggACEPqfo0m37BOSKAqd/mhr0b0bSfJdYpEWw22hnm1UEDQH+N/WGSCxSF69VudvnCXhdvj/m6XvaBmr71oIt936f+tWTkBLuaIvO3JKp07Zya9bp89K6+2c2bLYCJ6I5r3JC0Hwek+7DNG4M7eoOZzbvPA9AXEkkBEbMyV7jt0illZwH5BhbJFZNW6zWYpNwxgWdZHK03hfDmNezZiGyBIGZ4LpPFVymqgOgjWSkfQxC0aSM0SKE1b/tkXqTgIVh4+//az8o7yI2qjr/Xz9R34TuNXzPz3b6bON0HhUB76FoMvQ3XpQgReHDXhJxkxfravVdGpGwXM9Ws1jgjuAWsqic8ZOV2AFTwqlCksw3Q1B8TCwPseZWDlis/Vk8edWEswYhk5u2CaFQbUEB1/pgYvnahR3jGlxy6emGBKFyLXI94F5s6v1d+ddVUM1M0X8fT+Qd2tdviSL9OSAAk83gSowD/e/cvWkUBAE3Dl/ujcoBd0mTaIFa3Y+byrfVgzBvd81ywD1/rjwSaacSx1dYeSiLmREDcGUhmgLv2Yj43IyXVadDfXWvOVXV1juYfaLbCu6hQIx7Cs00GNBl+vVQ9p3324qTLaZe8nbxmkTZ1CCufPIWk10rSzVc2Vay6ij4/S4G2wpr3z0SCBZRnrJJ/WqNaIst5z0EQpWThPSJ20RnaJaXPHdRy3JXHZrjCtQiRuXGC7CHvmkPMx3Q89VPPF8iaY3MrfN0v9d3qa/4N1Xj/czCMSeIVgygCUKru4roMetVUB9yesigjw2Kxdf0FQxq7tGzus4vb8rG1E0Ee0aywlB6V70/Y9xsvBOo/fCNyIaN0deow0S/UhWneWjOrOHFo4+gf9gcBjTTTCd7eB4yVn1pAI8tb9Ya+nlbfz8wFlDcvzfTV5nhno+E5XfLAEngWIYm55zVjHA+23uzaCk60rTbM83btI5O4d6HiOnMD31qCO8GLpqQOYGOTB/fhajUoyVZfoxLOEZTAxUGkXpyzMKee+Q2R75NXqgy/MPbBTA4taYrXMVT44Zq1qYaU3v22JP/uklbYTU2+mSc1mXaRlp4FmPnxeXWnBncBrBPFJ5i5ZGyYJBrqw/CSs2z30Pv1qyjwz1cWeyBsmbZrVNEs5vvvJEGmpbUbsClcu/Z760NX7B3XBwNsiXVECq0lQSIAESMBOIIa6H3FqjZ0It0mABAKKQLP2/TVI3DWZNbaXz/WGRQ9LcWHevK8BgjC/+YQudwWXbrt7ps+VCLAL8CfjuAZpS6nWcGuwIzJNgCL2fIP3pU3TWvJ2Yw0YFklBHx5QV9hMGdJ4Ff/AXTH+ape7/DHXHx/kWBrLclN2lxaWyxpNO0urRjVMfAd36SI6jlUW4D4MJRuBy7wRBNZDHaH4wAqPiNpLp4f1aoDSg6ktzgEHrfzxXBw6dsos5WgPSmad9/Y3BmouaMT+NPp8wdqJ/mmkSz8isv2EoTof/TEQ5zZGtklReQfay0T/w7UcLuZRkbN67+Eed3ePRCVvuPlb96ArZdk57xnzVkifoZNl9tjexmPHft6slnDugnkm/9q6xww6/PBVDymQJ7sjmTdM9h04ZoLlYRArsuLq/QPPgGG6TORcjc4f1T6JbL14HQmQQPQkQAt89OwX1ooESMALAlhqCPMQG75axYvU4ZNAMcB8eF+Vd+QE5RXXBpPyjnbD4g4Phqgo78hn6qxlRjGrV+NZ7EZa0IdwpfcmeGFEhfirXe7KwLrwuM88Ke+4HlbD95rXkdGT5kYYPd5dWTgO11xw8VZ5xzWYa+tJ6UIbIkqD+wLWy6go76gLnitwQP9CMCVg+64D0uP9Zmb/cfjh3MbItCmq70B7meh/fyiKUKwjukfsZfq6jecH02e8Ud6RN2JtII5Kt8/HhfNoQV7wBIrIO8obJrDoR0V5Rz2d3z+Yn49pDPBq8UefoAwKCZDA40OACvzj05dsCQkEHYHVf24xS8FV92LpuKCDE40bDGsT5jZj7juW/qOEJ9D41eeljLoxD9KI4Qjo9qgFyjMUk+ggu9QVe97StdK2eW1H0LHoUK/oUAe+AyPuBSjGPTo2k+s3bsnkGUvcJsaAE+IJxIsbdsk5txc8xBPwDBg4+nsT36XZa1UfYknMmgRIIFAJ0IU+UHuO9SYBEiABEiABEiABEiABEiABEggqArTAB1V3s7EkQAIkQAIkQAIkQAIkQAIkQAKBSoAKfKD2HOtNAiRAAiRAAiRAAiRAAiRAAiQQVASowAdVd7OxJEACJEACJEACJEACJEACJEACgUqACnyg9hzrTQIkQAIkQAIkQAIkQAIkQAIkEFQEqMAHVXezsSRAAiRAAiRAAiRAAiRAAiRAAoFKgAp8oPYc600CJEACJEACJEACJEACJEACJBBUBKjAB1V3s7EkQAIkQAIkQAIkQAIkQAIkQAKBSoAKfKD2HOtNAiRAAiRAAiRAAiRAAiRAAiQQVASowAdVd7OxJEACJEACJEACJEACJEACJEACgUqACnyg9hzrTQIkQAIkQAIkQAIkQAIkQAIkEFQEqMAHVXezsSRAAiRAAiRAAiRAAiRAAiRAAoFKgAp8oPYc600CJEACJEACJEACJEACJEACJBBUBKjAB1V3s7EkQAIkQAIkQAIkQAIkQAIkQAKBSoAKfKD2HOtNAiRAAiRAAiRAAiRAAiRAAiQQVASowAdVd7OxJEACJEACJEACJEACJEACJEACgUqACnyg9hzrTQIkQAIkQAIkQAIkQAIkQAIkEFQEqMAHVXezsSRAAiRAAiRAAiRAAiRAAiRAAoFKgAp8oPYc600CJEACJEACJEACJEACJEACJBBUBKjAB1V3s7EkQAIkQAIkQAIkQAIkQAIkQAKBSuD/AIYbFNtZ7j8AAAAASUVORK5CYII=",
+      "text/html": [
+       "<div>                            <div id=\"d4e5bf04-9da8-49c3-a0b0-a418e0168286\" class=\"plotly-graph-div\" style=\"height:800px; width:1000px;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"d4e5bf04-9da8-49c3-a0b0-a418e0168286\")) {                    Plotly.newPlot(                        \"d4e5bf04-9da8-49c3-a0b0-a418e0168286\",                        [{\"line\":{\"color\":\"blue\"},\"mode\":\"lines+markers\",\"name\":\"PyTorch\",\"showlegend\":true,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:04:12\"],\"y\":[44.93835258483887,44.93835258483887],\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"line\":{\"color\":\"green\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (no quant)\",\"showlegend\":true,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:04:12\"],\"y\":[44.66026306152344,44.66026306152344],\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"line\":{\"color\":\"orange\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (quant)\",\"showlegend\":true,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:04:12\"],\"y\":[11.949405670166016,11.949405670166016],\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"line\":{\"color\":\"blue\"},\"mode\":\"lines+markers\",\"name\":\"PyTorch\",\"showlegend\":false,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:03:05\"],\"y\":[44.93835258483887,44.93835258483887],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"line\":{\"color\":\"green\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (no quant)\",\"showlegend\":false,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:03:05\"],\"y\":[44.66026306152344,44.66026306152344],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"line\":{\"color\":\"orange\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (quant)\",\"showlegend\":false,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:03:05\"],\"y\":[11.949405670166016,11.949405670166016],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"}],                        {\"template\":{\"data\":{\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"white\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"#C8D4E3\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"white\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"radialaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"yaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"zaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"caxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"matches\":\"x2\",\"showticklabels\":false},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.575,1.0],\"title\":{\"text\":\"Model size (MB)\"}},\"xaxis2\":{\"anchor\":\"y2\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Datetime\"}},\"yaxis2\":{\"anchor\":\"x2\",\"domain\":[0.0,0.425],\"title\":{\"text\":\"Model size (MB)\"}},\"annotations\":[{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"x86\",\"x\":0.5,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":1.0,\"yanchor\":\"bottom\",\"yref\":\"paper\"},{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"ARM\",\"x\":0.5,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":0.425,\"yanchor\":\"bottom\",\"yref\":\"paper\"}],\"legend\":{\"orientation\":\"h\",\"yanchor\":\"bottom\",\"y\":-0.2,\"xanchor\":\"center\",\"x\":0.5,\"itemclick\":false,\"itemdoubleclick\":false},\"font\":{\"size\":14},\"margin\":{\"t\":100,\"b\":50},\"height\":800,\"width\":1000,\"showlegend\":true,\"title\":{\"text\":\"Model Size History\"}},                        {\"displayModeBar\": false, \"responsive\": true}                    ).then(function(){\n",
+       "                            \n",
+       "var gd = document.getElementById('d4e5bf04-9da8-49c3-a0b0-a418e0168286');\n",
+       "var x = new MutationObserver(function (mutations, observer) {{\n",
+       "        var display = window.getComputedStyle(gd).display;\n",
+       "        if (!display || display === 'none') {{\n",
+       "            console.log([gd, 'removed!']);\n",
+       "            Plotly.purge(gd);\n",
+       "            observer.disconnect();\n",
+       "        }}\n",
+       "}});\n",
+       "\n",
+       "// Listen for the removal of the full notebook cells\n",
+       "var notebookContainer = gd.closest('#notebook-container');\n",
+       "if (notebookContainer) {{\n",
+       "    x.observe(notebookContainer, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "// Listen for the clearing of the current output cell\n",
+       "var outputEl = gd.closest('.output');\n",
+       "if (outputEl) {{\n",
+       "    x.observe(outputEl, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "                        })                };                });            </script>        </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#| label: fig-modelsz\n",
+    "#| fig-cap: \"Model size\"\n",
+    "\n",
+    "plot_progress(\"Model size\", \"Model size (MB)\", \"Model Size\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "f0f112a0-af04-40b6-a0fe-3b7cfbeb6800",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "displayModeBar": false,
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "color": "blue"
+         },
+         "mode": "lines+markers",
+         "name": "PyTorch",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:04:12"
+         ],
+         "xaxis": "x",
+         "y": [
+          468.90625,
+          469.3828125
+         ],
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "green"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (no quant)",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:04:12"
+         ],
+         "xaxis": "x",
+         "y": [
+          65.21875,
+          65.33984375
+         ],
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "orange"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (quant)",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:04:12"
+         ],
+         "xaxis": "x",
+         "y": [
+          33.9765625,
+          33.9765625
+         ],
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "blue"
+         },
+         "mode": "lines+markers",
+         "name": "PyTorch",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:03:05"
+         ],
+         "xaxis": "x2",
+         "y": [
+          462.5,
+          462.953125
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "line": {
+          "color": "green"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (no quant)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:03:05"
+         ],
+         "xaxis": "x2",
+         "y": [
+          78.46875,
+          78.375
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "line": {
+          "color": "orange"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (quant)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:03:05"
+         ],
+         "xaxis": "x2",
+         "y": [
+          39.765625,
+          39.828125
+         ],
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "x86",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "ARM",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 0.425,
+          "yanchor": "bottom",
+          "yref": "paper"
+         }
+        ],
+        "font": {
+         "size": 14
+        },
+        "height": 800,
+        "legend": {
+         "itemclick": false,
+         "itemdoubleclick": false,
+         "orientation": "h",
+         "x": 0.5,
+         "xanchor": "center",
+         "y": -0.2,
+         "yanchor": "bottom"
+        },
+        "margin": {
+         "b": 50,
+         "t": 100
+        },
+        "showlegend": true,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Memory Usage History"
+        },
+        "width": 1000,
+        "xaxis": {
+         "anchor": "y",
+         "autorange": true,
+         "domain": [
+          0,
+          1
+         ],
+         "matches": "x2",
+         "range": [
+          "2024-07-18 11:01:03.9559",
+          "2024-07-19 05:03:08.0441"
+         ],
+         "showticklabels": false,
+         "type": "date"
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "autorange": true,
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          "2024-07-18 11:01:03.9559",
+          "2024-07-19 05:03:08.0441"
+         ],
+         "title": {
+          "text": "Datetime"
+         },
+         "type": "date"
+        },
+        "yaxis": {
+         "anchor": "x",
+         "autorange": true,
+         "domain": [
+          0.575,
+          1
+         ],
+         "range": [
+          1.216573417514077,
+          502.1428015824859
+         ],
+         "title": {
+          "text": "Max memory usage (MB)"
+         },
+         "type": "linear"
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "autorange": true,
+         "domain": [
+          0,
+          0.425
+         ],
+         "range": [
+          7.924975308259214,
+          494.7937746917408
+         ],
+         "title": {
+          "text": "Max memory usage (MB)"
+         },
+         "type": "linear"
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA/AAAAMgCAYAAACEYYkhAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAD8KADAAQAAAABAAADIAAAAAAwD/peAABAAElEQVR4AezdB3wUVdfA4ZNOQgoJvVdBQQEFBVREwQIW1NcO74ti+2zYe2/YsGMviI0iFlABUZoURaVJFVCa9BJCEhI2ZfPdM2HDbrJJNrCz2U3+11/YnZk7c+88M0LOzC1hBSYJCQEEEEAAAQQQQAABBBBAAAEEglogPKhrR+UQQAABBBBAAAEEEEAAAQQQQMASIIDnRkAAAQQQQAABBBBAAAEEEEAgBAQI4EPgIlFFBBBAAAEEEEAAAQQQQAABBAjguQcQQAABBBBAAAEEEEAAAQQQCAEBAvgQuEhUEQEEEEAAAQQQQAABBBBAAAECeO4BBBBAAAEEEEAAAQQQQAABBEJAgAA+BC4SVUQAAQQQQAABBBBAAAEEEECAAJ57AAEEEEAAAQQQQAABBBBAAIEQECCAD4GLRBURQAABBBBAAAEEEEAAAQQQIIDnHkAAAQQQQAABBBBAAAEEEEAgBAQI4EPgIlFFBBBAAAEEEEAAAQQQQAABBAjguQcQQAABBBBAAAEEEEAAAQQQCAEBAvgQuEhUEQEEEEAAAQQQQAABBBBAAAECeO4BBBBAAAEEEEAAAQQQQAABBEJAgAA+BC4SVUQAAQQQQAABBBBAAAEEEECAAJ57AAEEEEAAAQQQQAABBBBAAIEQECCAD4GLRBURQAABBBBAAAEEEEAAAQQQIIDnHkAAAQQQQAABBBBAAAEEEEAgBAQI4EPgIlFFBBBAAAEEEEAAAQQQQAABBAjguQcQQAABBBBAAAEEEEAAAQQQCAEBAvgQuEhUEQEEEEAAAQQQQAABBBBAAAECeO4BBBBAAAEEEEAAAQQQQAABBEJAgAA+BC4SVUQAAQQQQAABBBBAAAEEEECAAJ57AAEEEEAAAQQQQAABBBBAAIEQECCAD4GLRBURQAABBBBAAAEEEEAAAQQQIIDnHkAAAQQQQAABBBBAAAEEEEAgBAQI4EPgIlFFBBBAAAEEEEAAAQQQQAABBAjguQcQQAABBBBAAAEEEEAAAQQQCAEBAvgQuEhUEQEEEEAAAQQQQAABBBBAAAECeO4BBBBAAAEEEEAAAQQQQAABBEJAgAA+BC4SVUQAAQQQQAABBBBAAAEEEECAAJ57AAEEEEAAAQQQQAABBBBAAIEQECCAD4GLRBURQAABBBBAAAEEEEAAAQQQIIDnHkAAAQQQQAABBBBAAAEEEEAgBAQiQ6COPldx6/bdcvdTb1v56yQnyatP3iJhYWEl9t+bsU9uefA1cRY4Jcz898nrD0h4OM8ySkAVWzH7tyXyzqffSpsWjeWJuwcX21q4uH3XHrnz8TcLXYc/KOFe/L3uGKIr3/joG/l1wXK5+JxecmG/nl7P4ruffpExE6ZL147t5I7rLynKc8WNT0pqWoa1ru9pJxSt9/XL8lXrZG/6PmnfroXUSoz3dTfyIYAAAggggAACCCCAQIgKVKkAPnu/QxYv+7voUkyfu0j6nHxc0bLry+hvpsnCpatdi1JQUPSVL2UI7N6Tbvnm5ztLzZWdffAaFDgNbETJByil7hyCG9Zt3GqZnNj16FJrv21HqpUnOSnBI8/mbbtETTP3ZXus93XhmeGfW8d989nb5dQenX3djXwIIIAAAggggAACCCAQogJVKoAvfg3e++y7EgG8w5Ejn3/9U/GsLCMQcAFtIZKTmyetmzcKeNkUiAACCCCAAAIIIIAAAqEnUCUD+Pp1UyQmOkqW/bVOfpm/XE7s2qHoynw9ebbVbPmEY4+S3xetLFrv7Yu+IV31z0bZsStNmjWuL+3bNi/RVFkfCOzYnSY1YqKlbu1asit1ryxe/rdkZGZJl45trf1cx9bjLP1rrew2edq0bCzHHn2E1yb+ml+b+a9cs0H0DW/jBnXlqCOaWcd3Hcv1qU3Wc3JyRc85Oqrwcupb3by8PImNrWGaWGcai2ipV6eWaxePT307nGvy1jN1jzHnYGfSN/d//b1BNmzeIfn5+dKofh1p17qpxNeM9Sg2Mytb/l672bLcm7lPkuJrSoN6KdLBNBX31iVCdy4wzSj+Xr/Zuub7zTU5omUTOeaoVuba7Sn1/DXfqn/+lTVrN0lsjWjrmrRr3cyjLnYuNGlYTxw5OZKYULNEMTvNPaX12rYzVVKSE6VZo3rSyi3Q37Rlp+zfn2Ptt2PnHvl3y46iYzRpWLfIyWlc1m7YYtw3Sq55WKDn17ZVE4mMjCjK7/oSSveSq858IoAAAggggAACCCBQnQSqZAAfER4mV1/eTx5/aaS8Z/psuwJ4p9MpI7/4wervfs0VZ5cawGvw/eTLH8uk6b953AvxcbFy3y1XyH/OPqVo/dz5y2TIQ69bwb32cf7sq59M3/qDbfIvPreX3HPT5TLsrTHy5fc/F+2nX3p26yjDh94qUZGel2H0+GlWfocJzF1J+5Jf/9/z5KarLpCIiIP99W+6/xUrOHtv2F2yfNV6GTN+umggpumWwReK9tHWAHHml6+UCNA10O874F4rgP9mxNNWYOcqz9+f8xaukMdfHOkRaGoZ+tDh0v6nyQNDBlpFbjHjGJx1+d0ehq66tGzWUJ594DorMHet008934ee/cDqi+6+PiE+znqQ0vnoNvL5Gw+7b5IZpnvFoy9+JKnGwD2dePzRMvS+a0t94OGe93C/D3n4NeuBg167k44/xjqcPkx58uVPZMKUOeYhh2dXBX2I9Jp5a9/GBOBnDbinqPgnzL3qnmZ/87oV9OuYEPc+/a5HdxHNpw8CXnr0RmlrHp64p1C5l9zrzHcEEEAAAQQQQAABBKqTgGfkWIXO/Py+J8ubI8fLH3+ukkXL1lhvu6f8/Ifom8tzTu8hTc0bTW9Jg6ZBtz0rq82b2dYtGslFZnAy7cs9cdqvsmL1BnnkhRHSomkDOe6Yth676zb90eMed8wRom9Q9e2/Bu2Tps2TLNM3vHGDOtZbeR24bM7vS0UHhftm0mwrgHUd7NMvf5Tn3hhlvUE919RT3/pv2LRdvjb5dAA5fTvtCnZd++jn7Y++YZWh3/VBQ1b2fjm+85FS27y91UB9oqmD+4MHzTfu+5lW8N61Uztbg3d9y3/bI8Otvt7a6qCHaRHhNM7awmDOH0vlzxX/aHWspOv18UeHti3kmPatrFYH+kBl6uwFVmuEWx95XSZ++rzExcZY+bUJ+tV3PC/r/90mSYk1pe+pJ0idlCRZZ5Z//nVx4UGL/Tll5h/WQHs6cOFl5uFBhyNbyqKla+RHc3/88scyefDZ9+WDlw4GyMV297qoff/TTasJb0nHZvA1vfzuOHOtZ4k+fDjzlK7Swjy02LBpm/y2cKVs3LzdelhxhAngzz/rJHN+f0qaaWFxvLl+DevXLiqiRo0Y0TIH3vy0lV8D/3NO7249KJo6e751n15x01My6bPnrJYbRTse+BLM91LxurKMAAIIIIAAAggggEB1EqiyAby+2R10yVny0jtjRfvCv/3cnTJi9CQrML52wDmlXmN9+63BuwbpX33wZNHb8asu6yvPvP6Z6T8/Vd4aOaFEgFczroZ5Oz9A/mNGInc1837ouQ9k/A9zrEHyHr79f3L5+b2Ltj31yifWyOSzTBCvb6A1aQD49icTrO9P3DNYLnJ706+jlA82garW74oL+lj1szIe+CPfPGS4/bqLRYN+Deb07X2UaSZ9ybmnWoG/vpl3D+C1NcIX38609h74n9PdD+X37/qgQgdqa9Korox89X6P5tva9HvOb0uLytS6zzCtBbQ7gnu6cdD5cu6gB6zuDBr4a/cETR+NmWwF79rEftSbD3sEpDN/WSw3P/iq+2GswPb5N0db656+72oTCJ9sfVfrO80I8adefLv1Jt/10Mdj5zIWPho7WfTncNPkA60+tNWG+/XX6/Xtj79Y11bvr2dMS4SBtzxtDWJ3lWltUnwQu7fMwyttmaAzBnz+1sPWQx2t29VX9BN9064Pl159/0t59sHrS1Q5mO+lEpVlBQIIIIAAAggggAAC1UjgYFvsKnjS+nZV32TOmrdERphAT9+Qn9K9U5lvmzVI0jT4sn5FwbuLxjXV1+q1/7pWFX0e2aaZFXC5gnfdcNIJhc2itb+7Bt3u204+sE2bObvS74v+sqYF0zemxack0z772hVAWwjo6PrF04uP3iDXDTy36E2sjgGgb5gv7X+q1eR++er1snTl2qLdps9ZJNtN/2oNfE/v2aVovR1fog70zd+3b7/VMsG9DG2xcMWFfYpWafcAV/CuDzSWmDpPn7tQtPVEYkKclW+9eSPtSjN/KbT4P9O9QMcB8EheBsD/ffFf1nnrg4JzTz/RI7v2NT++05HWutWm/3lFkj7A0WN6+9EWEb4mfeiiaaNpdaFBuyvptbzAtCrRgNyX9NOs+Va2a8zDKvfytbvGzVddaG37adYCr4cK5nvJa4VZiQACCCCAAAIIIIBANRGosm/g9fppUDXABIfvfvqd9SZe113/33P1o9S0/t+t1raX3v3C6j/unjH/QEClTdJ18LryBn1LNA8PNGmz8OJJHyxocu/nvsE0kdakzea9zZ/eoV1L682pNqkunmrGeg8SNajtbabS++nn+ebt/fSi/uOjxk+1DqGtAjQ4tDP1PulY6637nr0ZcuYV90g38zCiU/vWclzHI8xDiaM9HmxoPXRe9dc/+MoM+LfOGpyueN3cPdduKLxenTu0KZ7N6/J6Myigpu2mWX+fS+8skUfrqGnz1p0ltpW14spL+5rA+AKvWd7//HvrbbfXjcVWnnnq8TJy7A/ywaiJ8v3UXy0fHbxPp0N0PdgotkuJRR3Qb6MZKFDT0Wbf4knnjdeHSdrMXgdWLD7AYTDfS8XPhWUEEEAAAQQQQAABBKqTQJUO4PVC/veiM83AdVOsgFv7CpcV6Gn/8n1Z+63rr286XaO6e9wQLQ8smQCovOQ+2FzxvJERJUcB32X6zWuqlRhfPLu1nHBgtPY9aYVBptdMXlYOMG//NYD/YcZv1iB8Ogq+9qnWt/Q6yJ6vKdb0rdak/b1LSzqyuyY9tuv8dRC94U/fJi+8Ndrqx64Buv5oOuqI5vLgrQOLxhT4yvT/fnzYR9YgdtoSoftx7U13gfpWv3btvuDeX17L0mumSfu/+5K2mRHbNSXXSihz+rbSxkjwpYzDyXPr1f8x/ftryIcmgNexA7Q/vP68YJr9X2Yettz1f5d6dEHwVpbew67r4O1e0vs62lwffQi1Z296iQDe2zFd6/x1L7mOxycCCCCAAAIIIIAAAgj4LlDlA/gUE6hpX+JR30yV68p5+65NjXVKM+2v/dBt/xVtFh/IpM3ZNelUdN7Snr2Z1uq6pUwJ520fXafN73VAvn/Wb7GCQVez/X69u0lyUkJpu5VY38g0EdeUmpZeYptrhavu2pTcPZ3SvaPpvtDRqsOfK/6W+WZwQR1MTvuzD33tM2u8Ac0/+ptpVvCuzeofuGVg0UMA3TZj7mKPAF6n7tPAfW/6PsusRBN63alYctVLWwAMH3pbsa2Vv6itOvRN/pVm/IYlZnC/JWbaQXXScRk+GTfFDEzYTnqfdJxnRQ9OemCt13tY72V9uKHXQ7sGuCd9867Bu6a6tZPdN5X73V/3UrkFkQEBBBBAAAEEEEAAAQRKCNjbdrpEcZWzQoPx5TNHFk3VVVYtWh+Ya3vanIVlZbNlW/MmDazj6jzyOrp68aT9tzW58hXfXtbyFecX9jP/2LRG0IH1NA38zxll7VJim46ir0lH0de+6d7SjAN90l15i+fRBwk6mJ4Owjb+o6etzTpH+SbTZF0DTv2uSccvcL3Bt1aU8oe+pdc0dXbJ67XPPIgpnlo3b2itWmhGndcR3IM1aRCuU9rd8L/+8s2HT0n/Mwv7609167cedaAVR7ajZIuIZk0KZ1n4bdHKEqfouo+0DH3AVdHkj3upomWSHwEEEEAAAQQQQAABBESqRQBfkQvtalKuI9e7B0t6DO1brFPC3f7o8Ioc0ue8Pbq0twZi07emOn+7e/py4s9mnvd1os3Ydaq0iqb+ZtoxHRNAp7fTJtY6N7r2ta9I0je5vcwggJoeGzZCdM529zTZNNHXafE06fR7rvT2xxOsqfFc/ctd67eZQfQ0RZqB23Sguzhzbtq0W9Nst5Hpncb9i29nWNPuWRvd/tBAX9OIMZOsvuM6+Jw2z392+Ofy0HMfuuUs/NrVDFKnMwxo8H6fmSNdH0a4Jx3YT2cPmFnKFHTuef39Xd+KX3zdY/LzvD9LHHqraU6vKfbA9Hn63dWaYPa8pbrokVyDIKqLjvTvSnoNXnv/K2tRZ0w4lOSPe+lQymUfBBBAAAEEEEAAAQSqu0CVb0Jf0Qusb4d/NP3Fdeqz20yg3rZ1U2vkbw2qV5iR3LV5fasDb+kreuzy8mvz6btvvEzufeodqw/07+btaTtTvs5dP2/hCmv3//vfeRXqs+wqU4P388xbXJ1OTlNF3767jnP/kAFWXTRQ7n/lg9ZDAB1cbe2GLeIaub3bcUfJWWYwNlfSOel1fvtx380UHZBN/bZs2yV/Lv/HyqKj59evU9iU+6xeXa3p0nT6v7HfThd9k6+zB+hc8N5S/zNPkolT51lB+7C3x4i8fTCXvmHOzcuTMPOfK2nf/CfuHizX3jVM5vy+VPoNuNd6mKF5V5m3/xt09HfzwKBnt46uXQL2qS3htUuBTvOmffD1AYs+sFm+ar2sWbfJ6u7gGkFeK6UzGeisCROmzDFT6W21xk7QFgxfffikacHQ2/LWa6IPBXT2hUgzwv+vC1ZYD3HqpCTJjVeef0jn5q976ZAKZycEEEAAAQQQQAABBKqxQJUK4F3TtPkyqrprDDrXPu73wFvP3m7N0f7OJ99afY+1/7ErdWjbwmPgt/CwwkYM3kaNLzq2qzDXQcxnWHhhUBl+4NO16WzTL11Hr3/khQ+tad9cU79pgPnAkIHWVGKuvPrp2t/16b6t+Pcux7S1AngddfzMU7oW3+zTsjZZ/9o06dZ57PWhwoIlq4v208HRrr78bLnePGRwT716dDaB6UYzcF5hftc+GpxebeYw14cSrvTgrf+VdBOs6xzu+uBCf+LMW2ed1k+nj5thptBz2ek+2sz+vWF3yWdmgDs9/g4z93mLpg1FWzPoYHB3PfGW1Kmd5Dq89dnVDGaozfefe2OUFfhrIO9K6tzn5C5m9PaWrlVlfroeDhx8RFAyu+vecH26criWww7cQ+p31WV95fuffrXemru/OT/mqFZy381XeDR5P7tPd2uk/s+/+qlobADXva8un73xsHWdJprR7LXliCudZJrmD73/WjMtn+fAf657yPXpyu/t0x/3krfjsg4BBBBAAAEEEEAAAQRKFwgzzcKLDYFVeubquEWbWuuUXDpgWpOGda1gMlAO2kT9X1N2/brJ0qxJfa9Ty1WkLtfc+YIVdA8xI53fMKh/RXb1mjfLjEa//t9tJuDeJw3r1bZ8yuq3rv369c27tmbQN8CNzNt1ryP9m9I0cP936w5rMLYjWjWx/L1WooyVb44cL2+ZH31IcNcNl3nNmW+m+NNAOc0MENiwforUNS0BXIG11x0CtFKb9rumstNWCMUHonOvhg5Kt9m4ar01b/HpDXVEen0Tr9PvtWnZ2Bqo0X3/Q/nu73vpUOrAPggggAACCCCAAAIIVDcBAvhqcsVX/bNR/nPNoxIVGSnTxr0stYuNTB7KDPp2+TjTusA1ir+ey8Klq+WWh16zRqgf8fJ9os36Sf4RqMr3kn+EOAoCCCCAAAIIIIAAAvYIVKkm9PYQVY2j6ujzmvqedkKVCt71nJ55/XMzn3mG1QdcB3bTt9falF4bl5zeswvBuyL5MVXle8mPTBwKAQQQQAABBBBAAAG/CxDA+500+A6owe2kab9ZFRv4n9ODr4KHWaNOHVqLDvin3R30R/uBa3eHKy7oLf+96MzDPDq7uwtU9XvJ/Vz5jgACCCCAAAIIIIBAsAnQhD7YrohN9cnLy7eOrFO2VcWkb9t1hgCdIk/711fV8wyGa1fV76VgMKYOCCCAAAIIIIAAAgh4EyCA96bCOgQQQAABBBBAAAEEEEAAAQSCTKBwDrQgqxTVQQABBBBAAAEEEEAAAQQQQAABTwECeE8PlhBAAAEEEEAAAQQQQAABBBAISgEC+KC8LFQKAQQQQAABBBBAAAEEEEAAAU8BAnhPD5YQQAABBBBAAAEEEEAAAQQQCEoBAvigvCxUCgEEEEAAAQQQQAABBBBAAAFPAQJ4Tw+WEEAAAQQQQAABBBBAAAEEEAhKAQL4oLwsVAoBBBBAAAEEEEAAAQQQQAABTwECeE8PlhBAAAEEEEAAAQQQQAABBBAISgEC+KC8LFQKAQQQQAABBBBAAAEEEEAAAU8BAnhPD5YQQAABBBBAAAEEEEAAAQQQCEoBAvigvCxUCgEEEEAAAQQQQAABBBBAAAFPAQJ4Tw+WEEAAAQQQQAABBBBAAAEEEAhKAQL4oLwsVAoBBBBAAAEEEEAAAQQQQAABTwECeE8PlhBAAAEEEEAAAQQQQAABBBAISgEC+KC8LFQKAQQQQAABBBBAAAEEEEAAAU8BAnhPD5YQQAABBBBAAAEEEEAAAQQQCEoBAvigvCxUCgEEEEAAAQQQQAABBBBAAAFPAQJ4Tw+WEEAAAQQQQAABBBBAAAEEEAhKAQL4oLwsVAoBBBBAAAEEEEAAAQQQQAABTwECeE8PlhBAAAEEEEAAAQQQQAABBBAISgEC+KC8LFQKAQQQQAABBBBAAAEEEEAAAU8BAnhPD5YQQAABBBBAAAEEEEAAAQQQCEoBAvigvCxUCgEEEEAAAQQQQAABBBBAAAFPAQJ4Tw+WEEAAAQQQQAABBBBAAAEEEAhKAQL4oLwsVAoBBBBAAAEEEEAAAQQQQAABTwECeE8PlhBAAAEEEEAAAQQQQAABBBAISgEC+KC8LFQKAQQQQAABBBBAAAEEEEAAAU8BAnhPD5YQQAABBBAIaYGCggLJ3JddoXPIzcurUH4yI4AAAggggEDlCERWTrGUigACCCCAAAL+FNiwabsMe3uM/Dp/uex35EhcbIz06t5Z7rrhUmlYv7ZHUfn5Tvlw9ESZt3CFrFi9QTIys+TKS/vKvTdd7pGPBQQQQAABBBAILgEC+OC6HtQGAQQQQACBCgs4zVv3Ox57U/7dsl0GXNhH2rVpJn8s+ku+mjRLVq39V7764EmJjir8Jz91T7rc/tgbsmDJajnS5Dv3jB5S4CyQ5KT4CpfLDggggAACCCAQWAEC+MB6UxoCCCCAAAJ+F5g49VdZ9c9GGXxZP/PG/TLr+Oee3kN27N4js+YtkRWr1kvno9tY61/74CsreL9hUH+5ZfCFEhYW5vf6cEAEEEAAAQQQsEeAPvD2uHJUBBBAAAEEDltg+tyFMujWZ+T5N0d7HGvn7jS55s4XrDfpTqdTMjML+7zXTkn0yHdkm+bWcoEUWJ87dqXJhClzpdtxR8mQq/9D8O6hxQICCCCAAALBL0AAH/zXiBoigAACCFRTgVN7dDZN36Pkk3FT5ItvZ1gK2n/9rifekvlLVsmgi8+U8PBwOaVHJ4mKjJThH34tn375ozhMH/g9ezPkx5//kAb1UqRTh8K37zN/WSQ6YJ2+nZ86e4GMGDNZPjbHXr5qXTUV5rQRQAABBBAILYEwM1pt4WP50Ko3tUUAAQQQQKBaCKSlZ8ol1z0mu1L3yudvPiKTp8+zAu/H77pKLjnv1CKDJSvXytV3PC/Z+x0SXzPW+omLrSHvvXBX0SB2r7w3Tj4YNdF6867//EdEhIs+ENB08bm95Im7Bxcdjy8IIIAAAgggEHwCvIEPvmtCjRBAAAEEECgSqJUYL68+NcQKuq+7e5h8NPYHufyC3h7Bu446/9lXP5k8IvffMkBO6dZRdLC6jZu3y4Qf54oOcqdpy/bd1ufdpp/87PHDZcm0EfLDqBfkmKNayZff/yzf/viLtZ0/EEAAAQQQQCA4BQjgg/O6UCsEEEAAAQSKBDq0bSFXX3G26Nt4Deg1SHdPGnzrQHZP3XuN/M80qx/26I0yYeRQade6mdWsft6CFVb22Jho6/OMXl0lpVaC9b1po3ryyB2DrO/zF/9lffIHAggggAACCASnAAF8cF4XaoUAAggggECRgDaf/2riz1Z/d+3b/uGoSUXb9MuMuYus5e5d2hetb9a4vtw8+AJrWfu+a2rWpL71uWnLTuvT9Yf2n9ekDwhICCCAAAIIIBC8AgTwwXttqBkCCCCAAAKSl5dvzfG+N32fjH7rETn6yJby5kffyJzflxbpJCXWtL7//OufRev0y5q1m6zlmnGx1qfuq2nClDnWp+uP6XMWWl91XngSAggggAACCASvQMTjJgVv9agZAggggAAC1VvgmeGfy08/z5dHbh8kp510rPTo0kHG/zBHfpq1QPqedoIkJtQUDdAnTp0nS1f+Yw1KFxMdKZOm/Wb6y0+WiPAIefTOQZJkmt43aVhXlv211oxOP98apd7pLLBGrR/77XRJiI+TofddI7GxMdUbnLNHAAEEEEAgiAWq5Cj0OkjPnyv+LsEeEx0lvU86rmi9NhWcNW+JbNi0TVq3aCyndO8o8QfeUrgy+ZLHlZdPBBBAAAEE/Cmg/drvffpdObtPdxn2yA1Fh55qgvfbHh0u+sZ83HuPW03rv/vpF3nx7bHWaPWujEcd0dwE71dKRzNInSvtNoPbPf7iRzL9QLN7Xa9v5rX/fNtWTVzZ+EQAAQQQQACBIBSokgG8jqL7wDPvleBOTkqQOROGW+s1yB98x3OyY+ce0X6C600Q36p5Ixnx8r2i+TT5ksfKyB8IIIAAAggEgYBOCbdp604riG/coI7Ur5tsjV7vrWp7M/bJxk3brXni69au5S0L6xBAAAEEEEAgyAQKR60Jskr5qzpTRg0rmvtWj6nT67jSiDGTJG1vpjVKrwbwy1evl4E3PS1jxk+XG68838rmSx7X8fhEAAEEEECgsgV0XvfmZqA6/SkvJZmm9zp9HAkBBBBAAAEEQkegSg9iFxkZIfrLjOsnPPzg6U6Z8bv06tHZevuul0un6OnaqZ1MmflH0dXzJU9RZr4ggAACCCCAAAIIIIAAAgggYKNAlX4DP+qbqdagPA3r15bTTjzWDPJTw6J05ORKalqGHNGysQetLi9dudbnPB47s4AAAggggAACCCCAAAIIIICAjQJVNoCPM6Po6gi9+x0O2bErzQrkR7x8n7Rv21xSzQA+muJiCwN6l68uZ2ZlS25enk95dN7cbEe+a/eQ+czLL5B8M/JwTNTBFgkhU/kQrqia55r+qTWiIkL4LEKv6pZ7nnGPxj2QV89ZUCCOXKfE4h5IdrHcc4x7DPd7IOELpMD8PuCUONwDyW7UxbjnGfcq++tsQD0rUti+/XlSswbuFTHzR94sc7/HmvvdrVewPw4b8GPwb9ThkVfJ//POMaP19j/zxCKZZX+tk+vvfVGeNVPxfDr8QYk2o9FrcjqdRXn0S15+voSbjvIRpqm9L3l0H/1lKdSS/qJRYOodinUPNWv3+lre5nbB3V3F/u96r+v/pbjbb+1egnleJQqPu7uK/d/1nyTud/udi5dg/SrA/V6cxf5lvd9xt9+5lBL4+70UGBtXW3/Hm39gC0I9grfRqDocukoG8Nrn3T3p9Dinmv7u02YvtFYnJ8VbgXp6ZpZ7NknPyJJaus0E8L7k0Z1D8emjvhXLEWdI1t3jgoXYQo55C7w/Jx/3AF+3XOPuNC1lQvH/1QBT+bU4q6WPaXGCu19Zyz2Yq8UJ7uVS+TWDBjI55t9W3P3KWu7BNJjZn8vf7+VC2ZBBW6Byv9sAW84h9ffIONPywX1g7nJ2YXMVFPCMdKvgCbpOafO2XVKndpK1qAF6y+YNZfGyNa7N1ufi5Wus+eB1wZc8HjuzgAACCCCAAAIIIIAAAggggICNAlUygL/+nhdl+Idfy28LV1rTwz33xiiZ/+cqOc+tWf0FfXvKL/OXy8fjpsjf6zfL8BFfy+q1m+TCfj2LuH3JU5SZLwgggAACCCCAAAIIIIAAAgjYKFAlm9A3alBHPhw9Sd759FuLTqeTG3xZP7n2inOKKK+85CxZv3GrvPj2WHnhzdHWVHNXX97Po++8L3mKDsgXBBBAAAEEEEAAAQQQQAABBGwUCDMDPJkeRFUv6VRx23akSr4ZmK5p43qiI8Z7S9n7HaLN65s2qicxBwa3K57PlzzF9wnmZasPvOmrlxDn3SSY6x7KdXP1gU+MKxxEMZTPJZTqrn3gs0xfvaSauAfyumkf+MzsXKkVHx3IYqt9WdoHPn1friQn4B7Im0H7wKdl5EpKIu6BdNffYFMzHFI7MSaQxVKWEdi11yF1knAP9M2wO90hKQkx9IEPNHyQlVdlIzgNxps3qV8ud2yNGGnTwnM++OI7+ZKn+D4sI4AAAggggAACCCCAAAIIIOBPgSrZB96fQBwLAQQQQAABBBBAAAEEEEAAgWAQIIAPhqtAHRBAAAEEEEAAAQQQQAABBBAoR4AAvhwgNiOAAAIIIIAAAggggAACCCAQDAIE8MFwFagDAggggAACCCCAAAIIIIAAAuUIEMCXA8RmBBBAAAEEEEAAAQQQQCCYBMxEW6RqKkAAX80u/MqVInfeESYDLo+QH34QcTqrGQCniwACCCCAAAIIIIBAiArs3i3y6KMiTZuKdO0qMmKESNWcFDxEL1AAql1lp5ELgF3IFbFihcjRR+v/5GFW3b//TuT550XuvTfkToUKI4AAAggggECQCFQ0eKhofj1Nb/voOn0LWdqbSG/7lEcWrPsEW72yskSyogo1g61urmscrPXS+h1q3dIywuTF50TeeafwLLduFbnmGpEWLUR69y5cx59VXyCswCS7TjMtPVN+XbBctmzdJbvTMszNWiC1EuOlft1kOeHYo6RR/dp2Fc1xvQgMGSLyxhueG6LMX75t2hz6XySeRyt76VDutKq0j56L/j8QFlb4AKVsrcKth3L+ruMeyr4V3aei+bVulbGPlukLeyDqFogyKsvZde+5Pr25V6fzdzkU/6yogd35XfWraDm6XyD2CUQZgTqXQJUTKDM9HxICCFS+wMUXi4wbV/n1oAaBEbDlDfyadZvkueGj5PdFK8VZxr8ibVs3lXtuuExOPN68FibZLrBhQ8kicnNFtFk9KVACvgfvgaoR5SCAAAIIIHA4Ar48IHU/fkXz677VfZ/qfv6Hcg9URTOneSGRvrdkF9jERPf/w/he1QX8+gZ+vyNH3ho5XkZ+8YNpzuSUzke3kbN7d5fWLRpJw3q1JTIyQrbtSJV/t+yQn2bNlzm/L5W8vHyTp5vcd8sAqZOSVNW9K/X8Jk4UOfdczypcdpnIY48F7z+MVekv31zz/4Qj1ykJsRV7bnYoBnqVK7pfRfMfShmVsU9unlOyc5ySGFe+e0UNKpq/Ms5fy/Q1+fN88vILZN/+XEmqGe1RvD/L8DhwsYWqVE5FziXf/HaXkZUryQme7sV4vC5WpBzXAQKxTyDK0PM5nHL0ZUVaRq6kJJbvfjjluNzL+wxEGeXVIRDb9R1RaoZDaifGBKI4ynAT2LXXIXWScHcjCcjX3ekOGf5yjDzxhGdx8+eLdOniuY6lqivgtwB+V+peGXDTU7J52y45pXtHue/mAdKiaYMy5VJNs/o3Rnwt476bKXFxNeS9YXdLp/aty9yHjYcuoAPWaZ937TejA2AMHCjyyCMiTZoc+jHZ03eBHBNI7s/JN4HkgU5jvu9KzsMQ0AA+y5FvAkncD4OxwrtqAJ+ZnSu14ssPaCp8cHYoVUAD+PR9hxbAl3pQNpQrUJEAvtyDkcFnAQJ4n6n8npEA3u+kPh1QA/i4qBj54guRd98VadZM5MYbRXr18ml3MlURAb8F8H+v3ywXX/uYPHXf1XLeGSdWiGfxsr9lyMOvyb03X1HhfStUEJktgaz9Ttmb7jStIsp/IwmZ/wQI4P1nWZEjEcBXRMt/eQng/WdZkSMRwFdEy395CeD9Z1mRIxHAV0TLv3kJ4P3r6evRNIBPSYg5pBZDvpZBvuAX8FsEl5yUIO+8cKd0P659hc9am9p/Ovwh2ZeVXeF92aHiAhERIvHxFd+PPRBAAAEEEEAAAQQQQAABBCpPwG8BfO3kRKmdXPHg3XXq5TW3d+XjEwEEEEAAAQQQQAABBBBAAIHqKOC3AL48vKUr18oPM383Tbf3SecObeTCfj0lIiK8vN3YjgACCCCAAAIIIIAAAggggAACRsDvAfzW7bvlm8mzzbzv6WYwu07Sy/yMHPuDDHt7TBG4bp84bZ68bwat05HpSQgggAACCCCAAAIIIIAAAgggULaAXwP4zH3ZctUdz8mmLTutUseMny43DOovn389VZo2qie3X3exFbB/NHayNUf8+B/myMXnMmxi2ZeIrQgggAACCCCAAAIIIIAAAgj4+Q38tDkLrOC9Z7eO8p+ze8qseUvknU++tZzffeGuoiniTuh8pPT6z23y/dRfCeC5CxFAAAEEEEAAAQQQQAABBBDwQcCvb+DXrN1sFfngrQOlWeP6cmav42XRsjWycdN26XhUq6LqJCbUlGPM8rYdqUXr+IIAAggggAACCCCAAAIIIIAAAqUL+HUUuazs/VZJTRrWLSrxiJaNpUaNaDNfYVjROv2SZIL4PXszPNaxgAACCCCAAAIIIIAAAggggAAC3gX8GsDn5uVLeHi49eMqLiY62mPZfb0UuJb4RAABBBBAAAEEEEAAAQQQQACBsgT82oTeVVBuXp7rqzidTtFA3X2dbszX9SQEEEAAAQQQQAABBBBAAAEEEPBJwO8BvAbsnU+/tkTh3tbFx8WWyMcKBBBAAAEEEEAAAQQQQAABBBAoKeDXAL5hvRRp17pZyVJKWRMXG1PKFlYjgAACCCCAAAIIIIAAAggggIC7gF8D+JuuukD0h4QAAggggAACCCCAAAIIIIAAAv4V8Osgdv6tGkdDAAEEEEAAAQQQQAABBBBAAAGXgF/fwDtyciU39+AAdq5CSvvUqeVqxtUobTPrEUAAAQQQQAABBBBAAAEEEEDggIBfA/inX/1Uvp40y2fc+Jqx8tvEt33OT0YEEEAAAQQQQAABBBBAAAEEqquAXwN4d8Rjjmol4eYNe1kptgaD2JXlwzYEEEAAAQQQQAABBBBAAAEEXAJ+DeB7dO0gs+b9KbtS98q+rP1y7YBz5NzTe0hEBF3tXeB8IoAAAggggAACCCCAAAIIIHAoAn6NrM/u3U1+GvuSPH7XVZKfny8PPvu+9B1wj4z+Zpo4HDmHUj/2QQABBBBAAAEEEEAAAQQQQAABIxBWYJIdEk5z2GmzF8gHoybKsr/WSUpyolx5yVly+QW9JT4u1o4iOaaPAo5cp+SYn4Q4vzbA8LH06pstJ88p+3PyJTEuqvoiVMKZ5xr3LEe+JNXEPZD8efkFkpmdK7XiowNZbLUvK99ZIOn7ciU5AfdA3gz6O09aRq6kJOIeSHf9DTY1wyG1E+mSGUh3LWvXXofUScI90O670x2SkhAj5fRSDnS1KC/AAn59A+9ed+3/fsYpXWXsO4/J7dddLKl70uWV98bJu598656N7wgggAACCCCAAAIIIIAAAggg4IOAra9g5y1cIe9++p38vmileVIUJr1POlb6n3WSD9UiCwIIIIAAAggggAACCCCAAAIIuAv4PYDXFvkzf1ks7332nSxZuVYiIyPk/LNONgPanS2tmjdyL5vvCCCAAAIIIIAAAggggAACCCDgo4BfA/hf5i+XYW+NltVrN0mNmGj570VnyFWX9pWG9Wv7WB2yIYAAAggggAACCCCAAAIIIICANwG/BvCTp/9mBe9a0CndO0leXr41iJ23gnVdjAny773p8tI2+229NuXXlgE9unTwOGZaeqaZ9m6JbNi0TVq3aGzq3LHEAHu+5PE4KAsIIIAAAggggAACCCCAAAII2CDg1wDevX4//vyH+6LX7zoavd0B/MSpv8q9T78rHdq1lB7vHgzgt2zfLYPveE527NwjzRrXtx40aBP/ES/fK8lJCVZ9fcnj9cRYiQACCCCAAAIIIIAAAggggICfBfwawN9x/SVy3cBzfK5ieJhtg+BbdVi4dLU8/PyHEhNdcvqoEWMmSdreTJkwcqgVwC9fvV4G3vS0jBk/XW688nxrf1/y+HyyZEQAAQQQQAABBBBAAAEEEEDgMAT8GsCn1EoQ/QmGtHHzdhny0Oty0bm9ZOeuNNm6I9WjWlNm/C69enS2gnfd0KFtC+naqZ1MmflHUQDvSx6Pg7KAAAIIIIAAAggggAACCCCAgE0CfnsFrv3dHY6cQ66m9lHPzMo+5P3dd9ybsU9uvP8V6di+lTw4ZKD7Juu7IydXUtMy5IiWjT226fJW07Reky95PHZmAQEEEEAAAQQQQAABBBBAAAEbBfz2Bn69GQjusWEfydvP3SGJCTUrVOX8fKdp6v6BnHj80XLeGSdWaN/imXPz8uS2h183zeaj5aXHbpbw8JLPKFL3pFu7xcXW8Nhdl/Uhgh7DlzxRkZGyJ+PQH1p4FB7AhQJTlnleEpJ1DyCT34sqdC/A3e+yZR8Q97J97NzqNH/RhOLfkXaaBOLY+U7cA+FcvAzu9+IigVnm95nAOHsrhb/fvanYu07v97TM0Is9iqskJ0QXX8VyBQT8FsCHSZgsXv63XPJ/j8sjtw+Sk084xqdqrP7nX3n8pZHy54p/5CQf9ynrwB+OniTLVq2XD168R9LNm3j9yd7vkNzcXNlmmtEnmyb+0Qf6xDudTo9D5eXnS3hYmESYoN+XPLpzYs2S/es9DhqECzm5TvOQokBqxkYEYe2qbpVy85ziMPbxsX77367qYvnxzPKMe3aOUxLicPcja7mHyssvkCxHniTGhd7fkeWeXBBn0OA9M9u4h+C/TUHMWm7VNHjP2Id7uVB+zqDBzN59Odzvfnb15XAavPP3jC9S/s2jwXuC+XfVhCukaizgt99oW7doJC8+dqM8/8Zo+b97X5KTzNv0C/r1lD4nHWtNF+durP/QzVuwQr6dMlcmTZ8n+ib7rhsuk36ndXPPdkjf96YXBuwDb3m6xP59Lr1T3hh6m+n73skK1NMzszzypGdkSa2keOutfbJ+mv87ysqjO0eEh97/QeGmzmFhBSFZd48LFmIL+ZZ7aN4zIUbtUV0n7h4egVrQX6z1b8dQ/DsyUEZ2lYO7XbKlH9f8k2ol7vfSjezYon/PaMK90CHQf+IeaPHC8tSdAL5y7IOlVL8F8HpCGoD3PKGjvPL+OPliwgyZ+8cyawT4Rg3qSKP6tSUqKtL0MU+Vzdt2Sua+wv7uOpDcw7f/z9ruD5QbBvWXARf28TjUky9/LDt375XhQ2+VurVrWQF6y+YNZfGyNR75Fi9fY80Hryu16X15eTx2ZgEBBBBAAAEEEEAAAQQQQAABGwX8GsBrPeNrxlpN6C8/v7dMnbXACuK3bNslvy/6S/JNk3V9s920UT3pdtxRctqJx1ojv/vz/JJM/3v9cU/atz06Ossq17X+gr495aV3xsrH46ZYrQUmT/9NVq/dJM88cJ0ri/iSpygzXxBAAAEEEEAAAQQQQAABBBCwUcDvAbyrrke0bGJGeW9SNCWbrteR5sMqoc2HFlm82CsvOUvWb9wqL749Vl54c7RERITL1Zf3k/5nHhxEz5c8rvPlEwEEEEAAAQQQQAABBBBAAAE7BcJMUH2gB5GdxQTvsXWAu82mhYC2Cog5MLhd8dr6kqf4PsG8rAOp6UB2DOoV2KuUYwZT25+Tz6BegWU3AzY6zWBq+ZLEoF4BlddB7DKzc6VWPCPNBhJeB7FL35crjPAbSHURHdsnLSNXUhK53wMpr7/BpmY4pHZiTCCLpSwjsGuvQ+ok4R7om2F3ukNSEmJKvJgMdD0or3IFbHsDX7mn5XvpsTVipE0Lz/ngi+/tS57i+7CMAAIIIIAAAggggAACCCCAgD8FSk6S7s+jcywEEEAAAQQQQAABBBBAAAEEEPCLAAG8Xxg5CAIIIIAAAggggAACCCCAAAL2ChDA2+vL0RFAAAEEEEAAAQQQQAABBBDwiwABvF8YOQgCCCCAAAIIIIAAAggggAAC9goQwNvry9ERQAABBBBAAAEEEEAAAQQQ8IuAraPQ78vaLx+NnSyLlq6RLdt3yzVXnC0Xn9tLZv6yWL6eNEv69ekm/U7r5pcT4SAIIIAAAggggAACCCCAAAIIVGUB2wL4zKxsuejaR2XTlp1mrsIw0enm09IzLcuO7VvLvU+/Izt2pxHAV+W7i3NDAAEEEEAAAQQQQAABBBDwm4BtTeg/+WKKFbxfdVlfmT7uFamVGC9hB6qdUitBTjr+GFm+ar3k5eX77WQ4EAIIIIAAAggggAACCCCAAAJVVcC2AP7PFf9IbI0YuWXwhVKvTq0Sfke2aSZOp1O27UwtsY0VCCCAAAIIIIAAAggggAACCCDgKWBbAJ+f75Q6KUlWEO9ZZOFSVvZ+64u+mSchgAACCCCAAAIIIIAAAggggEDZArYF8G1bN5V/t+yQZX+tK1EDR06uTJ7+mxXgx9eMLbGdFQgggAACCCCAAAIIIIAAAggg4ClgWwB/Qd+TJToqUu556h35cuLPkpObaw1iN2/hCrnqtmdl87ZdMuDC0z1rwxICCCCAAAIIIIAAAggggAACCHgVCDOjwxd43eKHlROmzJGnXvlUsvc7ShztlO4d5fWnb5WoSNsGwi9RJisKBRy5TvNAxSkJcdgH8p7IyXPK/px8SYyLCmSx1b6sXOOe5ciXpJq4B/JmyMsvkMzsXKkVHx3IYqt9WfnOAknflyvJCbgH8mZw6kw7GbmSkoh7IN31N9jUDIfUTowJZLGUZQR27XVInSTcA30z7E53SEpCjJnhK9AlU14wCdgawZ1/1snS/bj28s3kObJ241ZJz9gnLZo2kK6d2snpPbsEkwN1QQABBBBAAAEEEEAAAQQQQCCoBWwN4PXM69dNkRsG9Q9qBCqHAAIIIIAAAggggAACCCCAQLAL2BbA6yj0efllz/EeFRkh4eG2dcMPdnvqhwACCCCAAAIIIIAAAggggIDPArYF8MNHfC3vf/59mRXR4L1Ny8bS77QTZPDl/egPX6YWGxFAAAEEEEAAAQQQQAABBKqzgG0BfHKtBMu1fdvmUiup8LsLevmqdZKRkSVdjjlC/tmwRV774CtZ/+82eeaB61xZ+EQAAQQQQAABBBBAAAEEEEAAATcB2wL41D3pVvP4d1+4W1IOBPOucidMmSsPPvu+XDPgHDmh85Ey5OHXRdddN/BcadmsoSsbnwgggAACCCCAAAIIIIAAAgggcEDAtg7oK9dskIb1UkoE71ru2X26SaTp/z55+m8SExMtV156llWd1Ws3HagWHwgggAACCCCAAAIIIIAAAggg4C5gWwCvhezZmyE6N2rxpHO/J9SMkw2btlubXE3st+/aUzwrywgggAACCCCAAAIIIIAAAgggYARsC+A7d2gjWdkOeXPEN5KTm+eBPfePpVZw37xJA2v91m27rc/4uBoe+VhAAAEEEEAAAQQQQAABBBBAAIFCAdv6wA+65Cz5ZvJseefTb+XjcVOkR5f2pjl9oixavkbWbthqNZ0fcvWFVi0WLFllfbZoWhjQc3EQQAABBBBAAAEEEEAAAQQQQMBTwLYAPr5mrIx87QEZ+uqn8vO8P2X63EVFJTesX1vuufFy0U9NvU8+To45qpV0aNeyKA9fEEAAAQQQQAABBBBAAAEEEEDgoIBtAbwW0bhBHXnruTskLT3TvHXfYjWpb2SC9maN61uD2LmqcbwZiZ6EAAIIIIAAAggggAACCCCAAAKlC9gawLuKrZUYL8cd09a1yCcCCCCAAAIIIIAAAggggAACCFRQwNYAPnu/Q2bNWyLrNm6V3DzPgey0nrE1YuRaMxc8CQEEEEAAAQQQQAABBBBAAAEEyhawLYDP3Jct/xsyVMqa2z0+LpYAvuzrw1YEEEAAAQQQQAABBBBAAAEELAHbAvivJs2ygvez+3SXBnWTZcSYyTLs0Rulfp1k0VHnX/vgK7ny0rO4DAgggAACCCCAAAIIIIAAAggg4IOAbfPAL1u51moiP/T+a6Xbce2tqrRq1lC6dGwr1w08V9q1biY/zV7gQxXJggACCCCAAAIIIIAAAggggAACtgXwqWkZUrd2LYmOipTkWgmW9L9bdlifYWFhcsKxR8rqf/6VnbvTuAoIIIAAAggggAACCCCAAAIIIFCOgG0BvM4Dn5qWbhXfpkVjK5Cft2BFUXXS9mZa3/cc+CzawBcEEEAAAQQQQAABBBBAAAEEECghYFsf+Hqmr7sOZPfP+i3SukUj6dShjXw58WepW6eWREVEyIy5iyQqMtLMCV+vRKVYgQACCCCAAAIIIIAAAggggAACngK2vYE/6fijTTP5o2Tj5u1WiQ8OGSiRJnAf/uHX8vJ74yQzK1tuvfYiqRET7VkjlhBAAAEEEEAAAQQQQAABBBBAoIRAWIFJJdbatGLTlp0y+7clsit1r3Tv0l6O73ykTSVx2LIEHLlOyTE/CXG2NcAoq/hquy0nzyn7c/IlMS6q2hpUxonnGvcsR74k1cQ9kP55+QWSmZ0rteJ5SBtI93xngaTvy5XkBNwD6e40v0qlZeRKSiLugXTX32BTMxxSOzEmkMVSlhHYtdchdZJwD/TNsDvdISkJMWKGEyNVY4GARnBNGtWVKy7sI/n5TomIsO3lfzW+nJw6AggggAACCCCAAAIIIIBAVRWwLYDfsn23PP3qp3Jkm6Zy6zUXWX7fTJ4t7332vWzZvkt6de8kzzxwnehgd/5ODkeOzFu00up/v8cMpNegXm0569TjpU5KkkdRaemZMmveEtmwaZvpp99YTuneUeLjPOvjSx6Pg7KAAAIIIIAAAggggAACCCCAgA0CtgXwk6f/Jj//uljOO7OHVe3de9KtgD4nN88E0okybc5CGfbWGHninsF+P63HXhwp3/30iyTEx0k9M2je+n+3yavvj5ORr94vHdq1tMrTBwyD73hOduzcYwbSqy8fjJoorZo3khEv3yvJSYXT3vmSx++V54AIIIAAAggggAACCCCAAAIIeBGwrR27zvGuc8CfecrxVrHjzdv3/ebN+B3XXyLTvnhZevXoLBOmzBWn0+mlWoe3qkvHtjLytftl3vdvybcjn5EJHw2V3Nx8GfXNtKIDjxgzSXQquwkjh1o/o956RNZt2Cpjxk+vUJ6izHxBAAEEEEAAAQQQQAABBBBAwEYB2wJ4nQO+SaN6RX3dl/611jqNs3t3k/DwcOl23FGSm5cn28wbcH+nS847VY7vdHCAvKSEmqbMsKI361relBm/Ww8R9O27pg5tW0jXTu1kysw/rGX9w5c8RZn5ggACCCCAAAIIIIAAAggggICNArY1odd54BcsWW0F6Tpo3byFK6Vu7VqmP3qKdTr7zBzxmuwczE6nsJu3YIV8P/VXia0RI5ef39sq05GTK6lpGXJEy8bWsusPXV66svBBgy95dL9cc26hlnSUYh0xNxTrHmrW7vVVdx0xF3d3Ffu/426/sbcS8vOF+90bjM3rtFGbTi3D3zM2Qxc7vP7djnsxlEAsKrpJ3O+FDoH+E/dAixeWl6exR4iPQh/FYOaHdfPYFsD36NpBxv8wRwbePFRqxtWQjMwsuficXkWVnb9kldXEvp4J6u1KH38xRcZMmG698b9l8IVFDw9STX98TXGxNTyK1mWdn15bBviSJyoyUrL2m99SQyw5DwSSoVj3EKP2qK4+NNFfrnH3YLF9AXfbib0WoDOUqj33u1ce21aqu/7gbhux1wPj7pXF9pXmVrceFHK/207ttQDcvbLYqwkxmAAAQABJREFUulLv+X0m9gj1aeSSatrWCNxW/2A5uG0B/Nl9ultN0KfPXWSda33zRv7//nee9X3+n6vkN/NGvme3juYGtO8R0v1DBsjNV10gc/5YJo++MEJ0RPn7br5CoqML54Mu3v8+z7wyCjf1iTBN/H3JoycTinNLMw+8dRsG/A/mgQ84uVUg88BXjrtrHvhQ/DuycsT8U6prHnjc/ePp61H0YZXOA4+7r2L+yafBjM4Dj7t/PCtyFJ0HHveKiPknr84Dr+42hk/+qShHsVXAtgBeA+HXn75Vlq9aL9kOh3Q5pq31JlzPJrZGtAy9/1o5+sjCEeHtOkN9Q56SnCj9zzxRJk2bJ9PnLrQC+OSkeCtQTzetAtxTekaW1NJtJoD3JY/7vnxHAAEEEEAAAQQQQAABBBBAwE4B2wJ4rbS+XfcWpOtUbq7p3Ow4OW3KVvzNvvZ5j42JsYrTAL1l84ayeNkaj+IXL19jzQevK33J47EzCwgggAACCCCAAAIIIIAAAgjYKGBbAL9yzQZZvfbfMquuzdT7ndatzDyHsvG8QQ/IuWecKDqdnA5e9/WkWaYlwDrRfvCudEHfnvLSO2Pl43FT5KTjjxadt3712k3yzAPXubKIL3mKMvMFAQQQQAABBBBAAAEEEEAAARsFbAvgdTq29z//vsyqx8fF2hLAt2zWUN76eLzo6PeaIiMj5KrL+sr1/y3sg6/rrrzkLFm/cau8+PZYeeHN0dZo+Fdf3s9qbq/bNfmSpzAnfyKAAAIIIIAAAggggAACCCBgr0CYaW5uhgDxf1qxeoP89fcGrwfWAex0arcbrzzf462418yHuDIn18wxv2O35OXlS+OGdSXmwMB1xQ+Xvd8hm7ftkqZmzvrDyVP8uMG8zCB2lXN1GMSuctwZxK5y3F2D2NWKj66cClTTUl2D2CUn4B7IW8A1iF1KIu6BdHcNYlc7sbCLZCDLru5l6SB2dZJwD/R9oIPYpSTEMIhdoOGDrDzb3sC3b9tc9Mdb6te7m/y2aKX8ueIfb5v9si46KlKaNa5f7rG0iX2bFp7zwRffyZc8xfdhGQEEEEAAAQQQQAABBBBAAAF/ClTKJHwaEGu/83nzl4u+ASchgAACCCCAAAIIIIAAAggggEDZApUSwGuVoqOiRJucbdq6s+washUBBBBAAAEEEEAAAQQQQAABBMS2JvQ6bduu3WkliLMdObLENJ2fMGWONG9Sv9zm6yUOwAoEEEAAAQQQQAABBBBAAAEEqqGAbQH8J2Z6tvJGob9mwDkl5muvhteAU0YAAQQQQAABBBBAAAEEEECgXAHbAvjOR7eRAReeXqICYWEi9eokS48u7aVDu5YltrMCAQQQQAABBBBAAAEEEEAAAQRKCtgWwJ/ao7PoDwkBBBBAAAEEEEAAAQQQQAABBA5foNIGsTv8qnMEBBBAAAEEEEAAAQQQQAABBKqPAAF89bnWnCkCCCCAAAIIIIAAAggggEAICxDAh/DFo+oIIIAAAggggAACCCCAAALVR4AAvvpca84UAQQQQAABBBBAAAEEEEAghAUI4EP44lF1BBBAAAEEEEAAAQQQQACB6iNAAF99rjVnigACCCCAAAIIIIAAAgggEMICtgXwU2cvkOlzF4qzoCCEeag6AggggAACCCCAAAIIIIAAAsEhYNs88Mv+Wifvf/69NG5QRy6/oI9cdM4pkpRQMzjOmloggAACCCCAAAIIIIAAAgggEGICtr2Bv7BfT7n0vNMkNS1DXnpnrJx28R3y2LCPZPU//4YYEdVFAAEEEEAAAQQQQAABBBBAoPIFwgpMsrMamfuyZfwPc2TM+Gmy7t9tVlHHd2onAy86Q/qcfJyEh9v2DMHO0wrpYztynZJjfhLibGuAEdI+dlU+J88p+3PyJTEuyq4iOK4XgVzjnuXIl6SauHvhsW1VXn6BZGbnSq34aNvK4MAlBfKdBZK+L1eSE3AvqWPfGu0umJaRKymJuNunXPLI+htsaoZDaifGlNzIGlsFdu11SJ0k3G1F9nLw3ekOSUmIkbAwLxtZVW0EbA/gXZL6nGDewhUy+ptpMm3OQmt1g3opcvn5veXic3tJclKCKyufNgsQwNsMXMrhCeBLgbF5NQG8zcClHJ4AvhQYm1cTwNsMXMrhCeBLgbF5NQG8zcBlHJ4AvgwcGzcRwNuIG0KHDtjrb0dOrmzetku2bN9dxLN95x559f0vpc8ld8pDz30gW922FWXiCwIIIIAAAggggAACCCCAAAIIiO1tqNebZvNjJky3mtFnZGaZJh9hctLxR8uAC0+Xrp3bybdT5son4360tnfv0l7OO+NELgsCCCCAAAIIIIAAAggggAACCBQTsC2A/3PFP/L6B1/Jb4tWijafT4iPk0GXnGU1mW/epH5RNTSQ11HqZ8xdJA3qJhet5wsCCCCAAAIIIIAAAggggAACCBwUsC2A14Bc+7y3a93MvG3vI+ee0UNqxHgf3CXcvJXXAe1ICCCAAAIIIIAAAggggAACCCDgXcC2AL592+by7APXSe+ex0l8XKz30lmLAAIIIIAAAggggAACCCCAAAI+Cdg2iN2adZvlgWffl/mLV/lUETIhgAACCCCAAAIIIIAAAggggEDpArYF8DVja1ilRkcz93Lp/GxBAAEEEEAAAQQQQAABBBBAwDcB2wL4480I85qWmMHsSAgggAACCCCAAAIIIIAAAgggcHgCtgXwHdq1lP5nniiffDlFUvekH14t2RsBBBBAAAEEEEAAAQQQQACBai5g2yB2b388Qb798ReLt8+ld0p4eMlnBfE1Y+Xnr1+r5peA00cAAQQQQAABBBBAAAEEEECgfAHbAvhaSfHSoW2LMmsQGxtT5nY2IoAAAggggAACCCCAAAIIIIBAoYBtAfwVF/QR/SEhgAACCCCAAAIIIIAAAggggMDhC5Rs1374x+QICCCAAAIIIIAAAggggAACCCDgZwHb3sBrPQsKCuT7qb/KVxNnycZN2yVrv0MaN6gjxx3TVm4c1F9SkhP9fDocDgEEEEAAAQQQQAABBBBAAIGqKWBbAK/B+60Pvy7T5y6y5JKTEqRmXA35e/1m+evvjfLtlLky5p1HpWWzhlVTlrNCAAEEEEAAAQQQQAABBBBAwI8CtgXwE0yArsF7z24d5eHb/idNGtW1qp2TmydffDtDnn9jlDzw7Psy5u1H/Xg6HAoBBBBAAAEEEEAAAQQQQACBqilgWwD/869/Wm/cX378ZolzG20+OipS/nvRGbLu360ydsIMyczKlvi42Kqpy1khgAACCCCAAAIIIIAAAggg4CcB2wax271nrzSsV9sjeHevc5sWja0+8pu37nRfzXcEEEAAAQQQQAABBBBAAAEEEPAiYNsb+NbNG8s3k2fLth2p0qBeSomif52/XCIiwqVJw3olth3uin1Z++XXBctl3cat1qFO6d5R2rVuVuKwaemZMmveEtmwaZu0Ng8UNF/x1gC+5ClxYFYggAACCCCAAAIIIIAAAggg4GcB2wL4M0/tKuO+nynX3j1Mhlz9HznmqFZSIyZa9I37qG+myrQ5C+W0k461mtn7+ZzkjsfekLl/LJOUWgnWoV99/0trsLxPhz8oOpiepi3bd8vgO56THTv3SLPG9eWDUROlVfNGMuLleyuUxzoYfyCAAAIIIIAAAggggAACCCBgs4BtAXyPLh3klsEXypsjx8udj79Z4jTatm4qT95zdYn1/lhxshk4z/XQQEfDH/fdTHni5Y9lzPjpcuOV51tFjBgzSdL2ZsqEkUOtAH756vUy8KanK5zHH/XlGAgggAACCCCAAAIIIIAAAgiUJ2BbAK8F32Dmeu/T8ziZ8MNcq5l69v6cwnngOx4h551xooSH29MFf9DFZxadd1hYmPQ/6yR58pVPZKt56+5KU2b8Lr16dLaCd13XoW0L6dqpnUyZ+UdRkO9LHtfx+EQAAQQQQAABBBBAAAEEEEDATgFbA3it+BEtm8jdN15m5zmUe+xFy9ZYA+a1bF4457wjJ1dS0zJM3Rp77KvLS1eutdb5ksdjZxYQQAABBBBAAAEEEEAAAQQQsFHA9gBe665zv2dl7y9xGhHmDXxCfFyJ9f5c4XDkyEvvfGH1a7+wX0/r0Kl70q3PuNgaHkXpsk5rl5uXJ77kiYqMlMzsPI9jhMJCvrNAnOYnFOseCr6l1VHd9Qf30oTsWa/3Ou722JZ1VKfpvsTfM2UJ2bNNu42pPX/P2ONb2lELxPyHe2k8tq0vMEc27NzvtgmXfWD+ninbx46t1v2+P0/C7Dh4AI8ZHxuQEDSAZxTYomzV+/TLH0Xng1+wZJUVxBc/tfiasfLbxLeLr/bbsj44uOXh12Xthi3yzvN3Sq3EeOvY0dFR1qfT6fQoKy8/X8JNk3t9sOBLHt05MiI0/xfSvwBCte4eFy2EFsytZf2Ch3tgL1q+cdcAHvfAujudYZIXhntg1cUE72ESlod7oN0LzK/TOdzvgWa3yssxf8fz93ul0ONeCez6u2RUiMYelcBVZYu0LYCfOnuBPPfGKIkxwfLRR7aSpMSaVmDsLqmj0tuVdCq5IQ+/JktWrJU3ht4mJxx7VFFRyUnxVqCenplVtE6/pGdkSS3dZgJ4X/LoPjWiI/QjpJIj12kCSWdI1j2koItVNifPaQWSoXjPFDuVkFrMNe55+QXc7wG+amqek5ePe4Dd9WGVIwf3ALNbrR6y9+MeaHd9GbHPvI3k39VAyxe2esA98O56v8dERYgG8qTqK2BbAD/6m2mW6qi3HpEj25Scg91O8u279shN978i280UcSNeuU86mins3JMG6NoffrHpG++eFi9fY80Hr+t8yeO+L98RQAABBBBAAAEEEEAAAQQQsFPAnmHgTY1r1IiW6KhIaWemiwt0GnDTU/LX3xvlqsv6yrYdu+XHn/8o+skzb4Q0XdC3p/wyf7l8PG6K/L1+swwf8bWsXrtJXP3kfc1jHYw/EEAAAQQQQAABBBBAAAEEELBZwLY38J3at5aZvyyWZX+tk2OKvQG3+ZxkV+peq4hX3htXoqhfv3tTEhNqypWXnCXrN26VF98eKy+8OVoiIsLl6sv7Sf8zTyzax5c8RZn5ggACCCCAAAIIIIAAAggggICNAmFm1FQdxNPvSUdz73/lQ9KkYR157akh1mjExQsJDw+zRocvvj6Qy9n7HbJ52y5p2qie1V/fW9m+5PG2X7Cu0z7wOeYnIc625zfBeuqVWi/tA7/f9E1NjCscRLFSK1ONCtc+8FmOfEmqiXsgL7v2gc/MzpVa8faNdRLI8wmVsrQPfPq+XElOwD2Q10xH/k/LyJWURNwD6a6/waZmOKR2Ykwgi6UsI7Brr0PqJOEe6Jthd7pDUhJi6AMfaPggK8+2CC4+LlZO6HykfPfTL3Ly+UO8nrbdo9B7LbTYytgaMdKmhed88MWyiC95iu/DMgIIIIAAAggggAACCCCAAAL+FLAtgP/i2xlW8K4jzWsT+lpmFHodGM491YjhyZ27B98RQAABBBBAAAEEEEAAAQQQKE3AtgB+zu9LrTJHv/2otG3VpLTyWY8AAggggAACCCCAAAIIIIAAAj4IeL4S92EHX7NofzAdhb5Ny7Kbp/t6PPIhgAACCCCAAAIIIIAAAgggUJ0FbAvgjzf933Ny86xR6KszMOeOAAIIIIAAAggggAACCCCAgD8EbAvgdTq2lFoJ1hRt23ftEW8/O3en+eMcOAYCCCCAAAIIIIAAAggggAACVV7Atj7wH38xRVLTMqyf3hff4RVSR6r/bdLbXrexEgEEEEAAAQQQQAABBBBAAAEEDgrYFsAf2aaZnN2n+8GSvHzTEepJCCCAAAIIIIAAAggggAACCCBQvoBtAXzf004Q/SEhgAACCCCAAAIIIIAAAggggMDhC9jWB969atn7HbJ2wxbZm7HPfTXfEUAAAQQQQAABBBBAAAEEEEDARwFbA/g/Fv8lF137qHTt+39y3pUPyrjvZlrVmjBlrhxz2mB58e2xPlaTbAgggAACCCCAAAIIIIAAAghUbwHbAvg16zbJ9fe8KH/9vVE6tGsp4eEHizr39B7SqGEdmTLz9+qtz9kjgAACCCCAAAIIIIAAAggg4KPAwajaxx18zTb22xnWPPDvvnCXfPHuY5IYHydhB3aOiAiXbp2Pki3bd0tWtsPXQ5IPAQQQQAABBBBAAAEEEEAAgWorYFsAv/qff6V+3RQ56fijveI2b9rAWp+6J93rdlYigAACCCCAAAIIIIAAAggggMBBAdsC+OSkBNnvcEhefv7B0ty+bdqy02pWX79esttaviKAAAIIIIAAAggggAACCCCAgDcB2wL49m1byN70ffLjzD9KlKsj0k/4ca60bt5IoiJtm8muRLmsQAABBBBAAAEEEEAAAQQQQCBUBWyLngdedLp8+f1MuW/oezJp+m+SmZUtv5tR6XfsTjPrfxaHI0duv/7iUHWj3ggggAACCCCAAAIIIIAAAggEVMC2N/DxcbGiA9gdd8wRMvOXxZKXly9zfl8qn331k0RGRMhjd14pp/boHNCTpTAEEEAAAQQQQAABBBBAAAEEQlXAtjfwCtLKNJH/5PUHZdU/G2Xtxq2SnpElLZo0kKOOaCaJCTVD1Yx6I4AAAggggAACCCCAAAIIIBBwAVsDeNfZtGvdTPSHhAACCCCAAAIIIIAAAggggAAChyZgewCflp4p8xasEP0snmrERMsFfU8uvpplBBBAAAEEEEAAAQQQQAABBBAoJmBbAJ+V7ZDr7hkmS5b/I86CgmLFFi5qP3kCeK80rEQAAQQQQAABBBBAAAEEEEDAQ8C2AH7k2MmyeNnf0vnoNnJ27+6SlFjTmvfdvfSoyAj3Rb4jgAACCCCAAAIIIIAAAggggEApArYF8L/MXy7hYWHy/rB7JC42ppTiWY0AAggggAACCCCAAAIIIIAAAr4I2DaNXLPG9SQsPExMDE9CAAEEEEAAAQQQQAABBBBAAIHDFLAtgD+5W0fJz3fK1NkLDrOK7I4AAggggAACCCCAAAIIIIAAArY1oT+7dzcZP3m2DHtrjGTuyxans+RAdjExUXLxOb24CggggAACCCCAAAIIIIAAAgggUI6AbQF86p502bM3Q3abz6df/dRrNXQUegJ4rzSsRAABBBBAAAEEEEAAAQQQQMBDwLYA/tOvfpIVqzdIl45t5ew+haPQR4R7ttiPZBR6j4vBAgIIIIAAAggggAACCCCAAAKlCdgWwP+54m9r2rj3ht0tNWKiSyuf9QgggAACCCCAAAIIIIAAAggg4IOA5ytxH3bwNUuj+nWsEegLCkr2fff1GORDAAEEEEAAAQQQQAABBBBAAIFCAdsC+DN6dbVGof/x5/lYI4AAAggggAACCCCAAAIIIIDAYQrY1oQ+KaGm1EqMlxffGStp6ZleqxkdFSlXXNDH6zZWIoAAAggggAACCCCAAAIIIIDAQQHbAviZvywuCtxfeHP0wRLdvuko9ATwbiB8RQABBBBAAAEEEEAAAQQQQKAUAdsC+P5nnijHHNWqlGILV0dE2NaCv8xy2YgAAggggAACCCCAAAIIIIBAqAnYFsC3at5I9IeEAAIIIIAAAggggAACCCCAAAKHL8Ar8MM35AgIIIAAAggggAACCCCAAAII2C5g2xt422vuYwE/zZovR7RsIi2aNiixhw6uN2veEtmwaZu0btFYTuneUbRfvnvyJY97fr4jgAACCCCAAAIIIIAAAgggYIdAlQ3g8/LyZeavi+XOx96Uh27/X4kAfsv23TL4judkx8490qxxfflg1ESryf+Il++V5KQEy9qXPHZcFI6JAAIIIIAAAggggAACCCCAQHGBKhnAr1m3SS68+hEpKCgofr5FyyPGTJK0vZkyYeRQK4Bfvnq9DLzpaRkzfrrceOX5Vj5f8hQdkC8IIIAAAggggAACCCCAAAII2ChQJfvAa3P57z95Vr5497FS6abM+F169ehsBe+aqUPbFtK1UzuZMvOPon18yVOUmS8IIIAAAggggAACCCCAAAII2ChQJQP4qMhIq8l88yYl+72rpSMnV1LTMkzf+MYetLq81TSt9zWPx84sIIAAAggggAACCCCAAAIIIGCjgG1N6L/4doa0bdVUOh/dxmv1M7Oy5ZX3xskjtw/yut3Olal70q3Dx8XW8ChGl7VeuXl54ksefVCwa6/D4xihtODYmx9K1a0ydQ3leyaULwLulXP1cMe9cgQqp1Tud9wrR6BySuV+rxz33emhG3u4xOokxbi+8nkIArYF8DoA3NDXP5MHb/2vXNb/NI+qaR/12x99Q3bt3lspAXx0dJRVH6fT6VGvvPx8CQ8Lk4jwcPElj+4cijegI9cpOeYnIc62y+/hykKhQE6eU/bn5EtiXOH9h0tgBHKNe5YjX5Jq4h4Y8cJS8vILJDM7V2rFRwey2GpfVr6zQNL35UpyAu6BvBmcZsydtIxcSUnEPZDuOtRRaoZDaicSDATSXcvS4D0UfwcOtJO/y9PgPSUhRky4QqrGArY1oe/X+wRpUC9Fnnz5Y3n0hREmYMyzmL+f+qtcfsOTsv7fbdL3tBMqhT45Kd4K1NMzszzKT8/Iklq6zQTwvuTx2JkFBBBAAAEEEEAAAQQQQAABBGwUsO0VbLvWzeSr95+UR0zw/tWkWaJv3du2bipffv+zxMXGyHMPXS/nnXGijadW+qE1QG/ZvKEsXrbGI9Pi5Wus+eB1pS95PHZmAQEEEEAAAQQQQAABBBBAAAEbBWx7A691jq8ZK688cbMMvqyfLFm51gremzaqJ+Pee8LW4F0HqdNp4VaYH03anF+Xd6XutZb1jwv69pRf5i+Xj8dNkb/Xb5bhI76W1WvN9HP9elYoT1FmviCAAAIIIIAAAggggAACCCBgo0CYmSu99MnS/VDw1NkL5OHnP5QM01w9MjJCwsx/d95wqQy6+Ew/HN37IaxA/OqHS2wccvV/5IZB/a31+flOeeKlkfLND3NE+8JHRITLlZecJXf+36WmX0lhxxJf8pQoJARW0Ae+ci4SfeArx50+8JXjTh/4ynGnD3zluNMHvnLc6QNfOe5aKn3gK8eePvCV4x5spdoWwOtI7sPeGiOffz1VoqMi5YEhA+XErkfLrY8Ml1X/bJTTTjpWht5/rSQl1KxUk+z9Dtm8bZdoy4CYA4PbFa+QL3mK7xPMywTwlXN1COArx50AvnLcCeArx50AvnLcCeArx50AvnLctVQC+MqxJ4CvHPdgK9W2JvTvffa9Fbw3ql9bPnvjIbnUjETfpFFdGf3Ww9L/zBNlxtxFMvCmpyrdI7ZGjLRp0bjU4F0r6EueSj8RKoAAAggggAACCCCAAAIIIFClBWwbxC7XjDrfs1tHef7h//N4yx4TEy3PPni9dDyqtbw5cnyVxuXkEEAAAQQQQAABBBBAAAEEEPCXgG0B/EXnnCJNGtYt6k9evMJXXNhHunRqV3w1ywgggAACCCCAAAIIIIAAAggg4EXAtgBe+5SXl9q2alJeFrYjgAACCCCAAAIIIIAAAggggIARsC2AV93Fy/+WT7/8UdZu3Cp5efklwBPMNHOj3nqkxHpWIIAAAggggAACCCCAAAIIIICAp8D/s3cfcFKU9x/Hv9f7HRwICEhRKYoi9t5iw441lsTeS4yamGY0+tfEmKhRY+/G3gsW7FgRFFFBVJQivXP99rbc/3kG77i92z2WY2d25+4zr9e6O88885T3jMf+dp55xrUAfpYJ2k+56DrZ2ejt4+NsAF9qZpy3n2tq6xUINMhOcMeCAAIIIIAAAggggAACCCCAAAJrF3AtgH/mlfFO8P6vv56jzMxMXXrV7Xr6rr85M9FPnzFHx559lTMz/dqbSA4EEEAAAQQQQAABBBBAAAEEEHDtMXJz5y9Rj+6lOmifnVTercSRXraywnnfbMhA7b7DlnrwydcVDkc4Ch4KhCIhvfDd87rj81u1sm6lhzVTFQIIIIAAAggggAACCKyvwPzK+bp6/NV6YMoDqgvWrW9x7O8zAdcC+Nq6gPP8dOvRq2d3h2X23EXNPJsO7qdVldWav2hpcxof3BVYUrNEg28erOOePVp/eOcS9b+pv174lkf5uatO6QgggAACCCCAAAIIJEfgiamPa9DNg3Tle1fqtBdPc77PL6hakJzCKcUXAq4Noe9eVqzPv/rOufd9YP/e6l5Woudf+0BjRu/mwHzz/RznPRJp9AVUZ2jkfV/cp3mV85q7Uhus1bmvnKtxP45rTvPzh0Z14FzqwC4dNQo3NpoRJ43KzV7772Yd6ktHG+bifh3qR5KPScS4hxJ0b4+iQ31pr8AUbetQPzpwTOyf9pAZYZXI+d5Rig71paOVubhfh/oR55jY5GDQuOes/e9MsrvUoX4kuxEulxe3jwa+IUXuHe1y3L50tMAU7Gf+vCsQDCsvN8b5Huf/kRQ0M6Eq/XY86hvCys/Nitm3uH3hmMT0WpdEe76/O+dN2RG1TcuKuhW6Z/I9unLPK5uSeO/kAq4F8Bv162X+MQvpMxPE77TN5tpn9230zNjxOuqMK5SVlaVp383ShmYSuwEmuGfxRuDNmW+2qWhR9SLd+dmdbdJJQAABBBBAAAEEEEAAgfQX+GDOB+nfSFqYNAHXAvjD9t9VG/ToZq68FzuN/cP5J2jmnIWa/PX3znqvnt307yvOVWZGRtI6Q0HtCxw34ji9O+vdqExb9t5S5253rpOWoc5xLKL60bJL7f3y2zJflFDyVuzV96C5IhnvF+vWNUX1o/VGn61H9aWldbxj0jLPevbVujeEIirIi32lYF2Kj+rHuuyYhnmj+tLSO0nHJGwuwQfMFZrCfNf+mXFUo/qRhs7r0qSovnTwmNhRbXXGvchl9/b6FdWP9jL6bFtGy+8rrf4/iZgRYLX1YRUXuHu+J4OssxwfezzsFfia+qBxz1HcQXgt/19KBqALZfjxmFTXhdqc7+39PxLFxjGJ4liXFet+31e3aeL8iVG7/Xrkr6PWWencAhmNZvGyi8tWVGi5mcxu44F9lZOd/v/QeWnjdl01DTU68qkjZa/E28M+rMcwPTjmQe3Ufye3q6Z8I2CDSDvkrLTQfNFg8UwgaNxrA2GVFeHuGbqpyN62UF0XVLfiXC+r7fJ12R9OKmuC6l6Cu5cng71VZ1VVUOWluHvpbr/BrqgKqEdpnpfVUpcRWFYRUM8y3L0+GZZXBvRTzXSd/cpZmjR/knIyczRm+Bg9dMRDKsgu8Lo51JciAc8D+BT1k2pbCExb/J1mr5yrg4bvY665++Bn0BZt9/NHAvjUHD0C+NS4E8Cnxp0APjXuBPCpcSeAT427rZUAPjX2NoAvL8mTHRA0eeFk9Snuo74lfVPTGGpNmUBSL4FPmPyNZsycl3Bn8vNydcyheyWcn4zJEdi0fIgGlGxC8J4cTkpBAAEEEEAAAQQQQMBTgW023MbT+qgsfQSSGsC/8tYEPffq+wn3rriwgAA+YS0yIoAAAggggAACCCCAAAIIdGWBpAbwLSHt4+K22nyTlkltPmdnr/+kUm0KJQEBBBBAAAEEEEAAAQQQQACBTiiQ1AD+/FPGqLgwX0+bx8W98PqHWrB4uc488RDtst2ITkhHlxBAAAEEEEAAAQQQQAABBBDwTsCVSewqqmr0+PNv69Hn3tSKVVUaMWywzjKBvH0WfNQjJrzrJzW1EAgEI2owr5LCpP5+06IGPsYSYBK7WCrupzGJnfvGsWpgErtYKu6nMYmd+8axamASu1gq7qcxiZ37xvFqYBK7eDLuprecxM7dmig9nQUy3WhcWUmRzjnpML315A26/Le/VkVVtS664lYdevKf9enk6W5USZkIIIAAAggggAACCCCAAAIIdGoBVwL4JrE8M8v87juM1I6jNnOSZv20UJO+/LZpM+8IIIAAAggggAACCCCAAAIIIJCggGtjqH+cvUD3PDpWr7w9QZFIRCM321hn/uoQ7b3L1gk2jWwIIIAAAggggAACCCCAAAIIINAkkPQAftp3s3T3I2P19oeT1WhuTtpl+y2c+9+3HzW8qU7eUyyQUf2jsqrmSgP2Ni3JSHFrqB4BBBBAAAEEEEAAAQQSF2iUlphHdxf2l4rbf+pX4mWS0y8CSQ3gb3vwBd1uXpkZGdp/z+10xgmHaPOhA/1i0fnbGaqRPjxauQvfUG5jRCoztzbs9KDUY4fO33d6iAACCCCAAAIIIICA3wWWT5Q+PUWqMPOKZZi7oTfcX9rtGSm7yO89o/0JCiQ1gF+0ZIVTrZ2N9b1PvnRe7bXDPnLu/edvaS8L25IpMPsxacHra0q0/+NPPEsact6aND65JpAZaVRuyPxwkpvlWh0U3FYA97YmXqRk2lM9GJbyON+98G6qI8NclMkLGPd83JtMvHi3Y9ny6nH3wrp1Hfn1IXO+J/XrbOsqWI8hkF9n3Atwj0HjapI93zPm3r06eLc12Qty9ru9/Y6/6Zmu1k3h6SOQ1P/zBvXvra23GJJw7woK8hLOS8YkCMx5om0hK780QfzZbdNJSbqA/Z8tqf/DJb2FnbNAG8YUdM6upXWv7AyphWndws7ZONxTc1xtAM+1L+/tcffevKnG4qYPvHsqEPfvjP2OTwDv6bFIZWWuPAc+lR2i7nYEpv1d+vIv0Rnye0v9D49OY80VgYi5Ah+yV+Gz7VdsFq8EHPewcc/B3StzW48diRUyI05yc7gS7KW7nXumwbjn4e4luzPnT0PQuDPCylN3mREn9WakTz7u3rqb2uobcPccvcl9yVhzABZHV7/VtdKIP0ensdZpBbgg2GkPbYyObXKG9P1tUt2C1Ruz8qXt75A2OiJGZpKSLWCDGfsPXm5hTrKLprx2BMLGvc4MKc4twr0dpqRvipgfTWrrgsotzk162RQYX8D+YFVbE1ReCe7xlZK/xf5wUlNl3EtxT75u/BINu3EPKL+UEZ3xldzZUl1h3Mtwd0c3fqk1lQHlVRysjI9PkML1qzMW9JXsd3yWLiNAAN9lDrXpaH4v6fDZCs55XpGqn5Q37FRz016PriRAXxFAAAEEEEAAAQQQ8K9Af3Phbcw8adZD5l61AatH0mZykcK/B3TdW04Av+5m/t7D/A8e6X+0nKF+eRx+fx9MWo8AAggggAACCCDQ5QTsBbjhl3S5btPh1QLcFMqZgAACCCCAAAIIIIAAAggggIAPBAjgfXCQaCICCCCAAAIIIIAAAggggAACBPCcAwgggAACCCCAAAIIIIAAAgj4QIAA3gcHiSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICADwQI4H1wkGgiAggggAACCCCAAAIIIIAAAgTwnAMIIIAAAggggAACCCCAAAII+ECAAN4HB4kmIoAAAggggAACCCCAAAIIIEAAzzmAAAIIIIAAAggggAACCCCAgA8ECOB9cJBoIgIIIIAAAggggAACCCCAAAIE8JwDCCCAAAIIIIAAAggggAACCPhAgADeBwcp2U3MysxQbg6HPtmuayvPuufhvjampG/PxD3ppokUaNiVn5uVSFbyJFEgMyMD9yR6JlpUhox7Hud7ol7JymdOdxXkZSerOMpZB4FCzvd10EpeVud8N+c9S9cWyGg0S9cmoPcIIIAAAggggAACCCCAAAIIpL8Al2HT/xjRQgQQQAABBBBAAAEEEEAAAQREAM9JgAACCCCAAAIIIIAAAggggIAPBAjgfXCQaCICCCCAAAIIIIAAAggggAACBPCcAwgggAACCCCAAAIIIIAAAgj4QIAA3gcHiSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICADwQI4H1wkGgiAggggAACCCCAAAIIIIAAAgTwnAMIIIAAAggggAACCCCAAAII+ECAAN4HB4kmIoAAAggggAACCCCAAAIIIEAAzzmAAAIIIIAAAggggAACCCCAgA8ECOB9cJBoIgIIIIAAAggggAACCCCAAAIE8JwDCCCAAAIIIIAAAggggAACCPhAgADeBweJJiKAAAIIIIAAAggggAACCCBAAM85gAACCCCAAAIIIIAAAggggIAPBAjgfXCQaCICCCCAAAIIIIAAAggggAACBPCcAwgggAACCCCAAAIIIIAAAgj4QIAA3gcHiSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICADwQI4H1wkGgiAggggAACCCCAAAIIIIAAAgTwnAMIIIAAAggggAACCCCAAAII+ECAAN4HB4kmIoAAAggggAACCCCAAAIIIEAAzzmAAAIIIIAAAggggAACCCCAgA8ECOB9cJBoIgIIIIAAAggggAACCCCAAAIE8JwDCCCAAAIIIIAAAggggAACCPhAgADeBweJJiKAAAIIIIAAAggggAACCCBAAM85gAACCCCAAAIIIIAAAggggIAPBAjgfXCQaCICCCCAAAIIIIAAAggggAACBPCcAwgggAACCCCAAAIIIIAAAgj4QIAA3gcHiSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICADwQI4H1wkGgiAggggAACCCCAAAIIIIAAAgTwnAMIIIAAAggggAACCCCAAAII+ECAAN4HB4kmIoAAAggggAACCCCAAAIIIEAAzzmAAAIIIIAAAggggAACCCCAgA8ECOB9cJBoIgIIIIAAAggggAACCCCAAAIE8JwDCCCAAAIIIIAAAggggAACCPhAgADeBweJJiKAAAIIIIAAAggggAACCCBAAM85gAACCCCAAAIIIIAAAggggIAPBAjgfXCQaCICCCCAAAIIIIAAAggggAACBPCcAwgggAACCCCAAAIIIIAAAgj4QIAA3gcHiSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICADwQI4H1wkGgiAggggAACCCCAAAIIIIAAAgTwnAMIIIAAAggggAACCCCAAAII+ECAAN4HB4kmIoAAAggggAACCCCAAAIIIEAAzzmAAAIIIIAAAggggAACCCCAgA8ECOB9cJBoIgIIIIAAAggggAACCCCAAAIE8JwDCCCAAAIIIIAAAggggAACCPhAgADeBweJJiKAAAIIIIAAAggggAACCCBAAM85gAACCCCAAAIIIIAAAggggIAPBAjgfXCQaCICCCCAAAIIIIAAAggggAACBPCcAwgggAACCCCAAAIIIIAAAgj4QIAA3gcHiSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICADwQI4H1wkGgiAggggAACCCCAAAIIIIAAAgTwnAMIIIAAAggggAACCCCAAAII+ECAAN4HB4kmIoAAAggggAACCCCAAAIIIEAAzzmAAAIIIIAAAggggAACCCCAgA8ECOB9cJBoIgIIIIAAAggggAACCCCAAAIE8JwDCCCAAAIIIIAAAggggAACCPhAgADeBweJJiKAAAIIIIAAAggggAACCCBAAM85gAACCCCAAAIIIIAAAggggIAPBAjgfXCQaCICCCCAAAIIIIAAAggggAACBPCcAwgggAACCCCAAAIIIIAAAgj4QIAA3gcHiSYigAACCCCAAAIIIIAAAgggQADPOYAAAggggAACCCCAAAIIIICADwQI4H1wkGgiAggggAACCCCAAAIIIIAAAgTwnAMIIIAAAggggAACCCCAAAII+EAg2wdtpIkIIIAAAgh0WYHfXXWHfvxpgUYO31hX/f7UNg7n/fEmLVy6wknPUIYK8nO16eB+OvbQvTRi2OCo/I88+6aeffV9lRQV6L4bL1NOdvTXgMdfeFtPvfyeKSVDz9x7lTIzMqL2ZwUBBBBAAAEEUivAFfjU+lM7AggggAACcQXmLlii1979VN//OFfPv/6BVqysbJPXBvdz5i5Svz491WeD7qoPNOiZseN1wvnX6P0JX0XlX7p8lVPW5199r5fe+DhqWzAU0t2PvOxs/+7Hn6TGxqjtrCCAAAIIIIBA6gUI4FN/DGgBAggggAACMQWaguzDD9hV4XBEY9+eEDPfBj266b/XXqTbr7tYz957ta6//GyFQmE99NTrMfMXFxbo/sdfVaRFkD72zU+0ZNkqFRbkxdyHRAQQQAABBBBIvQABfOqPAS1AAAEEEEAgpsDL5ip5n17l+uMFJyg3J1svv/FRzHytEw/ed2eVFBfqh9nzW29y1k87/iDNNlft3xz/mbPeaAL5B558TduOHKptthwacx8SEUAAAQQQQCD1AgTwqT8GtAABBBBAAIE2AlOm/iA7hP7gfXZSaUmR9thpK33z/Rz9OHtBm7ytE2pq61VXH9CWm23cepOzfuj+u6j3BuW659Gxzvr7n37llHvWrw6NmZ9EBBBAAAEEEEgPAQL49DgOtAIBBBBAAIEogZd+vtp+iLmabpeD993JeW9Kd1Za/MdeRQ80BDVj1jz97urbnSH0+++5fYscaz7mZGfplF+O1vQZc/TRpK/1gBlOP3zTAdpthy3XZOITAggggAACCKSdQPT0s2nXPBqEAAIIIIBA1xOwE8q9/t5EDRncX0M32cgB2HPnUbL3ro996xP99syjldFihvh5C5dqi73XzFBv72O/7i9n6dD9domLd8whe+quh1/SFf96QIuWrNANV54XNy8bEEAAAQQQQCA9BAjg0+M40AoEEEAAAQSaBcZ/8qUqKmuUn5enC/9yc3N6RmaGE2xPmvKtdth6s+Z0e7/7eaeMUcRMdHeXmUneXokf2L9P8/ZYHwry83TCkfvq9gdfMHl7a/+9Yl+tj7UvaQgggAACCCCQGgGG0KfGnVoRQAABBBCIK2Anr7NX2HuWl2mxmRm+6bVh7x7OPk2z0zcVUGbukT/p6P2dYfE3X32BmbE+rPP/dJPmLVjalCXm+4kmgB+2yQAn+OeZ7zGJSEQAAQQQQCCtBLgCn1aHg8YggAACCHR1gYqqGtkr8HZG+Idu/lMUh33s277HXqo3xk/SX3/7a+Xl5UZttyv2yvzfLj1Fl//zPp39hxv06G2Xq1tpcZt8NsGmP3ff1TG3kYgAAggggAAC6SfAFfj0Oya0CAEEEECgCwu89s6nsvfAN01e15LCXiU/eJ8dZWeZf/vDyS03RX0+4sDddeaJhziPirvgzzc7Q+qjMrCCAAIIIIAAAr4UIID35WGj0QgggAACnVXg1bcnKCc7WwfEuSf9kP1Wz0r/islnl6zMzKgJ7ZpcLjrjKKeML6bOcK7G2/Smie+a3pvytnxvb1vLfHxGAAEEEEAAAe8FMsxjZxq9r5YaEUAAAQQQQAABBBBAAAEEEEBgXQS4Ar8uWuRFAAEEEEAAAQQQQAABBBBAIEUCBPApgqdaBBBAAAEEEEAAAQQQQAABBNZFgAB+XbTIiwACCCCAAAIIIIAAAggggECKBAjgUwSfympD4UYFgpFUNqFL1h2OWPdwl+x7Kjtt3esbcPf6GERw95rcqc/OalMX4Hz3Gt+61+LuNbtTH+4pYVdtfSg1FXfxWu35zuRlXfwkMN0ngO+C54ANaBoI4D0/8qsDeH448RreBpL8YOW1umTY+eHEe3bjzg9WKWA3X6iNOwG85/Srf7AikPQc3lTIDyepULc/0JrznQg+NfhpVCsBfBodDJqCAAIIIIAAAggggAACCCCAQDwBAvh4MqQjgAACCCCAAAIIIIAAAgggkEYCBPBpdDBoCgIIIIAAAggggAACCCCAAALxBAjg48mQjgACCCCAAAIIIIAAAggggEAaCRDAp9HBoCkIIIAAAggggAACCCCAAAIIxBMggI8nQzoCCCCAAAIIIIAAAggggAACaSRAAJ9GB4OmIIAAAggggAACCCCAAAIIIBBPgAA+ngzpCCCAAAIIIIAAAggggAACCKSRAAF8Gh0MmoIAAggggAACCCCAAAIIIIBAPAEC+HgypCOAAAIIIIAAAggggAACCCCQRgIE8Gl0MGgKAggggAACCCCAAAIIIIAAAvEECODjyXTi9LlzpUkTMzpxD+kaAggggAACCCCAAAKdT6CmRrr7bunBB6W6us7XP3q0dgEC+LUbdZoctbXSmDHS8KGZ2mfvLI0aJX3+eafpHh1BAAEEEEAAAQQQQKDTCnw2KVP9+0tnny2deqq00UbS1Kmdtrt0LI5ARqNZ4mxLWrKtoqKqRpFIo7qVFikzk98Nkoa7DgXdf790+unRO2yzjXThhdFpsdY6cpZ0ZB9bd0f268g+XtcVCjcqGIooPzcrFnHMND/0qyNt7Mg+HT1eYePesI7uHa3Ly36le13hiNQQDK/T+d5R947ul+6GHemX+WdWgYZ1d+9IXR3dZ332W599O3K8E93H5qs37gV5q/++J7qf7U/T0pF97L4d2a8j+6RjXbYf6+uejv2ybWq5pOPxqgusOd9tWzvSxo7s09XrGvdGo2bNjB5Fa4P5O+9secbwubMLuBbAfzp5usa9N1EffTZVCxcvV9h+mzNLRkaGepaXaYetN9Peu47SAXvtoEyTxuK+wD77SO+843491IAAAggggAACCCCAAALuC2yyifTDD+7XQw3pI5Cd7KYsXrpC/7j1Ub35/uqx2Rv06KbtthqmDXv1UHZ2lhYtWaG5C5bolbc+cV4PPvm6/nbpKdpsyMBkN4XyWgnsvXfbAL5nT+mQQ1pljLHa0d9YOrJfR/axTe7Ifh3Zp6N1RcxPzWFzeSw3e91GoHSkjR3Zp6P9Sve6rLsd/ZCX4757ZzXsSL/slZWGUMeuBHfknOrIPh3pV0f36eh+69ov6x4wIx+argTbehNd1rWupnI7sl9H9rH1dXS/9dk3kTob1aj6QKTZPZF9mvxavndkv47s01GPdKyrNhBSYd6ar7MdaWNH9ulMhi3PwUT7VVMfUlH++rknWldH2td6n85S1yOPRfTRB9HfZ447LlZvSevMAkm7Ah+JRPTIc2/pv/c/ZyZUCOiwA3bVmAN303YjhzlX3Vsjzpg1Ty+N+0iPv/COGe4X1K+O2k8XnnakCgvyWmdlPUkCixZJW20lLVmyusDcXOmRR6RjjklSBRTTroAdxm2H+pUW5rSbj43JFbC3LdSaoX5lRbgnV7b90uyPJtV1QXUrNn9oWDwTsD8SVtYE1b0Ed8/QTUX2h8JVVUGVl+Lupbv9wWpFVUA9Svnu6KW7rWtZRUA9y3D32v2zKQ0698xcffbZ6pp32UV66impXz+vW0J9qRRIWgD/w+z5OvyUv2jzoQN11e9Oc94T6Zi9In/Nzf/Tux99oev+cpYO3c+ciSyuCQQC0hNPNmr2nEadc1amevd2rSoKbiVAAN8KxKNVAniPoFtVQwDfCsSjVQJ4j6BbVUMA3wrEo1UCeI+gY1RDAB8DxYOk5ZUBlZfkadIkKc/8fmIvzLF0PYE1Y1+S0Pc9dx6lm/52njmhEv8Fuk+vct16zW90413m5yMW1wXs/+zHHW8m9QpGVFIYPQTH9cqpAAEEEEAAAQQQQAABBNZLYIcd1mt3dva5QNKuwNuZ5s1IpvWakM4Ow2eGevfPqIAJ3lcH8En9/cb9hvu8Bq7Ap+YAcgU+Ne5cgU+NO1fgU+POFfjUuHMFPjXutlauwKfGvukKfEfnbUhNq6k12QJJuwRrZ5df22zyK1ZWOhPYxXtyHcF7sg8v5SGAAAIIIIAAAggggAACCHQWAVcuwdYHGpznvvfu2d1xsvfH/+OWRzVxyrfmWfARlXcr0TV/PEN77sSNG53lRKIfCCCAAAIIIIAAAggggAAC7gok7Qp8UzNvNbPQ73DQOfrF0RfriNP/qgXmGfDX3vyIJkz+RkMG99eIYYO1qrJGF/zpP5o5Z0HTbrwjgAACCCCAAAIIIIAAAggggEA7AkkN4L+aPlN3PvySsjIzNXzTAZo7f4mOO+cqTfxius4/ZYyeu+9qPXXXlbrhynOdR67c+9gr7TSNTQgggAACCCCAAAIIIIAAAggg0CSQ1CH0H376lVPuPy8/W/vvub1+mr9YY0693Emzz3lvWuy2Af1667sf5zYl8Y4AAggggAACCCCAAAIIIIAAAu0IJPUKfEVVjVPV7juOdN5tkL7dVsOUl5uj0pKiqGZs1HcDLVm2MiqNFQQQQAABBBBAAAEEEEAAAQQQiC2Q1AC+ri4gOxt9Qb552PjPS1lpsXKy217oLy4qUENDqCkb7wgggAACCCCAAAIIIIAAAggg0I5AUgN4+xx4G8C3XJxHy0UnOZszM5Jadcsq+YwAAggggAACCCCAAAIIIIBApxNoe2l8Pbton/H+rzueaC5l6nezFAgEo9Lsxq+/m9mchw8IIIAAAggggAACCCCAAAIIINC+gCsB/INPvt6m1lhpxYUFbfKRgAACCCCAAAIIIIAAAggggAACbQWSGsCfdMz+2m+P7drWEiclO4th9HFoSEYAAQQQQAABBBBAAAEEEEAgSiCpAfyQwf1lXywIIIAAAggggAACCCCAAAIIIJBcAS6BJ9eT0hBAAAEEEEAAAQQQQAABBBBwRSCpV+BfeesTTZ46I+GGFprHzV16zi8Tzk9GBBBAAAEEEEAAAQQQQAABBLqqQFID+AmTp+u5V99P2NJOYkcAnzAXGRFAAAEEEEAAAQQQQAABBLqwQFID+MzMNQ98HzN6Nx28z07Kzs6Ky5uZyQj+uDhsQAABBBBAAAEEEEAAAQQQQKCFQFID+D9feKI2GzJQDzz5ml54/UNN/GK6TjvuIB158B7Ky81pUS0fEUAAAQQQQAABBBBAAAEEEEBgXQQyGs2yLjskkjcSiWjc+Em6//FX9c33c9Sje6lOOuYAHTfmF+LZ74kIupsnEIyowbxKCpP6+427je4EpTeEIqpvCKu0kB+zvDycQeNeGwirrAh3L91D4UZV1wXVrTjXy2q7fF3hSKMqa4LqXoK7lydDxHyVWlUVVHkp7l6622+wK6oC6lGa52W11GUEllUE1LMMd69PhuWVAZWX5CljzaBnr5tAfWkg4MoYdjs0/sC9d9TTd1+le2/4vYZtspFuuvtp7XPMJXrt3U/ToNs0AQEEEEAAAQQQQAABBBBAAAF/CbgSwLcmCIUjTlJNbb2Wr6hsvZl1BBBAAAEEEEAAAQQQQAABBBBYi4ArY6jtqPx3P/5Cdz8yVl9Pn6msrEwdtv8uOv2Eg7XpoH5raVLyN0+Y/I1sm3bedkRU4asqq/X+hK80Z94ibWLatcdOI9sM8U8kT1ShrCCAAAIIIIAAAggggAACCCDggkBSA3h77/vr7050AvcZs+YpLy9XJxyxr0497kD17d3DheavvUj7bPrLrrlLI4YN1s53rQngFyxerlMvvk5Llq7UgH69de9jr2jjgX11/42XqXtZiVNwInnW3gJyIIAAAggggAACCCCAAAIIILD+AkkN4P9+66N6/Pm3nVYdfsCu+tVR+5sJ7FYHw4uXrmjbWjMDQ++e3dumJyll8tff6/J/3hdzBvz7n3hVqyqq9eKD1zoB/LTvZ+vE867REy+8o3NPPtxpQSJ5ktRUikEAAQQQQAABBBBAAAEEEECgXYGkBvCBQLC5shfHfST7am+xM9J/+uod7WXp8Laf5i/WhX+5RUcdsqeWLlulhUuif0AYZ0YK7LnzKCd4t5WMGDpI2201TOPem9QcwCeSp8MNZEcEEEAAAQQQQAABBBBAAAEE1kEgqQH8tiOHOveaJ1p/Xp47j3WqqKrRuX+8SSM331j22fQXX3lbVJMCDUGtWFWlIYOj78e36/aefbskkieqUFYQQAABBBBAAAEEEEAAAQQQcFEgqQH8mNG7yb5SuQRDIV10+S1m2HyubrjyfNlH2rVeVqxcPRN+YUF+1Ca7Xl1bJwYjEbMAAEAASURBVFtGInlysrPNc45DUWX4YcU+JzhiXn5sux9847XRutsX7vGE3Em35zru7ti2V6p9Ljbu7Qm5s81O2Grt+Tvjjm+8Uq27feEeT8iddENu3IW7O7xrLZXzfa1ESc/QdL77/TnwxQVJDUGT7pzuBXY6vfsef1VTv5ute//9e1WaK/H2VVcfUDAY1CIzjL57txLl5q6+8m8n3Wu5hMJhZZr/I7JM0J9IHrtvdlZGyyJ889n+AfBr232D3Kqh9o+t/YKHeysYl1fDxj2Mu8vKbYuPRDIUyuB8byvjbkqkMUMZIdzdVW5beqMy1IB7WxgPUhrMdRT+XfUAOkYVuMdAcTnJfpfMyfZn7OEyTZcqPmkBvJ2kbvLUGTpw7x07BGiHrtth6/Y+9PVZKipXB+wnXnBNm2L2OfYS/ffai8y971s5gXpldW1UnsqqWnUrK3au2ne37+b/kvby2J3zc7OiyvDDSiAYMYFkxJdt94NvvDY2hCLOFUk/njPx+uSH9KBxD4UbOd89PljWvCEUxt1jdzvqIdCAu8fszqiHunrcvXa3FyNq6kP8nfEa3tRnr77zfcZ7eHu+5+VkyQbyLF1XIGkBfFVNnS67+k4tXLxCp/xytBP8Jsr61vuf60//uFtXXHJyorvEzXfOSYeZR9ftE7X96hsf0tLlFbr12t9ogx7dnAB98MANNcX84NBymTJthvM8eJtmh96vLU/LffmMAAIIIIAAAggggAACCCCAgJsCbW8Q72BtPcvLNHzIAN1w55M67pyr9dmX3621pJlzFpiZ4m/WRVfcqpLiIg3duP9a91lbhrKSIm3Ut1fUy97bbofE2/R882x6u4wZvbs+/myaHnp6nH6YPV+33v+cvp85T0ccuHtzFYnkac7MBwQQQAABBBBAAAEEEEAAAQRcFEjaFfhupcV68s4r9chzb+nW+57VyRf9Q/37bqDRe+3gXNXu27uHcnKyzRX65Zq7YIneNFfdp303y7nSfdIxB+jC045UYUGeK121w0xaDzU52dQ5+6eF+vcdT+r62x5XVlamTjvuQB22/y7NbUgkT3NmPiCAAAIIIIAAAggggAACCCDgokCGmVTL3EGU3MXeD3/T3c/onY8mq6a2Pmbhdgb3HbYerovPOkabDRkYM48XiXaCu/mLljlX5/N+ntyudb2J5Gm9Tzqv23vgG8yrpDBpv9+kc3fTpm32Hvh6c29qaaE7j09Mm46mWUPsPfC1gbDKinD38tDYe+Cr64LqVrx61JOXdXfluuw98JU1QXUvwd3L88DO/L+qKqjyUty9dLffYFdUBdSj1J0LQF72xW91LasIqGcZ7l4ft+WVAZWX5LW5MOl1O6gvtQKuBPBNXQqZCYymTPvBCZBXrKpUOBxRuZkFvlfP7tpmy6GuXXFvqp/32AIE8LFd3E4lgHdbOHb5BPCxXdxOJYB3Wzh2+QTwsV3cTiWAd1s4dvkE8LFdvEglgPdCuW0dBPBtTbpiiquXYLOzs5xZ5dd3ZvmueGDoMwIIIIAAAggggAACCCCAAAItBZI2iV3LQvmMAAIIIIAAAggggAACCCCAAALJFSCAT64npSGAAAIIIIAAAggggAACCCDgigABvCusFIoAAggggAACCCCAAAIIIIBAcgUI4JPrSWkIIIAAAggggAACCCCAAAIIuCJAAO8KK4UigAACCCCAAAIIIIAAAgggkFwBAvjkelIaAggggAACCCCAAAIIIIAAAq4IuPoYOdviVZXV+u6HuVqweJm2GD5YQwb319Llq7R46Ur17d1D5d1LXekYhSKAAAIIIIAAAggggAACCCDQmQRcDeAfenqcbr3vOdXVBxyzi886xgngv/3hJ53zhxs1ZvRuuvaPZ3QmT/qCAAIIIIAAAggggAACCCCAgCsCrg2h/3Di17r+tsdVXFSgE47YV7k5a34r2H3HkRoxdJDe+egLVzpFoQgggAACCCCAAAIIIIAAAgh0NgHXAvjX3vnUsbr3ht/rLxf9SoUF+cpoobf1lkNUWVXjDLFvkcxHBBBAAAEEEEAAAQQQQAABBBCIIeBaAD9n3mIN3qiPNh3UL0a1Uq8e3Zz02rrVw+tjZiIRAQQQQAABBBBAAAEEEEAAAQQcAdcC+H59emr+omWqqq6NSf31d7OcYfV9epXH3E4iAggggAACCCCAAAIIIIAAAgisEXAtgN925FA1BEO67/FXFQqF19RoPr3+7kS99f7nssPoMzNaDqyPysYKAggggAACCCCAAAIIIIAAAgj8LLBmZrkkkxx9yJ568Y2PdM+jY/XSuI9UYe53f+XtT/XmB5/r6+kzlZWVqT+ef0KSa6U4BBBAAAEEEEAAAQQQQAABBDqngGtX4DMzM3X39b/Taccd6ATvjY2N+u7HnzT121kaMWywHr/9rxq6yUadU5VeIYAAAggggAACCCCAAAIIIJBkAdeuwNt2FhXm69JzfqlLzj5WC5escGadH9i/twry85LcDYpDAAEEEEAAAQQQQAABBBBAoHMLuBrAN9FlmPvc+/bu4bya0nhHAAEEEEAAAQQQQAABBBBAAIHEBVwL4N+f8JU++Xxauy3Jz8vVkI37a5ftRqhbaXG7edmIAAIIIIAAAggggAACCCCAQFcWcC2An/z193r46XEJ2ZaVFulffz1Hu26/ZUL5yYQAAggggAACCCCAAAIIIIBAVxNwLYC3z4G3y3V/OUsbD+wb5Xrvo6+Yx8h9pluvvch5Vvwt9z2ry/95n1753z9VWMD98VFYrCCAAAIIIIAAAggggAACCCBgBFwL4CdM/kalJUU6ZN+dZe+Bb7lces6xemP8JH35zY+66IyjzHbp2psfMes/aOdtR7TMymcEEEAAAQQQQAABBBBAAAEEEDACrj1GbunyVc7V9NbBu1Xvv+EG6l5Wom++n21XNXKzTZz3n+Yvcd75DwIIIIAAAggggAACCCCAAAIIRAu4FsAP6t9Hi8yj436cvSC6RrNWWxdQVU2tamrrnW21davfI+FIm7wkIIAAAggggAACCCCAAAIIIICAi0PoDzZD55977QOd/YcbNGb0btpzp63UvVuJpkz7Qc+MHa9QKKzjx/zCOQYzZs133nv2KOOYIIAAAggggAACCCCAAAIIIIBADAHX7oHfcZvNdMFpR+i2B17QHQ+96Lxa1r/tyKE6aJ+dnKR5C5ZoyOD+2mLY4JZZ+IwAAggggAACCCCAAAIIIIAAAj8LZDSaxU2N6TPm6OU3P9HMOQvM0Pl69e3dUzttu7kO3W8XZWW5NoLfzS75vuxAMKIG8yopdO33G98budGBhlBE9Q1hlRbmuFE8ZcYRCBr32kBYZUW4xyFyJTkUblR1XVDdinNdKZ9CYwuEI42qrAmqewnusYXcSY2Yr1KrqoIqL8XdHeHYpdpvsCuqAupRyhOMYgu5l7qsIqCeZbi7Jxy75OWVAZWX5DkTgMfOQWpXEHA9gttsyEDZFwsCCCCAAAIIIIAAAggggAACCHRcwPUA3jbN3u8ejrSdoC4zM0M52Z40oeNC7IkAAggggAACCCCAAAIIIIBAGgi4Gj0/88p43ffYq5pr7nGPNVK/pLhQE8bengYMNAEBBBBAAAEEEEAAAQQQQACB9BZwLYD//KvvdeW/HlBBfp426ttLP81frO22Gqb8vFzNW7hUs+cu0oihg9Jbh9YhgAACCCCAAAIIIIAAAgggkCYCrgXwr7z1idPFh2/5sxYsXqaL/nqrrvrdqRq0UR8tXrpCh5z0J+dzmjjQDAQQQAABBBBAAAEEEEAAAQTSWsC1aeAXLVmhDXv30OZDB6p7WYmDsHT5Kue99wbl5rnwo/T86x8qEGhIayAahwACCCCAAAIIIIAAAggggEA6CLgWwAfD4eb73vuaQN4uP8ya39znPr3KneB9/qJlzWl8QAABBBBAAAEEEEAAAQQQQACB2AKuBfA9u5dqybJV5tnvAedKfL8+PfXoc2+qprZedfUBTZj8jdMie488CwIIIIAAAggggAACCCCAAAIItC/gWgA/eMCGiphHx308aarTgiMP2kOzzMR1exzxG+155EWaPmOOthg+2Anu228iWxFAAAEEEEAAAQQQQAABBBBAwLVJ7I49bG/tuM3maho+f9avD9XKiiq9Of4zrVhVpV22G6Grf38aRwABBBBAAAEEEEAAAQQQQAABBBIQyDDPZ29MIF9Ss9gr85mZrl38d+6tn/DFdP04e4FWrqpUn149dMBe26tneVlUP1ZVVuv9CV9pzrxF2mRQP+2x00gVFxasc56oHXywEghG1GBeJYWu/X7jAwXvm9gQiqi+IazSwhzvK+/CNQaNe20grLIi3L08DULhRlXXBdWtONfLart8XeFIoyprgupegruXJ0PEfJVaVRVUeSnuXrrbb7ArqgLqUcrtmF6627qWVQTUswx3r92XVwZUXpKnjAyva6a+dBJwLYILhcKa+t0sFRXma8jg/k6fq2vr9MZ7k8wz4Zdor11GadSITV2xuPLfD+rlNz9WSXGhevXs5jxz/j/3PK0H//NHjRg22KlzweLlOvXi67Rk6UoN6Ndb9z72ijYe2Ff333hZ86z5ieRxpQMUigACCCCAAAIIIIAAAggggEArAdcug3/w6Vc68fxr9MSL7zhV2gv9p1x0nf56/f2659Gx+vWFf9fbH05u1ZzkrG47cqgevPmPmjD2dr304N/14gPXKhgM67Hn326u4P4nXtWqimq9+OC1zuux2/+qWXMW6okXVrfXZkwkT3OBfEAAAQQQQAABBBBAAAEEEEDARQHXAviPPls9ed2ZJxziNH/8J186E9dtv9UwXX3ZaWY4e6luvOspV7p2zKF7afuthjeXXVZSZIbsZzRfWbcbxr07UXvuPMq5+m7XRwwdpO1M28aZEQJNSyJ5mvLyjgACCCCAAAIIIIAAAggggICbAq4NoV+wcJl6b1Bu7j8vd9r/4aSvnffzThmjHbbezNx3vlj3mWHrVdW1zlB3Nzr50/zFmvD5Nxr71ieyj6s77vBfONUEGoLORHpDBveLqtaufz19ZsJ5onZmBQEEEEAAAQQQQAABBBBAAAEXBVwL4LOyMqMmWJgy9QflZGdr6y2HON3p3bO7825npLf3qruxPPTUOGcIv50w74JTj2j+MWHFykqnusKC/Khq7bq9Tz8YCimRPLY/1XWhqDL8sGInOYqYlx/b7gffeG20kxytntjLf+dMvD75Id2623Oe893bo2XIzd8Z4e4tu+ykXtae891beEMu+8LdW3dbG+7emzfVyPneJOHduz3fa+r9/z2yuMC1ENS7g5HCmlzTs7O6v/PRF3rt3U+Vl5vTPHzeBr12mTFrnvPee4PVgbyzkuT//PHCE3S+ueL/oXkW/RXm3ns76/wfzj9euaY9drGz4bdcQuGwMs20jlkm4E8kj903O8uf00DaL3l+bXvLY+anz2YydGWab9a4e3vUwsY9bGZEx91bd/vnNWT+POLusbv5255hvtvh7q27/Te1wVSJu/fu9lsY7t66N9WGe5OEd+8ZQZk4JSPqIql3tVNTugi4FsD/0jwH/uFn3tDvrrqjua92+LxdqmvqnOfB999wA+XnuffIFftjQXn3Uh22/y569e0J5geFyU4A372s2AnUK83w/ZZLZVWtutltJoBPJI/dNz83q2URvvhsHyPX2BjxZdt9ARynkfYxcnbkgx/PmThd8kWyfYycHfmAu7eHy5o3mKeR4O6tux1tEjCPq8TdW3c70qfOPK4Sd2/d7Q8ntYEQ7t6yO7XZq++c797D26vv1p3HyHlvn041uhbAb9i7hx6++U+6+5GXzT9qDTroFzs6977bzo8bP0llpUU66uA9XbGwM95ntDqz7VD9grzVz6u0AfrggRtqytQZUfVPmTbDeR68TUwkT9TOrCCAAAIIIIAAAggggAACCCDgooBrAbxt8xbDB+uWa37TpvlHHbSH7Mut5dCT/qRD9ttF9nFydvK65159X9PMM+ntffBNy5jRu+uGO5/UQ0+P067bb6HX3vlU38+cp7//6cymLEokT3NmPiCAAAIIIIAAAggggAACCCDgooCrAbyL7W636MEDNtTtD71g7ns1N2GaJTs7S6f8crTO+tWhzfudfMwBmv3TQv37jid1/W2Py066d9pxBzrD7ZsyJZKnKS/vCCCAAAIIIIAAAggggAACCLgpkGGGm5s7iJK/2EfEPfLcm+0WbGeff+nBv7ebp6MbG4IhLVqyXCFzD2Y/c6+9nUgv1lJXH9D8Rcu0Ud9e65UnVtnpmmbvgW8wr5LCTvn7Tbqym/uBI6o396aWFsY+F9O24T5vmL0Hvtbcm1pWhLuXh3L1ExeC6lbs3jwnXvbHL3XZe+Ara4LqXoK7l8fM3gO/qiqo8lLcvXS332BXVAXUo3T1LZJe1t3V61pWEVDPMty9Pg+WVwZUXpLHPfBew6dZfa5FcPaqd15u7H/IVlZUORPZlZUUu8aRm5OtAf16r7V8O8R+UzNjfntLInna259tCCCAAAIIIIAAAggggAACCKyvgGsB/MnHjpZ9xVqmTPtBv7rgWh15sHv3wceqlzQEEEAAAQQQQAABBBBAAAEE/CqQmYqGjxqxqXbcejPd9fBLqaieOhFAAAEEEEAAAQQQQAABBBDwnUBKAnirNGTj/lpVWa25C5b4Do0GI4AAAggggAACCCCAAAIIIOC1QEoC+EBDUJO/nqGc7GwVFRZ43WfqQwABBBBAAAEEEEAAAQQQQMB3Aq7dA//ymx/rtbc/bQNSF2jQdz/+pIrKGh1+wK4q71bSJg8JCCCAAAIIIIAAAggggAACCCAQLeBaAP/j7AUaP+HL6Np+Xis2V93322NbXXTGUTG3k4gAAggggAACCCCAAAIIIIAAAtECrgXwF5x6hM488ZDo2sxaRkaGCgt4bmQbGBIQQAABBBBAAAEEEEAAAQQQaEfAtQDePgfevlgQQAABBBBAAAEEEEAAAQQQQGD9BVIyid36N5sSEEAAAQQQQAABBBBAAAEEEOhaAgTwXet401sEEEAAAQQQQAABBBBAAAGfChDA+/TA0WwEEEAAAQQQQAABBBBAAIGuJUAA37WON71FAAEEEEAAAQQQQAABBBDwqQABvE8PHM1GAAEEEEAAAQQQQAABBBDoWgKuBfAVVTVdS5LeIoAAAggggAACCCCAAAIIIOCigGsB/ANPvKZDT/6zHn/hbdXWBVzsAkUjgAACCCCAAAIIIIAAAggg0PkFXAvg+/fdQHPnL9E1//mf9j7qt7ruv4/pp/mLO78oPUQAAQQQQAABBBBAAAEEEEDABYGMRrO4UK5T5PKVlXpm7Hg99fK7WrRkhTIyMrTbDlvqV0ftp12338JZd6tuyo0vEAhG1GBeJYXZ8TOxJekCDaGI6hvCKi3MSXrZFBhfIGjcawNhlRXhHl8p+VtC4UZV1wXVrTg3+YVTYlyBcKRRlTVBdS/BPS6SCxsi5qvUqqqgyktxd4E3bpH2G+yKqoB6lObFzcMGdwSWVQTUswx3d3Tjl7q8MqDykjwTQ8XPw5bOL+BqAN/EF4lE9M5HX+jx59/WhMnfOMkD+/fWCUfsqzEH7qbiwoKmrLx7IEAA7wFyjCoI4GOgeJBEAO8BcowqCOBjoHiQRADvAXKMKgjgY6B4kEQA7wFynCoI4OPAuJxMAO8ysE+K9ySAb7IIhcK6+5GXdduDLzQlqbAgT4eP3k0nmmB+8IANm9P54J4AAbx7tu2VTADfno572wjg3bNtr2QC+PZ03NtGAO+ebXslE8C3p+PeNgJ492zXVjIB/NqE3NlOAO+Oq99K9WQM9eKlK8ww+vec4fTLVlQ4RqO22FQ7br2ZXn7jY+fK/BMvvKOb/+9C7bPbNn4zpL0IIIAAAggggAACCCCAAAIIuC7gWgBvb623w+VtYG6Hz9th9Pl5uTr64D11/BH7aPimA5zOXXDqEXpj/Gd66KnXzWz19a53mAoQQAABBBBAAAEEEEAAAQQQ8KOAawH8HQ+92DxUfkC/3jru8L11xIG7q7SkKMopMzNTo/fewXnZIJ8FAQQQQAABBBBAAAEEEEAAAQTaCrgWwIfDEe258ygzUd0+Cc84b4N5FgQQQAABBBBAAAEEEEAAAQQQaCvgWsQ8ZOP+khlGbyeps4+PY0EAAQQQQAABBBBAAAEEEEAAgY4LuBbAz5g1T+MnfKkww+I7fnTYEwEEEEAAAQQQQAABBBBAAIGfBVwL4IcMNlfgzbJg0fKfq+INAQQQQAABBBBAAAEEEEAAAQQ6KuBaAL/7jiPVe4NyvfLWJx1tG/shgAACCCCAAAIIIIAAAggggMDPAq5NYjd9xhwN6NdLH02aqv/7z8Pq1aN7G/Tc3Gyd+ssD26STgAACCCCAAAIIIIAAAggggAAC0QKuBfAfTvxak6Z869RmnwUfaykuLCCAjwVDGgIIIIAAAggggAACCCCAAAKtBFwL4I88aHftMGp4q+qiV7OysqITWEMAAQQQQAABBBBAAAEEEEAAgZgCrgXwA/r1NkPoe8eslEQEEEAAAQQQQAABBBBAAAEEEFg3AdcC+KZmBEMhM5T+O82Zt0h19Q3q16enRm62sTbs3aMpC+8IIIAAAggggAACCCCAAAIIILAWAVcD+E8+n6arbnhIcxcsiWpGdnaWTjxyP/3unGOVmenaRPhRdbKCAAIIIIAAAggggAACCCCAgJ8FXAvgZ89dpN9cfotCobCOPnhPbWmuuufm5mjB4mV6/tUP9NBTr6u4MF/nnTLGz360HQEEEEAAAQQQQAABBBBAAAFPBFwL4J8e+54zZP7eG36vnbbZPKozpx47Wsed93+6/4nXdM7JhyszIyNqOysIIIAAAggggAACCCCAAAIIIBAt4Nr49a+nz9RGfXu1Cd5t9Xl5uRozejcT4Ac0r9Xw+ujmsYYAAggggAACCCCAAAIIIIAAAlbAtQC+W2mxE6DHY66rC8TbRDoCCCCAAAIIIIAAAggggAACCLQScG0I/RbDB+vtDyfrrv+9rLN+dYgyWgyT/2H2fP3vmTfUq2c3Vx41V1NbLzuB3qyfFjrd3WOnkRq2yYBWXZdWVVbr/QlfOTPkbzKon2y+4sKCqHyJ5InagRUEEEAAAQQQQAABBBBAAAEEXBDIaDSLC+Wq1lxhP/rMK0xwvFiDNuqjEcMGq8AMnZ+3cKkmfjFdEVPtv644Vwf9YsekV3/W7/+tjyZNVXm3EqfsFauqNHjAhvrfrX9W97LVaQsWL9epF1+nJUtXOj8izDaPudt4YF/df+Nl65Qn6Y33oMBAMKIG8yopdO33Gw964b8qGkIR1TeEVVqY47/G+7jFQeNeGwirrAh3Lw9jKNyo6rqguhXnelltl68rHGlUZU1Q3Utw9/JksN9pVlUFVV6Ku5fu9hvsiqqAepTmeVktdRmBZRUB9SzD3euTYXllQOUleebCqNc1U186CbgWwRUW5OmBm/6g/9zzjMa++YnsrPRNiw3oLzWPkPvFrts0JSX1fbcdR+rC0450Zr63v088/fJ7uurGh/TEC+/oXDNpnl3uf+JVraqo1osPXusE8NO+n60Tz7tmnfMkteEUhgACCCCAAAIIIIAAAggggEAcAdcCeFtf7w3K9Y8/n6Wrfn+a5s5fopq6evXfcIPmK+Nx2rTeyScdvX9zGXbo/mEH7Kqrb3pYC81V96Zl3LsTtefOo5qH8I8YOkjbbTVM496b1BzkJ5KnqTzeEUAAAQQQQAABBBBAAAEEEHBTwNUAvqnhuTnZ2mRQ36ZVz9+/mDpD9kr84IEbOnUHGoKyw+qHDO4X1Ra7bmfPt0sieaJ2ZgUBBBBAAAEEEEAAAQQQQAABFwVcDeBDobAmf/29Pv5smjNhXOt+FOTn6Q/nH986OanrgUCDbrjzKee+9iMO3N0pe8XKSue9sCA/qi67Xl1bp2AopETy5GRnm1EFoagy/LBi75G0Lz+23Q++8doYNj8ihc19wbjHE3In3XHnfHcHt51SDbkiEXG+t2PkxiZDbuaYwd0N2/bKtJMJ2fux+fvenlLyt+GefNN1KZHzfV20kpPX+TtTH5Lfb4EvKnA1BE0OdhqX4pre0uWrdOjJf1ZVdW3c7tsZ390M4BuCIV1w+S2aOWeB7vznJbKPtrNLbu7qyawi9ttliyUUDivTDLnPysxMKI/dNSvLf/8L2V5nmH/1/Nj2FofLdx8bw1LYwOPu8aGz7sLdY/XVUaT588j57q28mZnW+WKHu7fudhI7C4+7t+4OO+7eoreojfO9BYZHH+3kdVmZGUxi55F3ulbjWgB/58MvOcH7kQftoTGjd1NZaZETGLeEaPlouZbpyfhsHyV34eU366tvZuq/116kHbberLnY7mXFTqBe2erHhcqqWnWz20wAn0geW2B+blZzuX75kGFnoW+M+LLtfjGO1U47C739kufHcyZWf/ySZmehD5lLkrh7e8TsLPTWHndv3e3oqkAD7t6q29+rGlUfwN1rdxvA1wZC/J3xGt7UV21GoPL33Xv4GnP13bozC7339ulUo2sB/IxZ85SdnaW/XXqK+UU609M+L162Uuf98SYtNo+Iu9/MhD9ys42j6rcBur0ffoq5N77lMmXaDHOv/ur74hPJ03JfPiOAAAIIIIAAAggggAACCCDgpoBrkfWQwf3N/b4RVdXEH0LvVsdOOO//9O0PP+mUX47WoiXL9cb4Sc0ve1++XcaM3t25N/+hp8fph9nzdev9z+n7mfPUdJ98onmcwvgPAggggAACCCCAAAIIIIAAAi4LuHYFfvTeO+iJF9/Rs6+8r9OPP8jlbkQXv2xFhZNw091PR28wa5+8fJtKS4p08jEHaPZPC/XvO57U9bc97owSOO24A3XY/rs075NInubMfEAAAQQQQAABBBBAAAEEEEDARQEz3429g8id5c//uFevvzdRh+63s5mNuG01hQV5+tOFJ7pTeYKl1tUHNH/RMm3Ut5fyfp7crvWuieRpvU86rwfsPfDmVVLo2u836dz9lLXN3gNf3xBWaeHqSRRT1pAuVrG9D7s2EFZZEe5eHnp7D3x1XVDdinO9rLbL12Xvga+sCap7Ce5engz2HvhVVUGVl+Lupbv9BruiKqAepXleVktdRmBZRUA9y3D3+mRYXhlQeUke98B7DZ9m9bkWwf04e4E+mvS17GPcnhk7Pma37Sz0qQ7g7aPsNv35vveYjTSJieSJty/pCCCAAAIIIIAAAggggAACCCRDwLUA/qmX35Udyn7MoXs5s9DbR7hlmscetFwyM1y7Bb9lNXxGAAEEEEAAAQQQQAABBBBAwPcCrgXw3/04VznZ2bri4pOcx7L5XooOIIAAAggggAACCCCAAAIIIJBCAdcugW86uJ9C4bBaP2s9hX2lagQQQAABBBBAAAEEEEAAAQR8K+BaAG8fx5aRkaGnX37Ptzg0HAEEEEAAAQQQQAABBBBAAIF0EXBtCP3CRctlZ5m/4+GXNMs8ri3Wkp+XqysuOTnWJtIQQAABBBBAAAEEEEAAAQQQQKCFgGsB/NTvZqm6ps6p6sVxH7Wocs1HOws9AfwaDz4hgAACCCCAAAIIIIAAAgggEE/AtQD+9OMPcmagj1exTc80Q+xZEEAAAQQQQAABBBBAAAEEEEBg7QKuBfAlxYWyLxYEEEAAAQQQQAABBBBAAAEEEFh/AdcCeNu0xsZGvf7eRH3x9QwtWLxcYw7YTfvusa0mffmtPp40Tbtuv4W222rY+veCEhBAAAEEEEAAAQQQQAABBBDo5AKuBfChUFhn/O5fmjTl22bCUSM2dT732aBc9z/xqr6ePlP33vD75u18QAABBBBAAAEEEEAAAQQQQACB2AKuPUbu8RfedoL3/cwV9/tuvEzFRQVquuN9o769tOt2W+izL79TxFylZ0EAAQQQQAABBBBAAAEEEEAAgfYFXAvgJ34xXdnZWbry0lO00zabKzsrK6olmw8bpGAopCVLV0als4IAAggggAACCCCAAAIIIIAAAm0FXAvgq6prNaBfb3UvK2lbq0nJ+HkG+tzcnJjbSUQAAQQQQAABBBBAAAEEEEAAgTUCrgXwmwzup5lzFmj23EVravv5kx02/+5HX6i0pEjl3WIH+G12IgEBBBBAAAEEEEAAAQQQQACBLizgWgB/wJ7bO1fZ//bvBzRl6g/NxEuXr9Kfrr1b02fM0UH77NiczgcEEEAAAQQQQAABBBBAAAEEEIgvkGEe9ebaLHK33vec7vzfSzFrHzxgQz1++195VnxMHXcTA8GIGsyrpNC1hxC42wGflt4Qiqi+IazSQm4b8fIQBo17bSCssiLcvXQPhRtVXRdUt+JcL6vt8nWFI42qrAmqewnuXp4MdmThqqqgyktx99LdfoNdURVQj9I8L6ulLiOwrCKgnmW4e30yLK8MqLwkz1wk9bpm6ksnAVcjuAtPP1K77bilHnvuLc38aaEqq2o0aKM+5tnvw3XqcQcqN8fV6tPJmbYggAACCCCAAAIIIIAAAgggsF4CrkfQW28xRPbFggACCCCAAAIIIIAAAggggAACHRdw7R74jjeJPRFAAAEEEEAAAQQQQAABBBBAoLWAq1fgx0/4UuM/nqKPP5umVZXVretWaXGh3nji323SSUAAAQQQQAABBBBAAAEEEEAAgWgB1wL4z778Tuf98Santp7lZerVs5uyMqMv+BcW5Ee3hjUEEEAAAQQQQAABBBBAAAEEEIgp4FoAf//jrzoV3vaP32qvnUfFrJxEBBBAAAEEEEAAAQQQQAABBBBITCD6knhi+ySUKxgOO7PME7wnxEUmBBBAAAEEEEAAAQQQQAABBNoVcC2A33L4YPOs8ZBmzlnQbgPYiAACCCCAAAIIIIAAAggggAACaxdwLYA/7vB9VGImqbvl/ufW3gpyIIAAAggggAACCCCAAAIIIIBAuwKu3QNvJ6076Bc76smX3tWOB5+rSCTSpiGlJUV6+6kb26STgAACCCCAAAIIIIAAAggggAAC0QKuBfBvjJ/kBO+2uqLCApWVFsWYhT4vujWsIYAAAggggAACCCCAAAIIIIBATAHXAvg3x3/mVHjPv36nXbbfImblJCKAAAIIIIAAAggggAACCCCAQGICrt0DX1ld68xCT/Ce2IEgFwIIIIAAAggggAACCCCAAALtCbgWwI8asakzC/2Ps5mFvr0DwDYEEEAAAQQQQAABBBBAAAEEEhFwLYA/8ch91bO8TDff+0wi7SAPAggggAACCCCAAAIIIIAAAgi0I+DaPfCPPPumlq2o0NsfTtY2+58ZswnFRQV6//lbYm4jEQEEEEAAAQQQQAABBBBAAAEE1gi4FsCXdy/VFsMHr6kpxqeCfGahj8FCEgIIIIAAAggggAACCCCAAAJtBFwL4I87/BeyLxYEEEAAAQQQQAABBBBAAAEEEFh/AdfugV//plECAggggAACCCCAAAIIIIAAAgg0CRDAN0nwjgACCCCAAAIIIIAAAggggEAaCxDAp/HBoWkIIIAAAggggAACCCCAAAIINAm4dg98UwWpfn/z/c80ZHB/DdqoT5umrKqs1vsTvtKceYu0yaB+2mOnkSouLIjKl0ieqB1YQQABBBBAAAEEEEAAAQQQQMAFgU4bwIdCYb33yRRdcuVt+stvf90mgF+weLlOvfg6LVm6UgP69da9j72ijQf21f03XqbuZSUOdSJ5XDgmFIkAAggggAACCCCAAAIIIIBAG4FOGcDPmDVPR5z2VzU2NrbpcFPC/U+8qlUV1XrxwWudAH7a97N14nnX6IkX3tG5Jx/uZEskT1N5vCOAAAIIIIAAAggggAACCCDgpoBr98DPnrtIkXYCaNupWT8tdKVvdrj82If/oafuujJu+ePenag9dx7lBO8204ihg7TdVsM07r1Jzfskkqc5Mx8QQAABBBBAAAEEEEAAAQQQcFHAtQD+hdc/1DmX3aDKqpqYzX/0ubf06wv/HnPb+ibmZGc7Q+YH9m9737stO9AQ1IpVVebe+H5RVdn1hWZofaJ5onZmBQEEEEAAAQQQQAABBBBAAAEXBVwbQt+je6k+mjRVx5z9N916zUUaunF/pxt19QFdcf39evWdT2XzpGJZsbLSqbawID+qerteXVunYCikRPLYHwpq6kNRZfhhJRxuVDjS6Mu2+8E3XhutubX34zkTr09+SI9Yd853zw9VJCLZF+e7t/R24Js53XH3lt3csifnxfnuLTzu3nq3ro3zvbWI++v2nLfuGRnu1+VmDUX5roWgbjY7bcp2Te/XR++v/Lxc/ePWR3XCef+na/5wuoZtspEuuuJW/Th7gYZvOkA3XHleSiByc3OceiP222WLJRQOK9P8H5GVmalE8thdbX6/LREz7iLD/AHwY9v9Zt2yvY3mVAkbeNxbqrj/2bpnCHf3pVvVkGn+yBh7zvdWLi6vRsy5bv9Vwt1l6FbFN9p/VDnfW6l4sGr/vuPuAXTsKvg7E9vFzVR7vmdlmv+wdGkB1wJ4q3rMoXtpq8030cV/u02XXnW7cnOy1RAM6YQj9tXvzzvOWU+FfveyYufLTWV1bVT1lVW16ma3mQA+kTx254K8rKgy/LASCEbU0BjxZdv94BuvjQ2hiDMvhB/PmXh98kN60LjbK/C4e3u0Qma0ibXH3Vt3e643mL/xuHvrbuf8qQ/g7q366lEPtYEQ57vX8KY+exWYvzPew9vzPT83y/dX4L2X61w1unYPfBPToAEbOkG8XbfB+2Czfv6pY1IWvNt22AB98MANNWXqDLvavEyZNsN5HrxNSCRP8458QAABBBBAAAEEEEAAAQQQQMBlAVcD+DnzFuv4c6/Wi+M+MoFxX/3ysL2dmeePPP0KTf76e9e6Zieps4+F+8a87GKf527Xl62ocNbtf8aM3l0ffzZNDz09Tj/Mnq9b739O3880j587cPd1ytOcmQ8IIIAAAggggAACCCCAAAIIuCiQYZ6Vbm7cSv7ysZnA7rdX/lc1tfU66Bc76urLTlNBfp7eGD9Jf7nuXjPULKjfnnGUTj/h4KRX7gTip13eptwLTztS55x0mJMeDkd01Q0P6nkzW769Fz4rK1MnH3OALjn7WDMsZfW9JYnkaVOJDxKcIfRmiGVJoat3UPhAwtsm2iH09Q1hlRaunoPB29q7bm12GHdtIKyyIty9PAvsEPrquqC6Fed6WW2Xr8sOoa+sCap7Ce5engx2CP2qqqDKS3H30t1+g11RFVCP0jwvq6UuI7CsIqCeZbh7fTIsrwyovCSPIfRew6dZfa4F8P+55xk98ORr+sP5xzv3vLfs98w5C/Sbv96qpctW6dNX72i5yfPPdlb8+YuWaaO+vZT38+R2rRuRSJ7W+6TzOgF8ao4OAXxq3AngU+NOAJ8adwL41LgTwKfGnQA+Ne62VgL41NgTwKfGPd1qde0S7Eb9eunhW/7cfP97y45vPLCvnrzzSl1/++Mtk1Py2Y4K2HRQ9PPgWzckkTyt92EdAQQQQAABBBBAAAEEEEAAgWQKuBbAH3XQHu22s6gwX1f97tR287DRHYGKQIUWVS7VyMKh7lRAqQgggAACCCCAAAIIIOCKwPK65crOyFZZfpkr5VNoegu4FsDbbtshZTNmztXMnxYqFAq3kbBD1vffc/s26SS4I9AQbtCFr12oR796VLWhWu238X76z+j/aLOem7lTIaUigAACCCCAAAIIIIBAUgSW1S7Vpe9crqemPeU8MevELU/U9fteTyCfFF3/FOLaPfD2kXG/ufwWffDpV3E1igsLUn4PfNzGdcINT0x9Qsc/e3xUz/YatJcu2/WyqLSmlQytnsyvab2zvne4n+vIEzITJ9rnMxfmu/q7WdzD1OF+xi0xPTe07mfITFIZaIioKBH3dTymqRRo3c9UtiVW3fZe7DozeWBxwfqd7+vVTx8dT2u4Xn39+SDYH85r6kJmktL0nbSxw/1M4+Np78WurjXuRWvO9w73M9b/UJ0gbb08Wh77pqmXTZp1r6oNqjSNJildr3766DhXmMkyuxV1cNLGOMczHbufbsfz9on36PFpD0dR3bD/Dbpk50ui0ljp3AJr/qVJcj/HvvmxE7yP2mJT9e+zgca+9YkuPusYde9Woi+n/qBnX31fRx7c/jD7JDepyxf3wJQH2hi8N/s92RcLAggggAACCCCAAAII+Evg3i/uJYD31yFb79a6FsBP/OJb5eZk667rL9XnX33vBPB77LSVhm7cX4fvv6smTvlW039+Tvt694ICEhLYdsNt9caPb0TlLckt0W4DdotKa73SqKafu1tv6VzrHe5ngjzmgqRzW0l2Zsufnr037HA/vW/qetXY1M/GiBQ2l2mys9bBPcFjul4NTNLOTf1MUnFJK8ZeGQub0Q/Z5hGdyVjWq59d6Hiudl/H8z0ZB6gDZXT4mKbh8bR9sU9eyIlxvne4nx0wTddd2jVYz+MZNKPbYrmnwqLdfqaiQS7V6ZzvIfN3Jnsd/l1tast6Hu+mYrx4T8fj+fXiqaoIrIrq/hYbbBG1zkrnF3AtgF++skJ9evWQHSbfvazEkVxgHtdmA/js7Cztuv0WeuLFd7Syoqp5e+fnTm0Pz972bN386c2qDdY6DbHDgm4afZNO3/r01Dasi9TOY+RSc6B5jFxq3HmMXGrceYxcatx5jFxq3O0PVjwHPjX2PEYuNe6PTXlOv3rxaPOT4epfQjIzMnX+DuenpjHUmjIB1wL4XDNBXVX16kBx44EbOhMtfDF1hvbaZZTT2VB49aR2S5dXEMB7dPgHdhuouRfP1b2TH9CclT/pgp3OYQI7j+ypBgEEEEAAAQQQQACB9RE4YOODNe28abrz8zuVm5Wrc7Y9R5uUb7I+RbKvDwVcC+B79ejuXF1fsHi5+vbuoc2HDtRjz7+lzYYMdK7Av/vRF8rIyHC2+dDNt00uLyjXRTtc7EymVlLo2uH3rQ8NRwABBBBAAAEEEEAgXQWGm6dH3Tz65nRtHu3yQCA5NyfGaOhWIzZR757dNcVcdbfLb888WvWBoC696nZd9NdbtXxlpY4b8wsVFxXE2JskBBBAAAEEEEAAAQQQQAABBBBoKeDaY+RaVtL0eeIX0/X2h5O1bEWFdtpmcx19yJ7OVfim7bx7IxAwjzKzjzPjCrw33k21cA98k4S379wD7613U23cA98k4e0798B7691UG/fAN0l4+8498N56t6yNe+Bbanj3eXllQOUleSZ+8q5Oako/AU/HUO+w9WayLxYEEEAAAQQQQAABBBBAAAEEEFg3AdeG0K9bM8iNAAIIIIAAAggggAACCCCAAALtCST1Cvz/3fSwnn/tg/bqi9pWWlKk9579T1QaKwgggAACCCCAAAIIIIAAAggg0FYgqQF8QzCkQEPQqaVfn55ta2uVUliQ3yqFVQQQQAABBBBAAAEEEEAAAQQQiCWQ1AB+y+GD9do7n6quPqC+JoA/68RDtMv2W8SqlzQEEEAAAQQQQAABBBBAAAEEEFgHgaTeA3/sYXvrradu0AWnHqEfZs3Xmb//t44962968/3PZGdoZUEAAQQQQAABBBBAAAEEEEAAgY4JuPYYuUCgQc+9+oEefOp1zVu4VIM36qMzzBX5Q/bdWdnZWR1rLXslRYDHyCWFcZ0L4TFy60yWlB14jFxSGNe5EB4jt85kSdmBx8glhXGdC+ExcutMlpQdeIxcUhg7VAiPkesQ23rvxGPk1puwUxSQ1CvwLUXy8nJ1/BH76LVH/6kLTztSs+Yu0l+uu1f/feD5ltn4jAACCCCAAAIIIIAAAggggAACCQgk9R741vV9P3Oe7nl0rF5/d6KzaavNN9Feu4xqnY11BBBAAAEEEEAAAQQQQAABBBBYi4ArAfzX02fqrkde1nsfT1GjGd+0q5nI7kwzfH77UcPX0hw2I4AAAggggAACCCCAAAIIIIBALIGkBvA2cL/53mf1yefTlJmRoQP22l5nnHCwNhsyMFbdpKVCYMkHyvnuNmXXzJWGnSMNOFbKyktFS6gTAQQQQAABBBBAAAEEEhVoDElzzO3IP9wuZeZKQ86T+o+RMly7KzrRlpHPQ4GkBvBPvfyeE7zb9h9sJqsb2L+3cxXeXomPteTmZOt0E+CzeCSwYrL01h5q/l/8k4+l6pnSlld61ACqQQABBBBAAAEEEEAAgY4I5M39nzK+OnfNrovelnZ72lyQO3pNGp86vUBSA/iWWi+/aYLDtSzFhQUE8GsxSurmGebXutbL1Kul729tnZre6z59JKH5nVQ56S3rUutS+whJa15qm5DhUvc6XbHJOV7Zppgya9MV3ZNDmOCZFV2ZfcZLtwT3JFvyBOwP493tv01m9GH7S/Txaj8vW9cmYLXLE3JfW0nxtnO8mmVaUfSQTVjb+d68t0cfWjXSo1q9rKY4XNu2Ovv9ngC+rUsnTklqAH/miQfriAN3S5grM7P5WnDC+5BxPQQaKtru3BiRAsvbppPiikC6/VPnSifTsFDcU3NQcMc9NQKpqZXzHffUCKSmVs731LjHrDVcFzOZxM4r4Npz4DsvmY97tvgd6e19ojswxNwHP/Ka6DQv12L9C9DeD6hrvboRp/Fp8EOxfQ58oCGsksKudB0+1gGOc4xcSrbPga8z7qVdyr2jmMk7XvY58DX1QZUV2bEnXWhJhDDe37hE9o2ibLuDfQ58VU1Q3Uq6mHuUi/cr9jnwFdUhdS9p7+972+PlfUs7V4324vvK6gaVu3K+d9Lj1bpb8f4exTpVWuy7vKJBPcri/J1pKrNF/ljFJTfN08qS2/R1KK326/+qcPqfovfY+SFp8EnRaax1aoGkXoH///bOA06K2ovj7+DovfdelF4EAUEQwYYgiKBIF0QBQYoFlSZNQIqCdOko0v6AIB2kSJUiXXrv/ejtuH9+OWaZ3dsye7d3sre/x+fYmUySSb6Znc1LXl5iNanYULkMlUXK/CxhB5Spze0zEpSvhXJk104kQZrYULunvw5xHimDs1CR+O46eE9/NfyuhOAeRu4x3m5KgQ8LfaCedxcdvBgvUIDcUCnwYfEU93jkHqMtrjTJsGByj1HmuJlSFMOC76nnnc54Y5q95h5M7jHN/W7OlpIoUSIJOjTysRM7tR4+R72YLgbv9x8ToAL/HzdAzN5ejU7m+VDuZ28m9+8/kGRJ+OKNWf68GwmQAAmQAAmQAAmQAAlEjkBY3EThk2/PfqoyCAyrg8iRit2puAg9drev69oFwdURhQRIgARIgARIgARIgARIwL8IUHn3r/bybWmpwPuWJ3MjARIgARIgARIgARIgARIgARIggWghQAU+WrAyUxIgARIgARIgARIgARIgARIgARLwLQEq8L7lydxIgARIgARIgARIgARIgARIgARIIFoIUIGPFqzMlARIgARIgARIgARIgARIgARIgAR8S4AKvG95MjcSIAESIAESIAESIAESIAESIAESiBYCVOCjBSszJQESIAESIAESIAESIAESIAESIAHfEqAC71uezI0ESIAESIAESIAESIAESIAESIAEooUAFfhowcpMSYAESIAESIAESIAESIAESIAESMC3BKjA+5YncyMBEiABEiABEiABEiABEiABEiCBaCFABT5asDJTEiABEiABEiABEiABEiABEiABEvAtASrwvuXJ3EiABEiABEiABEiABEiABEiABEggWggEhSmJlpyZKQmQAAmQAAmQAAmQAAmQAAmQAAmQgM8IcAbeZyiZEQmQAAmQAAmQAAmQAAmQAAmQAAlEHwEq8NHHljmTAAmQAAmQAAmQAAmQAAmQAAmQgM8IUIH3GUpmRAIkQAIkQAIkQAIkQAIkQAIkQALRRyDut0qiL3vmHB0Elq3ZInHjxJGUKZLaZX/r9l1Zs3GHrFi7TbbtOiBJkySUtKlT2MVxd3Lt+k1ZunqL+tssl69el0wZ0kj8ePHskliJY5cgFp244u5YxY3b9srJMxckW+b0jpecnsMNxV+bdsnCFRvl0LHTkjxpEkmZ3L5tyT3i827AvHn7jmzZcUA/uxu27pE8OTJL4kQJjMsuP8ndJRp9wd3zfv/BQ1m7eZfMW7JOHjwMlYzp00jcuNbGg61wtxLHfen96+oj9Q74Z/dB/e5etWG7gC/ev45Mo/IesMLUShz/Iuu+tFa4R/V31QpTK3Hc18T/rlqps5U4rmpuJa2VOK7y99dwT3W28p3wVPeDR0/p/szGrXvlYWioZM2Uzi6JpzLYRY4lJ97W+djJc7Jh2x7NLl5wsCUK5G4JU6yJRCd2ftSUD1VHGZ27Dt2GSef2jaRezZftSv/RFwNl3ebdkjplMh1+5doNyZU9k0z56RtJlSI8zC6B6eTM+cvyQYd+cuHiVcmeJYMcO3VOcitFaPzgL21prcQxZRlrDj1xN1d0wfIN8mXv0VLomVwyY3R38yWnx3ipIz6U95zZMgra7P79B/JTn3byQqlCOg25O3/eAWfLjv3yWY8RckUNOGXOmFau37wtI/q2lxKF8znlbQSSu0Ei4qen533Nxp3yec8RaoAwsRTMn0P+2XVQKZzhz2zZkgUjZmgKscLdShxTlrHicPbCNdL1+/GSIEF8SacGXU+dvagHob7v0lIqly+h6xiV94AVplbixArYpkpY4R6V31UrTK3EMRU5VhxaqbOVOK5gWElrJY6r/P013EqdrXwn3NV/0cpN8lWfMWoiIrEkTpxQTp25KI3qvCpftamvk1kpg7v8/fGat3U+d+GK1GvVUy5eviZLpw2ULKpv40nI3ROhWHhdPVgUPyBw4MjJsEIvNQ0rWKmJ/vtt7ooIpZ40c0nYzr2HdfijR4/Cpv/+p447YuLcCHEdA3r9ODns+Wotw46fOqcv7d5/NKxYleZh5rRW4jjm6+/nVrgbddy6c39Y8arNw0q88mFY3Y++NYLdfv69/V/dRlPnLNfx7t67H1anRbewmk0729KRe5MwZ8/7idPnw4pWaRbWrEP/sAuXrmpeoaGhYUoBtbFzdUDuzslYed6rN/467PX6X4aBNUTNUIa9UOOTsEZt+zjP1BRqhbuVOKYsY8WhmqkKm7t4re3ZPXn6QljpNz722XvAClMrcWIFbFMlrHCPyu+qFaZW4piKHCsOrdTZShxXMKyktRLHVf7+Gm6lzla+E67qj9+ESrXb6d9k4/fhp/GzdR/n8LHTOpmVMrjK31/DvanzzVt3wmo166L73+jvq8Fcj9Umd4+IYmUEazaPsXDgwt+qhNnZPyb3dTur21iNchYpkFtXLSgoSN56rbzg86yaXTdEKYh6ZE8phUaQ/lyy8m+pVK64nn1HQKH8OaVUsWdkyarNtnhW4tgix5IDK9xRVaVMStvOQ+Wd6pXkxTJFnda+/7Cpmr16QduuL1bcE6pZt7rVX9JhCeLHk3drVBaYQh05fkaHkbsNl93B6CnzJTT0kXT/rImkS5NSX4ujlpY4mh2Tux02tydWnvdb6vlNlyaFgDUEyxXy5MwsoY8e2eUdWe5WvhN2N4oFJ2VKFpCa6n1tPLtZM6dT799n5cz5S7baWX0PkLsNmccDK9yt/K7iRuTuEbctgpXvuJU45G5DaunAClMr3wlX3LeqpZuYNa5fu6rt9wGz7+iHGn1JK2WwVBk/imS1zmriTVsUPlBWmJ3avO+0hqvVMlnMzi9fs9V2ndxtKALqgAq8nzQ31sCgc50ja0bLJcaaSjXsJLlyZLKlURPzsuvfI3L4WLhyiAv31MsCptv5cmWxxcMBzg3l30ocu8Sx5MQK95Abt6TVVz9I0YK55Zu2DVzW/MiJs5r9g4cPbXFgKoV2DQ6OawvLlyurPj574bKltrEljEUHVrivWr9d8ufOJsvUD1nnfmNAdHn4AAA9v0lEQVTl20ET9RITRwzk7kjE9bkV7rXeqCBbdx6Q1l//KHv2H5X1W/bo5/qdahXtMo4Md2Tg6Tthd5NYeoKO3I49h/QSKFTRm/cvuUf+oXDk7iwnZ7+riEfuzmg5D7PyHbcSh9yd83UVapWpOb2r74Sz5/3s+Ss6qbkvmSJZEkmvBtiNvmRkymAujz8eW61znyG/yO59R2Vk/46SwsEPklFvLBdEH/7S1RAjSLEldxuMADqw5hkhgIDElqreUzPtg0bN0OvX337jRVu1EiaML0N6tbWtk8cFvBAgiRMl1J/GfziHgzAonFbioPMfaAI27boMlQTx48ug7p/YRp2dcWjVpKbUrfGSJFNrhw0B1yRqnZhZDAdsGFQhdzOZJ8ewJLkackP/xY8frNeI7dp3RGbOXyVtm9WWlo3fskUmdxsKnxyA7+bt+7XDzNXKJwekjrI8qe2gwEeGO/Ly9J1AnNguwyfOFTisg3UJxJv3ALlH/ulw5O6Yk6vfVcQjd0dars+tfMetxCF314ydXbHK1JzW1XfC1fOOtBH7kgnkivq9hkSmDDqhH/9npc5qqY7A/8CEH77SDpB3KUXemZRRfmbQhy+QL4ftMvKHkLsNSUAcBJ7GFQDNCg/GbZRSCRPsUWokz+zRPI4yZar64nN2FOIrs20IRlrNAu+hiA+P91bimNMGyvG43xbK7v3HZOzAL+S6monH35279+SBcuqFUddUyqEgzOIhxQvljYAlXrzgCKbHhikyBkTIPQIyHYDBDchnLd+TZvXe0MfwnttaWUKMmDRXPlBh5K6x+Py/r7/7WT3bl2Xxr9/L2YuXZYxayjDrj9V6sLB9izq2+0XmeUdiT98J2w1i6YHyhyGjJs+TxnVfk1crlda19OY9QO6RezCccTfn5O53FfHI3UzL/bGV77iVOOTunrPjVatMjXTuvhOunnekhaWnWR6qpW6GlaG3ZTDn46/HnuqMvvr3w3/T/ZmM6VPrvuO1xwMeFy9dUw5jEwksGSCZM6TRf2YWyB9C7mYqsf+YJvSxrI2x5U3LToO0Z+hhypP58yUKeKxhKrUdHRR1ePA2y/Ubt/VWdVjraiWOOW2gHIdcD1fYG7TpLVXe7aj/sBPAgSOn9PF6dexO0qRKITccuMMkH5ImdXJydwEPJnl4Lm/fuWuLgWf4pReK63Xxx06etYU7OyB3Z1Q8h2GkHzstYAcMrNMurdZpjxnwuVSpUFLQ2YOptzvxxB1prcRxdw9/voYBQZhRYt11p0+erIGM6vvXClMrcfyZrbuyu+JupInM7yrSWmFqJY5RjtjyaaXOVuK44mElrZU4rvL313Bv6uzpO+GMQZpUyXWwY5/m+s1bti2NvSmDs3v4Y5inOt947Bdp0Kjptn4kfgcg6Fv2Hfqr22qTu1s8sfYiFfhY1LTnL12Vxp9+JwcOn5LxP3SSF0oXjlA7rIk/f/GKNj02LkIRwjr57WrNvFm27zmonFOFr4u3EsecNlCOYaq9eOr3dn/Y/g3r2BFe7vFWcOABk1iwRxsYklf5GTh6/KwYSjvCt6u1r5p3tkzhnx7axsgrkD4xmo+9ZbGFmVmwNgySLk0qWzC521BE+eDSlRCBpYP5eYWDIlia3Ll7X6DoGBIZ7kjr6Tth5B+bPmH99N3QX+SHMTMFVgydHm+5ZNTRm/cvuRvUPH964o4crPyuIh65g4I1sfIdtxIHdyN3a8wRywpTK98J5OWMu+G/5x/VdzQE+5ljoiOP2pYYYqUMRtrY8umpzjCHd+xHfvl4AHeC6ssbx+CBZTzoR2IZoSHkbpAIrE8q8H7S3pjZ2nPgmOxVfxDsCYxzdKgNqd+6l+w7dEKavve6NnFdunqzGH/Y2xmCTvbLdTtKh+7DjWT6s9brL2pnVFiHc+jYaVFbf+hZZPP6eStx7DKNBSeeuMOsKVvm9HZ/WIcEk1eEw8O8IZ3Ufu9gjx8+Q+B5GtK1/zjZf/iEwDHbhGmLtCf7tGo/aAi5O3/em79fTTZu2ytYo4dOwpRZS7Vn1kpli9n5eCB3/RhZ+s/T844BPQyczFqwWuBZFzMtK9f9I4v+3CR13qzkE+5WvhOWKuNHkQaNniG/zl6uljeVVI5KM9je23h/Y094iNX3QGSfd3J3zt3K7yrah9xBwZpYedasxMHdyN0ac8SywtTKuwh5OeOO3UgKP5tLho2fo3+b9x44Lt8OnKCXs71ZpSySWSqDjhiL/vPEPb4ygXfsRxo762RRv7ep1QC5IQvVby36kWrbUSNI7wJD7jYcAXMQhM3xAqa2flxRmGS/3axLhBqYHXYVq9pcDEXdMeKG+cMluVI2sT671Osfa9N6jOwZgu24eigv3nPUSwEjsNjOqIlag9nx43f1FiCIZyWOkV9s+bTC3bGu7bv9JGfV+vfpo7rbXWrZabD8tWmnrJs3zM4vARShbgPG22YvixfOK0N7farML8PN0cj9CUbz846Z4IEjp2vFHc8sBKbcPb74QK/HNlKRu0HC86eV5x1bHHbuO1YPIBo5VixbVPp81cKuoxFZ7sjT03fCuG9s+URn+A+1NMGZdO/YRN59q7Ll9y+5O6PoPMwKdyu/q8id3J0zdhVq5TtuJQ65uyLsPNwTUyvfCeTsivvpc5ekzTc/6gkgxIMPpgHdWgksEw3xVAYjXmz69LbOi1Zuks97jJRl0wfZrXmfs+gv6aImfLp2aKyXshmMyN0gETifVOADp60t1RQKPl4EGA00nIA5JrQSxzENz90TgDJ68vQFSZY0sZ0SZE5F7mYaT47BBbOUGdKm0oNUT654PiJ3z4ycxcC47wW13+/lK9cFTnfMMwTO4juGWeFuJY5jvoFwHpX3gBWmVuIEAmdf1tEKUytxfFmmpyEvK3W2EsdVXayktRLHVf7+Gh4TdcZ+8Lfv3JPsWdLbJoHMvGKiDOb7PQ3HMVFncn8aWjpmykAFPmY48y4kQAIkQAIkQAIkQAIkQAIkQAIkECUCXAMfJXxMTAIkQAIkQAIkQAIkQAIkQAIkQAIxQ4AKfMxw5l1IgARIgARIgARIgARIgARIgARIIEoEqMBHCR8TkwAJkAAJkAAJkAAJkAAJkAAJkEDMEKACHzOceRcSIAESIAESIAESIAESIAESIAESiBIBKvBRwsfEJEACJEACJEACJEACJEACJEACJBAzBKjAxwxn3oUESIAESIAESIAESIAESIAESIAEokQg7rdKopQDE9sI3Lp9V1as3SqHjp3Wf7iQJlVy23V3BxcuXZMP2veTXNkzSeaMad1F1df2HDgmB4+cVHtsZnAad9+hEzLrj9Vy4vR5Sa/2x06cKIHTeO4CUZ81G3eoOm2TbbsOSNIkCSVt6hQRkly7flOWrt6i/jbL5avXJVOGNBI/XjxbPKv5GAnu3bsvy/7aIvGCgyVliqRGMD9JgARIgARIgARiiMC6zbsEfQ30ac5duCI5sjrvbzgWx9v+DPoQi1f+LXlyZpa4ceznlR48fChL1DVcP3LijO7PJE2cyPGWHs+xB/c/uw/q/syqDdvl/oOHuq8SN679/cJUvL827ZKFKzbqeidPmkRSJn/SD7Gaj7lAG7ftlZNnLki2zOnNwTwmARIggUgTCI50SiaMQODqtRvSf9hvOvzi5WvSstFbkq951gjxnAXcv/9A/1Bev3nL2WW7sGMnz8nX342R1CmTS/nSReyu4UepfutecvTEWSlV7Bk5c/6ydB8wQRrWeVU6ffK+XVxPJx26D5N1m3er+yTTUX/8eZYeYJjy0zeSKkV4GPL/oEM/uXDxqh5MGDt1geTOkVnGD/7SFsdKPkZZ8OPZSdVtmRoQ6Pjxu9L8/WrGJX6SAAmQAAmQAAnEEIEJ0xZrJfb6jVuSWQ3Mv1imqKU7e9OfQd5Dx/5Pps9bKZXKFbP1G3CjK2pCoKnqXxw+dkZyZcsol1Uf64cxM2V43/ZSutizlspiRJq76C/p+v14SZAgvqRTExGjp8zXExvfd2kplcuX0NHQ//iy92itvOdU97ui7jdw5HT5qU87eaFUIR3HSj7GPfG5YPkGnWehZ3JJudHheZiv85gESIAEIkOACnxkqLlIkzVzOln1vx/11UIvNXURK2rBbzX9Rv+YIZfUxSPO7k+ZuUT+PXhcZozuLvjBgHzVZ4xMVuEf1n/TskUA0lVQP9Ztm9WWIgVyC37YZs5fJT0GT5Jpc/+UVk1qIoqMn7ZQroXclN8n9tEKPEbrG7TubRfHSj46M/UffpzXq0EDCgmQAAmQAAmQwH9HYOygL/TNO3Qfri3+fF2S4RPnygj150oGjJwmR46fFUwalCySX27cvC31P+ktPQZOlLkT+khwcFxXSSOEZ8mYTr77uoVUr1pOMOt+6sxFqf1hVxmiBg8MBX7Lzv1aee/SvpG8X6uK3FMTKw3b9Jbvh/+m7tdb52klH+PmsFzs0n+cJIj/xCLRuMZPEiABEogKAXvboajkxLQuCWDGvF6rnlqxNiLBZAxhG7buMYIsfY7s11EWTOknxQvldRr/0pUQiRMUJOnSpLJdL1owtwSpsIehobYwKweN1aw9lHcI0r/1Wnn9eVbNuhsC07ZK5YrbTPkL5c+pZ/6XrNpsRBEr+SAyTP4nqYGGwd9+otPinhQSIAESIAESIIGnh8CnXYbKxOmL7QrUfeAEPQBvF+jhpNE7r+j+TNvmtZ3G3LB1r+7rQHmHJEuaWE9EHFV9qmOnzjlN4yqwTMkCUlP1YQyTeUy4lFKz+GfOX7IlgZl+QjVDX7f6SzoMive7NSrLwaOn1EDCGR1mJR9ExPLFtp2HyjvVK1m2XNA34H8kQAIkYIEAFXgLkKIa5dbtO7Lr3yOCteCG3L//UIdBkfdGsqj18TDtcrWm/Y0qZSVevGA9arxo5SY5f+mqTP99pVR4vohkUGvhoyJYP4aZ+Fw5MulsMDoNE7N8ubLYZYtzs5Jvd1GdOOaD6+u37JGeP0ySrh0a20zVHNPxnARIgARIgARI4L8lAB87p889UXxRGqyTP+6lUp08WRLdn0mbKqJvHaOGaVPbWxoa6/Axgx4VefTokezYc0gvCzTywTp/9K/MM/v5coUvgzx74cnEhREfn87yCVHLAlp99YNg8uSbtg3M0XlMAiRAAj4hQAXeJxifnkyKqhnzDh/V1T+uX/QcJS/X6SA31QDCoO6to1RIOJYbNGqGXp/29hsv6rywPg2SOFFC/Wn8h3PcE85nHMVZPvjhxzr5pu+9IXXerOSYhOckQAIkQAIkQAIBRqBE4XyyesMOWbnuHz15cPPWHT0BAAyYGImKwHwfEyhmPzvo0yRJ7NifCXcAjMkKZ+KYD/o97ZSFQoL48VW/6xOJ4+CUz1keDCMBEiABbwlwDby3xJ7y+MvXbNWK9oBurQTK/AzlGGbijMXSQK0bm67WxUdmLRYc47VRP0gwIRvVv6PNI2v8x+u6MAJtFpjqw4zf0Zusq3y+6DVK8ufOJvVqvqw93Rqm/iHqx/X8xSuSIV1qc/Y8JgESIAESIAESiOUEsBYd/Y42nYdoRRh9DWN2PGP6NJGu/dQ5y2XU5HnSuO5r8mql0rZ8YL0Y6tCfMc6xK46jOMtn3G8LZff+YzJ24BcCB334u3P3njx48ED3b1Ipp8CR6Yc53pvnJEACgU0g4hspsHn4pPYwM3cmYeI83FncyIb9qn6Y8ufOKtVeLqOzgCf3/HmySSflWXXt37ukSoWSXmUNs/+2XYbIzr1HZJjyxPp8iQK29KnUFm9Q1K8rxzJmuX7jtt7+zTzy7C6fkOu35MDhk/LKe5+ZsxF4tIfzvX+WjbUL5wkJkAAJkAAJkMB/R+BRmP3AfXSUBNvwzlHO43buPayW612XjOnSKG/1f2p/OZHdkg0K9uDRM7RvHsededIoU/7Dx0/bVQXm8JA0Dqb8rvJBfwYKewPl/M5RqrzbUfejDKd5jtd5TgIkQAJWCVCBt0rKi3iGQmvMUKdIFr6HaEhI+A8BsgqLph+/C2rNe2joI21uZjiBM/aiv6wc3BmCbe4wzpA+bUojKMIn1s+3Vuu4zqst4sb/0EnP6JsjQUHHevjtam28WbbvOaj2c32yLt5TPr8M66zK/MTBHsr/ZqOvtGnbu29VNmfNYxIgARIgARIggRgkEHLjpsRXJuGGYF90c38G4WGPomeCApMEhtPe23fuaS/xcJxr7rvAtB4m9SnV9rauZrcxe99v2FSZOmeFtG9RR1o0qG5Ux/aZV/nvWb5mi0BpT6HW50O2q3Xyuq+TLdz3j6d8WjZ+S+q/XcWWJw56qt17Ll4OUdvRfaocDLvuc9kl4gkJkAAJuCFABd4NHG8uYfs0KMXJlZfU2Qv/0i/8N6uW1VnA2yn2Rp8wY5GemT597qKaXV7oTfa2uNgP9e79+4IfLCi6uG8i5TUV+UPwwzZJmcxja5T6b1eVi1euaVMxOLCDB1YItmJ5uW5HwY/VnHG9dJiz/7CfPJy6YE39OeXABX+GvFy+pDZlq/X6i8pkf7r2Hl++dGFZ9OcmOXDklN6uxYjrKR/sL2sWwyQfP8ZZM6UzX+IxCZAACZAACZBANBKAD5sVf22VHFkzauu4bTsPaqXXuGVFtV87rOOWrt4siRImkLmL18oONUv+SsXnjCiWPi9cuqb7KKfOhjuk+/fgCUmRPIlyjJtV4itzdshyVY5sqg914vQF3ZeJExRHPnXwWv9ZjxGyTm0/+8fkvtoJnbObD1Kz7r/OXq7LCEd4KLshBdXuOehroI80atLv0lVt/fbJB7WUM94rMmHaIu1FPq3aOx5iJR9D+Tfyh1+g+PFvq3qkN4L4SQIkQAJRIkAFPkr4niTeuvOA9Feju5Bn8mSXzu0a2imf2Df9R7XHeZN2ffUIcc3XKui1XUFiv1Wa4/mTO4Qftes6VLCFiiHvfvStNpmfM763Dmr34Tt6zdU4ZX7+869/6DD8MPXr/JEkUIo+5O/t+7Tn1IZqCxd3gi3pINib3VE2zB8u8CDbRK0hO3birAwcOV3vlYotWprVe0PeevUFWxIr+dgi84AESIAESIAESOA/I4Alb9/0DV+6llqZscNxbd0aL9nKA0V3i+pHYH94SMWyRcO3knXY+tVTf2bG/JUyUinMhrT4fIA+xFa58AYP6fjtcD1ZAYW+WME8MmPMt2pgIYO+hv/gNA79rxdKFbKlsV00HVxSM+CQZcpPEP7M0r1jE4G1H/pK8B/UbcB4WbF2m45SvHBe6fVlM1t0K/nYIj8+ABYHNI5ReE4CJEACXhEIUuu1o8fuyatixI7IV0NuyMOHoS5NpB4p1FB2s6pRWGN0Obpqjhn6M2qbF4z8Zs6UVq9VN+7Ve8gUWbRik/w56weX5mZGXKufWPOFbWUwwuzKhM1qXoxHAiRAAiRAAiTw3xHAb/rVkJtq3Xkql57UsV1sokQJbI5to6O0mJ2/r7ashTWAsYe7+T6bd+yTpu36ych+HfVAgvlaZI/RVzupZvyx73xq5XSOQgIkQAJPGwHOwPuwRVIpk293grVchqm7u3i+uJY0SSLtvM5ZXhvVnut1qlfyqaINM7q8pnXvzu7LMBIgARIgARIggaefAH7T8edOMjksf3MXN7LXPC2j27hlr56Rf7FMkcjeIkI69NXMs/wRIjCABEiABP5jAtwH/j9ugJi+PdbNV3nxOWlQ2735fEyXi/cjARIgARIgARIgAW8IZFfm9N982lCZqNsvR/QmD8YlARIgAX8jQBN6f2sxlpcESIAESIAESIAESIAESIAESCAgCXAGPiCbnZUmARIgARIgARIgARIgARIgARLwNwJU4P2txVheEiABEiABEiABEiABEiABEiCBgCRABT4gm52VJgESIAESIAESIAESIAESIAES8DcCVOD9rcVYXhIgARIgARIgARIgARIgARIggYAkQAU+IJudlSYBEiABEiABEiABEiABEiABEvA3AlTg/a3FWF4SIAESIAESIAESIAESIAESIIGAJEAFPiCbnZUmARIgARIgARIgARIgARIgARLwNwJU4P2txVheEiABEiABEiABEiABEiABEiCBgCRABT4gm52VJgESIAESIAESIAESIAESIAES8DcCVOD9rcVYXhIgARIgARIgARIgARIgARIggYAkQAU+IJudlSYBEiABEiABEiABEiABEiABEvA3AlTg/a3FWF4SIAESIAES8AGBsLAwuXHztty+c88HuTELEiABEiABEiCBmCAQHBM34T1IgARIgARIILYSKP9WG7l+45auXlCcIEmcKKGkTJ5UniuaX+pUryQlCueLdNVXrd8u6zbvlqbvvS5ZMqaNVD6u8jhx+oJUa9hJns2bXf43tmek8mYiEiABEiABEiCBmCXAGfiY5c27kQAJkAAJxDICD0NDJV68YKldraJUr1pOihXMI/fvP5C5i9dKwzZ9ZMwv8yNd4392H5Spc5bLxUvXfJ5HooQJpGzJgrq8kc6cCUmABEiABEiABGKUAGfgYxQ3b0YCJEACJBAbCSRLmlh6fPGBrWqPHj2SJas3S5d+42TouNmSNVM6qValrO3603CQPm1KGTf4y6ehKCwDCZAACZAACZCARQJU4C2CYjQSIAESIAESsEogTpw48kblMtqcvm3nIdK531ipWK6YJE2cSGexdecBGTFxrpw6e1EuXQnRM/h5c2aRRnVelddeKq3j/Dp7uSxYsVEf9xk6RZInTaKP69V6WV6pWEofL1WDBJNnLpX9h09I/HjxpPCzueTL1u9LnpyZPeZRqVxxadVpsBRVFgPtPnxHx5/2+5+ybPUWadustsxasFqZ7++Se8qaoHypwtL986YScv2W/Dhmpvy9fZ9aO39XShcvID3VwEXa1Cl0euM/T+Uy4vGTBEiABEiABEjAOwJU4L3jxdgkQAIkQAIkYJlApbLFlEL+vCxUiviuf49IuecK6bQHj56Sjdv2akW7TIkCcvvuPdm++5B0/Ha4/NizjVbQoSDfvXtfx79+47Y8fBiqj+88Dhs1eZ78NH62BAfHlfKli8iZc5dk7d+7ZMuO/fLH5L6SKUMarWS7yiNUmf6jDDD/N+TYyXM6bNM//0qQCsyjBhUwwLDwz01y5MRZOXnmgtxRTu8QjvKs3rBdRk76Xbp2aGxkIVbKZYvMAxIgARIgARIgAa8IPPnV9ioZI5MACZAACZAACVghgFlxKPA79h62KfAVlWK/YsZgyZg+tS2L7XsOSYNPesu8Jeu0At+iQXW5eeuOjJ26QPp3/liKF85ri3v81HmtKOfPnVXGDfpSUqdKrq9hBr3XD5N1GijV7vK4owYNXEnFMkWl+2dNJEO61HLz9h2p9UEX2XfohFQuX0K6dWgiML9H2d5q8o2s37LHlo3VctkS8IAESIAESIAESMArAnRi5xUuRiYBEiABEiAB7wjkzJZRJzh89LQtYWY1Ow7l/WrIDT3j/btS2jEDHy84WOAd3pMsXvm3PHj4UJvcp0yRVLDmHn+vV35e4saNI/8ePO4pC7fX2zavrZV3RILZ/3NF8uv47VvU0cq7Dk+SSEqq8BOnz8v5i1f09egul74J/yMBEiABEiCBACbAGfgAbnxWnQRIgARIIPoJnLsQrtxmz5rBdrNr129Kl/7jZLXaJu6R2o/dLI7n5mvG8fFT5/Rh1+/HC/4c5dzFq45BUTpPqpR1yKPQR3b5JEmSUJ/fvHVXKfwiMV0uu8LwhARIgARIgAQCgAAV+ABoZFaRBEiABEjgvyOw7+AJfXNjFhsnH30xSPbsPyovlC4sdd6sJLlzZNKO4Go0/sZSQW/dvqvjfdSwRgQHcriQJHG4Ym0pMwuRsL+9M4mrnPWZJabLZb43j0mABEiABEggEAhQgQ+EVmYdSYAESIAE/hMCUNLnLV2nHc0VLZRHl+Hy1etaeX82b3b5ecDnduVypShjr3mz5Hg8m1+icD6pWLao+ZLLY8c8XEaMwoXIlCsKt2NSEiABEiABEgg4AvZD5wFXfVaYBEiABEiABHxPIEyZxWMLttZf/yh3793XW60ZW8hdunJN39Ds/R0Bh4+dkduPZ9aNEqVInlQfnjl/2QjSn1h7Dhk+cY5eC69PHv8Hp3OrN+6wBbnKwxbBhwfelMuHt2VWJEACJEACJBAwBDgDHzBNzYqSAAmQAAlEF4EbN29LN7UWHY7lMMN+VG25ZijdHT6qKzVfq2C7da7smSV1ymR6W7l2XX+SgvlzyiG1rdyyNVsjKOOF1DUI9l6/cOmq3pO90DM55aUXikuF54vobePgIb7W6xW02TzM9Veu/0cKPZNLsIUdxFUe2L7O1+JNuXx9b+ZHAiRAAiRAAoFAgAp8ILQy60gCJEACJBBtBIKCgrRi/b+Fa7QH+FQpkmkFvXa1ilK3xktStEBuu3vHV/uuD+zWWj7vNVKW/7VV/yVKmEAa131Vps9bKSo7m5QpWUDaNqsts1XePyglHvJ12wb6c0ivtnoruV9nL5Mff56lw/AfzNirVChpO3eVh6HAxzHdEHWBGJ9GJkYcRxN/I14c0xp5q+Uy8uYnCZAACZAACZCAdQJByszP3v2t9bSMSQIkQAIkQAIkEEkC95Rp/eHjZ3XqXNkzCpR4V4KfauyxnixpYknzeM93Iy6uYXb+ashNwfZ0yZMlMS7ZfbrLwy6ij06slstHt2M2JEACJEACJBAQBKjAB0Qzs5IkQAIkQAIkQAIkQAIkQAIkQAL+ToBO7Py9BVl+EiABEiABEiABEiABEiABEiCBgCBABT4gmpmVJAESIAESIAESIAESIAESIAES8HcCVOD9vQVZfhIgARIgARIgARIgARIgARIggYAgQAU+IJqZlSQBEiABEiABEiABEiABEiABEvB3AlTg/b0FWX4SIAESIAESIAESIAESIAESIIGAIEAFPiCamZUkARIgARIgARIgARIgARIgARLwdwJU4P29BVl+EiABEiABEiABEiABEiABEiCBgCBABT4gmpmVJAESIAESIAESIAESIAESIAES8HcCVOD9vQVZfhIgARIgARIgARIgARIgARIggYAgQAU+IJqZlSQBEiABEiABEiABEiABEiABEvB3AlTg/b0FWX4SIAESIAESIAESIAESIAESIIGAIEAFPiCamZUkARIgARIgARIgARIgARIgARLwdwJU4P29BVl+EiABEiABEiABEiABEiABEiCBgCBABT4gmpmVJAESIAESIAESIAESIAESIAES8HcCVOD9vQVZfhIgARIgARIgARIgARIgARIggYAgQAU+IJqZlSQBEiABEiABEiABEiABEiABEvB3AlTg/b0FWX4SIAESIAESIAESIAESIAESIIGAIEAFPiCamZUkARIgARIgARIgARIgARIgARLwdwJU4P29BVl+EiABEiABEiABEiABEiABEiCBgCBABT4gmpmVJAESIAESIAESIAESIAESIAES8HcCVOD9vQVZfhIgARIgARIgARIgARIgARIggYAgQAU+IJqZlSQBEiABEiABEiABEiABEiABEvB3AlTg/b0FWX4SIAESIAESIAESIAESIAESIIGAIEAFPiCamZUkARIgARIgARIgARIgARIgARLwdwJU4P29BVl+EiABEiABEiABEiABEiABEiCBgCBABT4gmpmVJAESIAESIAESIAESIAESIAES8HcCVOD9vQVZfhIgARIgARIgARIgARIgARIggYAgQAU+IJqZlSQBEiABEiABEiABEiABEiABEvB3AsH+XgGWnwRIIHYS2LrzgFy4fFVXLm6cOJIhXWopUiC3xAkK8ljhE6fPy54Dx9zGK1Ywr2TOkMZtHG8vzl64RuYsWitTfvrG26R+G3/7nkOy//BJeadaRQkOjuuTepw6e1F27Tui8wqSIEmUKIEUyJtD0qdN6ZP8rWQyf9l6SZ4siVQqW8xKdJ/HefTokbTvNkwehj6Sob3a+oytzwsaAxkeUM9X1wHj5Y3KZaTpe6/HwB3/m1v4+pkLVc/O0jWbbZWJFxwsWTKmlQL5ctjCovvgyrUbsmzNFnm++LOSK3um6L6d0/wPHzsjX383Rl57qbQ0r/+m0zhPUyDarX23nyT0UZj81PtTiRuXc21PU/uwLCTwNBCgAv80tALLQAIkEIHAz7/+IX9t2qk7L+jQQLJlTi8j+3Xw2BHcsHWv9Bw8KUKe5oDvvv5Qar5WwRwU5eOLl0M8DhxE+Sb/UQbnLlyRqu99Jj/2aCNVKz5nKwU65xOnL5Y3q5SVpMGJbOFROdi8fZ906T9O4qiBGwkLk0fqD8dN6r4mn7d6LypZR0jrql4//jxLciuF479S4KfOWSFrN++WaSO6BpTyjmfph59nyo7l42xtlT9PNqV8PS9Dxs6Sl14oLjmzZbRd88cDZ3VEPXz9zN27/0A+7zFSI4ISaLxHMRCK92iqFMl8iq9+616SJVM6GdC1pS1fDMbhXdzjiw88vrdtiXx4EKbeHT0GT9S/Iw3rvOrDnH2TlbP3D9qqXYs6Uq9lT5k8a4l88N4bvrkZcyEBEog1BKjAx5qmZEVIIOYJ7NwpMjK8fyitWokULerbMhTMn0Nmjukh9x88lM3b/5WO346Qz1SHdPa4nm5vVLfGS1K72ou2OI3bficJEyaQMQM+s4UFx/XNbLEtw6fkYMe5HTJiywiJGyeutC7VWgqnL+yTkkGJRmcY/8zStlltaV6vmiRN4hvl3Zz3ol/6S9bM6eTi5WvSb9hUmTB9kbxcoYSULJLfHC1Kx67qNXtcL8Xwv5n5unDpmgwd9z/5qGF1gfIaSILn69HjATtzvTHzvnT1Zun5wyQZP7iT+VL0HIfeFTkxU/3NEslSTSRnA5HgpD65l6s6Rtcz1/Gjunrm+d69+zJ/2Qb5dtBEGTV5nnzdVtXJhxKqrEbC1KyxWQrlzyl/zRkqSZMmNgfH2PGcRX8JrITANkH8eDF2X6s3cvX+yZszi7RqUlOGT5grr6vBq0w+thazWj7GIwESeDoJUIF/OtuFpSKBp57AwoUib5qsEUeNElmwQKSa6uv6WuLHC5bypYvI22+8KL/8b5ns3ndUeg+ZIh83rCGVy5ew3e7PddtkzC9/yMBurSSrmgkyJEiZ3cP0HiakhsDM/ruhv+rOXXj+heUr1aFNocymIej4zV28Vnp+0UzGT1soh46dlqbvvi5VKpSUSTOXyB+qI4zZpUzp0+gytPvwnfCslZKLdJNnLpXT6vorlUrJh8psMyZmDeftnyc1p9UML4f6f+TmkbKk4RJ5NU/UZ54+7TJU5zt49EwZ99tCzRJLBZas2iwz56+SX4Z11tcNbmgrZwymzFoqi1f+LaPVYErSxE+U/u+G/iJXrt6Qgd3VSJCDpEuTUpq//6ZOd/Doaa3AHzt5Tr5SZrHdOzaxmQRfu35TWnYaLGiLcs8VkvMXr0g7ZYZe89XysmrDdtm++5AUUINCjeu+Ki+XL6nv4qpe/dWAQWZlbtzmg7d1vE69R0vqVMnlvprVXP7XVsEzhWUD79asLANHTBNYfWRIl0oa1K6qBo8q2mrw9z//qpnj/+llBsmVElPlxeek48d1JZEaUHIlU9SsG/J3nHkzygDz+mVrtkqwmqmr/WZFHc9QTjDYhZncZUrZvRpyU57Nm11bLRQvlNfV7XT4ynX/yE/j58iR42e0spAzWwbdxkOVCS8EnDBwYjZh7z5wgqRMnlQ6KAURMmrKPJm3ZJ1cuhKiFj4EyTN5s0nb5rWldLFn9XVPz8bmHfv09xtKTb1W4YN05UsXFgwS4fuLtvj4y0Hyz+6DUqJwPp1ntP23Sr3czv8Znv3peSL71fP/5m517nkJj7syuauj+Znz9OwePHpKun4/3u07MHXK5HZFSZAgvtSpXknGTl0gSG/I1DnLZc3GnTKqf0cjSBb+uUl9f5fIb8oCBM+ip7b7adxsOaS+mydOX7C13Ret6kn2LOmlrXp2Pm/5npQq9ozOB3m9pb6TeBecPndJh/f56kOZ9cdq+X3JWrlx87Z+18Pc3Xgf45lHufF8IU02lW+LBtWlxisv2Mrs7GDkpN/10gsoxGY5c/6y9P5ximxRzxx+F4qp78eVa9el79cttKWAFSZY5tVv2K9y9vwVuX33nmRU3/861V+SZvXe0Lfy1IaI5Or9g2t4T41X79qJMxb7fLAF+VNIgAT8l8CT3qz/1oElJwES8AGBUqW8y+TQoYjx69cXyeteT4iQaMuWCEEuA9Cxw8z5M2pW8vqNW3pG1qzAj/9tkTITDbVT3p1ldvP2HWnQpo/uisMsO0Tl9b8Fq+XIibMybWQ33WHFLOiWHfvl7eZdJW+OzEqZS6NNUPv+NFXQuXuhVCF5763Ksv/ISa3QGwo8zFYHjZoutV6vIMmUwjZ+2iJ5oJSq/l0+dlYUl2Ghj0KlzNgyLq87u3DwysEIwe/Nek/ypMoTIdxVAGbuN324KcJlmJL/e/C4FCuYRyuFQXHCFRnMjhvr1ZHI4AZF0BkDdOIxm/774nVa2UUamJH+NvdPaW8MgiDQQY6dOqdDSjxWRG+pNtz17xG5dVvNlD6W+/cf6jAo8pA7d+/rcwz4vPFyGT2jtXjV3wJFeP384brj7qpeUHCw/tyQA+r8wPKTAkW4sTLF3b3/mFZYMbhTXCmTH6hOO0z/oVS9WKaoYNABz0+zjt+r8yLS/bMmcvDIKfXsrNBWDF3aNTKyjvC598Bxea1S6QgzhkYZCj+bS96v9bKcVMoSFKf8ubPaBiS6q7XiUL6wXrxAvuwyfd5KadKur/w+oY/LQSQolW06D9HWDu2V6S7adppqD3yXDNl36IT2Q2Gc4xODWulSp7AF4ftZqVxx/f18qNIij0++/lFWzBisvwueno30aVLpupy/eFXPOiLjvLmeKF74zqVV9wMfrxT4o1OUAj7EVk6PB5h9D9ljHy1kr8h8NRARzwuz81wNRZ5pb5ePuzqanzlPzy4UUk/vwNt37tndGydoo8tXQ6RalSfvFnz/9h44ZhcXgzD4fmE+Hd90T21XtFAeSaEGczCggxljCHxW3Lv3QOdz/eYtHYZ8oPgeP3VeK+kwF4eSWvXdjpJGtS0G2x48fKje7YtV+lTS8J1XdLr+w38T+BjBwCC+gxgE/KrPGMmYPrVtgEhHNP2H9zoU9W8/t1fyYYnQ5NPv9ABXrTcqSEHlE2DF2m26nLfvhL9PrDDB70jOrBn1gB0G59Zt3qPf/ShTNfW+8dSGGDhw9f5BNXD99crP6/euqVo8JAESIAGhAs+HgARIQBPYujXqIEJCRHyRj1GSBw9C5fylq3It5IaeIZq3dL1eax1PzcjXq1VFMGN1QClFUGD2Hz6hZ+Ywk+NJ/rdgjZrtvS6Th34jzxUNN8fOkTWDnpHZsGWPvKBm/SBYdz36+462DiLK8kXPkWrtfHn5Ts3UGNKifnXjUHe6Fkzppx2gIRAd2KlzVwhmkPSabltM9wcws916NuqNcu2u6jB7kU9wHOc/C++omTvMsFZ5saS8UtH9aA86nq4YwIFW8cJ5Zdrvf9oU+BnzVypucQX3MMvqjTuUQpBED6z8Onu5PF+iQKRMynt3aq4HE5A32vbtZl0EM+Ow6vCmXlBOh3/XTg/wQMlYrWb1X1eKMvwpQOqq8per8YnqyO/W9xs2frZA0RrZ78nMJmbFYb3hToE/oAaFqr9STufp+B86/MP7ttdlwLVtuw7IqnXbtQJ/VikrMJF+X303OrdTyqMSzFBWrN1OJqiBJKxDdiajJs1TylcSWTilv81h1qkzF3X9nMV3FYYZVwjWWl9SSiLa9Ju+Y/V31PieuXs28B1EG6/dtMtupt+4H74/GECCUzuv5O55kStR/y7JjQNe3VYyVI4Q31MdHRO4e3atvgP3q3ckFF7MMM/6Y40aGIov1as6f74c728+d9d2eC7TpUkh2TKlt2s7PEeOgnz+mNxXD+rg2vGT52XTP3tl/qTvbJYpGKRZ+/curcBjkBADX60avyWtm9bS2cEnwotvt5UFyzfa3s+O9zGekxKF7Zfc/K5m8aHYY0kV3gGQHEoRX7V+u2MWbs9RZ/xBMGhYUC0XwDthu7IQgQJviLs29PT+KVkkn/yxfIORFT9JgARIQBNw3lMjHBIggYAj4M1MOOBMniwyVFmVmuVTZW3buLE5JGrHmJF6uU4HnQlMaDH78mWb9/X522qGe4gyFZ6mlONuyowaHbzUKZOpmaWyHm8KU0+YMEMZMAQm15CDalbRUOAxUGCY/+prqiMM896KjzttOoH6DzMuhsRRM0rwXm4I1i5ipgwzxZiRtyqYCd/ykRfmCSrjCf9MkOGbh9vdokO5DtKgSAO7MHcnMH2OqnhiUF8pmF+qWXAo0SVUB3WmMp19UykUmL0zy6DRM/QpZsxKKy/W4wZ/ab5s+Thliif5ZnrcVjB79VYwmABzYgiUELRzimRP2hTnWI6B2TvIvseKZq0Puuhz/HdZKVGYBcXsnXkJgREBygo8d2fOkNYIsvtEXYwy4EJGtYQDygjksLJ6gJ+Css8V1Of4D2b/+dQAl9lk2nbx8QF2EcDzH1Vv17B0GDByml6W8vDhk9n7u/eezAR7ejYcy+Z4ju/Tjr2HHYPdn+dqJM6UaZeJwh6KrKqhRt9Mymdc1c6V1bohb9bBJ8zg8hZWL7h7dq2+Axev3CQr1LIPLP/AThELlG+JyOzAEdW2M+qMfMzvwrRK8cf3ybysBIMBsPqAYNkMBkBher909ZN34h1lYQBzeleC5xoDU4nVLhZmQTiWE5R6vLTDfM2b45u37ggsA+DIE99pQ+4qyx+zuGtDczxnx3jecR8MznEdvDNCDCOBwCRABT4w2521JoEIBJ574lg8wjVnAXmU7gsL2ynKOhXSSPWRe/QQSenDnb5yKW/T/Tp/LEkSJ9TmvejkGYIOIGYpsfUS1kJiVrOxMoeHAuVJ0JHFmmGzwoJ7QB4qc3dXAvN4CMwlrUqcx6bmVuMb8aBIP5fJu0bJlTKXNs+esnOKxFH/GhdrLN0rdZcUCZ6YORv5x+SnI4NX1XZO6PjCMkErrMoaAmvHHWWeMvvOkimtsnoYJTB9X6Y679gKyiyOTvXM15wdx/Wh80JnFhVGGBRpDDxUeL6I1FSDTY6SUM2COhOVTMvjcQJnUezC8Awb3sXvPwh/Po1n2YiYWA1WYRmHK8FyBLNC5Sreo7AnSwoc41xVVjKN2vaRfLmyyhC17V3+3NkkRM1K1mnR3TGq3bnjs4GLjxHYxTNOMHgBtl4JFGlvlekXfhHZ3Uvk4lo1ClJSpODXyia8kle3dRfZyxrorByfXavvwHbN39FO7OCv4rMeI2TwqBkyoFtLu4Egr5mqEjlrO3d1dnXN+M6YrwcFPXEgaQwAweIAFgxmSaMGqFwJ6uRsQBKDqQkTxIuwRMUxH09MwBKDSeBbusSzeiC3QevejtnYnTu2od1FJyfGYF1knhcn2TGIBEgglhAIjiX1YDVIgARimAAU9WHDRPr1C79x0ieTnD4rCfb/xnpfV1L/7Sra8REcl8GkuZ5yKGZF0AmEWSJmeIw9kTdu26uTwjmSK8GAAgTb2xmz9Dj31jweaaJDUidKLcOrDZd+VfvpjmvS+L5rlISPPTgbgxhRKT8GYgxnWoeUVQPMq+FszZmgA9tHmaifOndR7+UMR3FYA5siWXjdQkLC19YibZgbBdNZ3gjzZb3M90C5c6pt6K4oxRaOD42OOOJoxUJddyZYN4ztvc5eCJ9VdxbHVViOLOHP50blUK9syfBZeKyD3r3/qFRVzvNcCfYG36E8dZvFUVmHdYSZNeKaPY7DsRwc6H3Rup62lsD1u8qxl7eCgQ3wwffZPGBn5IOZyGfU4EC0Sybl+BF/d86KJMrk09t5qqM3N/PmHYjBr6Mn39Z+E7C7A/wdQOAoDrO8GAgyBjXD1Iy3t5JIzWrfvW8/++xtHs7i586eWQfDIsrxOXanZMNXCkzb76qBtISqbIbgeQ+5fkuOKp8nxt70Zn8PiOeJCSyx4PMCVmHvq9+hyIqn9w+ed1jqRMZiIrJlYjoSIIGnn8CTIc6nv6wsIQmQwFNIAIp7dCjvVqr6TJ7s2jM2nGlVqfBcBCdbrvKopTpdmIHH/sTwvoxZ/BETf9czKMaaRmdpcytndlij+z/lTOmHMTP1uvsFaiCgllpT/TRJsvjJxJfKO+oGU2z4Gpi7aK12IgZuURE4AMRE6lHlTb5B7XBHVa7yQ1sN69NOUqklEm2VszWsq4UCgvaYMGORdhYH79Uffj7QVRYuw31dL/ONmr77mvZ837nfWL1zAkzM4Xnb06x0/jxZVbrD5qwsHefJmVl79IY378nqPnBO92XvUQJz9no1X3aZB5YvwJcEPGJjrXSfIb/onQXMCSqWKyZrNu3QW7lhAMuYfTTiFC2QR5tnw7cBnJThe4E43ko55agOgr3S4TRxp3KkZgiUpp3/Ho6UHwQjD68/fay84/7u6uht+bx9B7Zs9JZe//7zr39op3C4H9oWgy9D1NaFcLw4YuJcGTZhjrdFUUs3Cun065UfETwDxlISrzNySIAdPCqWLSpD1W4O8IWB9z3ugZ0rvleWPK7E2IIR28iZBcusMKAG7/izlPPSScrLO5b0mMUTEyzpgud6+LvA2vn16vNrtSsGyuaNeHr/oOxGPbzJl3FJgARiNwEq8LG7fVk7EvBrAs7MHx0r9Krapg1ieCt2vO7sHLMZg3t8oreBa/XVYO3NOK4ydYeSiLWREBcTpNJfmfRjPTY8J9du3k2nNdYrO0tjmIeaZ2CdlckfwrCt03HlDb7uR92lfbefdJFRL3M7WWWQIV1qKVowt2RQnqYdZ9WcmebC+/gI5bwNs2ktOw0SzCxjn+SLyqs1vKz3GDRJShV9JrxMqkRmiWMyx7WFm6I4rZddreCJGwlMiXCmgxzD1PnjoJqvVdDO5FZv2CHvteyh/wardf0wM3cnsArBkgEoVWZxXgYVaioCnk/MKsLBY9N2/QROGbu0b2SbFTfnZxzDgz68XWMrOSjd2/cc1FYOxnV8wnEjvHV36D5cb9UHb93Zsyhz5sc3R/ugPeB4rLHy8N11wATJkyPcg7zxfJjLaeTt+P2Asobt+UZPma8HOn5TOz4YAssCeDE3rGaMcH/7dFVHcDI1pa6Wp2cXkVy9A23fIwfwvZRTR1ix9FADmBjkwfP4bo3K8qvaohPfJWyDiYFKszhkoS85th082yOvj74YqJ+BfcqxqCFGzZzlgzBjVwsjvv40Re77zUeqnlh6M1VqNu0sLT4foNfDP6t2WnAlsBqBf5J5S9bbRcFAF7afxOx2d/Wcjv5lvl7qYo5khUnrpjX1Vo6ffPOjtFB1hu8KZyb9ntrQ2fsHZcHA2yK1owR2k6CQAAmQgJlAkDI/4tIaMxEekwAJ+BWBpu37KSdxt2X2uJ5elxszetiKC+vmvXUQhPXN59R2VzDpNptnel0IP0uAn4yzyklbGjUbbgx2RKYKUMReqfeZtG5SSz5upByGRVLQhseUKWzWzOkt+T9wdRtf1ctV/ljrjw45tsYyzJRdxcXMZY0mX8tHDWto/w6u4rkLxy4LMB+Gkg3HZVYEjvVQRig+mIWHR+2l0+ytGqD0YGmLo8NBI398L06cuaC3cjQ7JTOuW/3EQM015bE/vfp+YbYT7dNQbf0Iz/YTh6j16LFAHOsY2SpF5R1ovifaH6blMDGPilxWzx6ecVfPSFTyhpm/8Qw6U5Yd8545f5X0HjJF5ozrpS12zNf1bglXrunv5LZdB/Wgw4zR3aXQM7ls0awwOXzsjHaWh0GsyIqz9w8sA4aqbSLnKe/8UW2TyJaL6UiABJ5OApyBfzrbhaUiARKwQABbDWEdYoN3qlqIHTEKFAOsh/dWeUdOUF6RNpCUd9QbM+6wYIiK8o58fp29TCtmdWu8hNNIC9oQpvRWnBe6u4mv6uXqHtgXHs+ZJ+Ud6TFr2KZZbRk5eZ5b7/Gu7oVwmOaCi1XlHWmw1taT0oU6uIuD5wKzl1FR3lEWfK/AAe0LwZKAPfuPSffPmurz2PCfYx0jU6eovgPN90T7+0JRhGLt7hkx39PbY3x/sHzGivKOvOFrA35Uun4/PoJFC/KCJZA76ygrTDCjHxXlHeV0fP9gfT6WMcCqxRdtgntQSIAEYg8BKvCxpy1ZExIIOAJr/96pt4KrbmHruICD8xRXGLNNWNuMte/Y+o8SkUCjd16RssqMeZDyGA6HbjEtUJ6hmDwNsl+ZYs9ful7aNnvb5nTsaSjX01AGvgPdtwIU4+4dm8qdu/dlyswlLiNjwAn+BBImsN9yzmWCaLwAy4ABI6dr/y5N3309Gu/ErEmABPyVAE3o/bXlWG4SIAESIAESIAESIAESIAESIIGAIsAZ+IBqblaWBEiABEiABEiABEiABEiABEjAXwlQgffXlmO5SYAESIAESIAESIAESIAESIAEAooAFfiAam5WlgRIgARIgARIgARIgARIgARIwF8JUIH315ZjuUmABEiABEiABEiABEiABEiABAKKABX4gGpuVpYESIAESIAESIAESIAESIAESMBfCVCB99eWY7lJgARIgARIgARIgARIgARIgAQCigAV+IBqblaWBEiABEiABEiABEiABEiABEjAXwlQgffXlmO5SYAESIAESIAESIAESIAESIAEAooAFfiAam5WlgRIgARIgARIgARIgARIgARIwF8JUIH315ZjuUmABEiABEiABEiABEiABEiABAKKABX4gGpuVpYESIAESIAESIAESIAESIAESMBfCVCB99eWY7lJgARIgARIgARIgARIgARIgAQCigAV+IBqblaWBEiABEiABEiABEiABEiABEjAXwlQgffXlmO5SYAESIAESIAESIAESIAESIAEAooAFfiAam5WlgRIgARIgARIgARIgARIgARIwF8JUIH315ZjuUmABEiABEiABEiABEiABEiABAKKABX4gGpuVpYESIAESIAESIAESIAESIAESMBfCVCB99eWY7lJgARIgARIgARIgARIgARIgAQCigAV+IBqblaWBEiABEiABEiABEiABEiABEjAXwn8H1gN0DXOAmglAAAAAElFTkSuQmCC",
+      "text/html": [
+       "<div>                            <div id=\"aaddb82e-ec53-4881-bb4e-18630fdc82d4\" class=\"plotly-graph-div\" style=\"height:800px; width:1000px;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"aaddb82e-ec53-4881-bb4e-18630fdc82d4\")) {                    Plotly.newPlot(                        \"aaddb82e-ec53-4881-bb4e-18630fdc82d4\",                        [{\"line\":{\"color\":\"blue\"},\"mode\":\"lines+markers\",\"name\":\"PyTorch\",\"showlegend\":true,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:04:12\"],\"y\":[468.90625,469.3828125],\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"line\":{\"color\":\"green\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (no quant)\",\"showlegend\":true,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:04:12\"],\"y\":[65.21875,65.33984375],\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"line\":{\"color\":\"orange\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (quant)\",\"showlegend\":true,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:04:12\"],\"y\":[33.9765625,33.9765625],\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"line\":{\"color\":\"blue\"},\"mode\":\"lines+markers\",\"name\":\"PyTorch\",\"showlegend\":false,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:03:05\"],\"y\":[462.5,462.953125],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"line\":{\"color\":\"green\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (no quant)\",\"showlegend\":false,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:03:05\"],\"y\":[78.46875,78.375],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"line\":{\"color\":\"orange\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (quant)\",\"showlegend\":false,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:03:05\"],\"y\":[39.765625,39.828125],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"}],                        {\"template\":{\"data\":{\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"white\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"#C8D4E3\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"white\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"radialaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"yaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"zaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"caxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"matches\":\"x2\",\"showticklabels\":false},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.575,1.0],\"title\":{\"text\":\"Max memory usage (MB)\"}},\"xaxis2\":{\"anchor\":\"y2\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Datetime\"}},\"yaxis2\":{\"anchor\":\"x2\",\"domain\":[0.0,0.425],\"title\":{\"text\":\"Max memory usage (MB)\"}},\"annotations\":[{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"x86\",\"x\":0.5,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":1.0,\"yanchor\":\"bottom\",\"yref\":\"paper\"},{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"ARM\",\"x\":0.5,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":0.425,\"yanchor\":\"bottom\",\"yref\":\"paper\"}],\"legend\":{\"orientation\":\"h\",\"yanchor\":\"bottom\",\"y\":-0.2,\"xanchor\":\"center\",\"x\":0.5,\"itemclick\":false,\"itemdoubleclick\":false},\"font\":{\"size\":14},\"margin\":{\"t\":100,\"b\":50},\"height\":800,\"width\":1000,\"showlegend\":true,\"title\":{\"text\":\"Memory Usage History\"}},                        {\"displayModeBar\": false, \"responsive\": true}                    ).then(function(){\n",
+       "                            \n",
+       "var gd = document.getElementById('aaddb82e-ec53-4881-bb4e-18630fdc82d4');\n",
+       "var x = new MutationObserver(function (mutations, observer) {{\n",
+       "        var display = window.getComputedStyle(gd).display;\n",
+       "        if (!display || display === 'none') {{\n",
+       "            console.log([gd, 'removed!']);\n",
+       "            Plotly.purge(gd);\n",
+       "            observer.disconnect();\n",
+       "        }}\n",
+       "}});\n",
+       "\n",
+       "// Listen for the removal of the full notebook cells\n",
+       "var notebookContainer = gd.closest('#notebook-container');\n",
+       "if (notebookContainer) {{\n",
+       "    x.observe(notebookContainer, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "// Listen for the clearing of the current output cell\n",
+       "var outputEl = gd.closest('.output');\n",
+       "if (outputEl) {{\n",
+       "    x.observe(outputEl, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "                        })                };                });            </script>        </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#| label: fig-memory\n",
+    "#| fig-cap: \"Max memory usage\"\n",
+    "\n",
+    "plot_progress(\"Max memory\", \"Max memory usage (MB)\", \"Memory Usage\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "f962bb2f-8f48-4042-bca3-27ebd618d7cb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "displayModeBar": false,
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "color": "blue"
+         },
+         "mode": "lines+markers",
+         "name": "PyTorch",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:04:12"
+         ],
+         "xaxis": "x",
+         "y": [
+          99,
+          99
+         ],
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "green"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (no quant)",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:04:12"
+         ],
+         "xaxis": "x",
+         "y": [
+          99,
+          99
+         ],
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "orange"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (quant)",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:04:12"
+         ],
+         "xaxis": "x",
+         "y": [
+          99,
+          99
+         ],
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "blue"
+         },
+         "mode": "lines+markers",
+         "name": "PyTorch",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:03:05"
+         ],
+         "xaxis": "x2",
+         "y": [
+          99,
+          99
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "line": {
+          "color": "green"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (no quant)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:03:05"
+         ],
+         "xaxis": "x2",
+         "y": [
+          99,
+          99
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "line": {
+          "color": "orange"
+         },
+         "mode": "lines+markers",
+         "name": "tinyRuntime (quant)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2024-07-18 12:00:00",
+          "2024-07-19 04:03:05"
+         ],
+         "xaxis": "x2",
+         "y": [
+          99,
+          99
+         ],
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "x86",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "ARM",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 0.425,
+          "yanchor": "bottom",
+          "yref": "paper"
+         }
+        ],
+        "font": {
+         "size": 14
+        },
+        "height": 800,
+        "legend": {
+         "itemclick": false,
+         "itemdoubleclick": false,
+         "orientation": "h",
+         "x": 0.5,
+         "xanchor": "center",
+         "y": -0.2,
+         "yanchor": "bottom"
+        },
+        "margin": {
+         "b": 50,
+         "t": 100
+        },
+        "showlegend": true,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Accuracy History"
+        },
+        "width": 1000,
+        "xaxis": {
+         "anchor": "y",
+         "autorange": true,
+         "domain": [
+          0,
+          1
+         ],
+         "matches": "x2",
+         "range": [
+          "2024-07-18 11:01:03.9559",
+          "2024-07-19 05:03:08.0441"
+         ],
+         "showticklabels": false,
+         "type": "date"
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "autorange": true,
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          "2024-07-18 11:01:03.9559",
+          "2024-07-19 05:03:08.0441"
+         ],
+         "title": {
+          "text": "Datetime"
+         },
+         "type": "date"
+        },
+        "yaxis": {
+         "anchor": "x",
+         "autorange": true,
+         "domain": [
+          0.575,
+          1
+         ],
+         "range": [
+          98,
+          100
+         ],
+         "title": {
+          "text": "Accuracy (%)"
+         },
+         "type": "linear"
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "autorange": true,
+         "domain": [
+          0,
+          0.425
+         ],
+         "range": [
+          98,
+          100
+         ],
+         "title": {
+          "text": "Accuracy (%)"
+         },
+         "type": "linear"
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA/AAAAMgCAYAAACEYYkhAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAD8KADAAQAAAABAAADIAAAAAAwD/peAABAAElEQVR4AezdB3yURfrA8SedhBQSgkFaaFJUiogKqIANRcXCgYpYsZ5/FSv2u9MD9dTTO1FRT0VFFDtFRKQXAZUqRYrSpBMCSUjZbLL5zwxsTEgWNtl3391NfuMn7O67887Mft8V8rzTwkpUEhICCCCAAAIIIIAAAggggAACCAS1QHhQt47GIYAAAggggAACCCCAAAIIIICAESCA54uAAAIIIIAAAggggAACCCCAQAgIEMCHwEWiiQgggAACCCCAAAIIIIAAAggQwPMdQAABBBBAAAEEEEAAAQQQQCAEBAjgQ+Ai0UQEEEAAAQQQQAABBBBAAAEECOD5DiCAAAIIIIAAAggggAACCCAQAgIE8CFwkWgiAggggAACCCCAAAIIIIAAAgTwfAcQQAABBBBAAAEEEEAAAQQQCAEBAvgQuEg0EQEEEEAAAQQQQAABBBBAAAECeL4DCCCAAAIIIIAAAggggAACCISAAAF8CFwkmogAAggggAACCCCAAAIIIIAAATzfAQQQQAABBBBAAAEEEEAAAQRCQIAAPgQuEk1EAAEEEEAAAQQQQAABBBBAgACe7wACCCCAAAIIIIAAAggggAACISBAAB8CF4kmIoAAAggggAACCCCAAAIIIEAAz3cAAQQQQAABBBBAAAEEEEAAgRAQIIAPgYtEExFAAAEEEEAAAQQQQAABBBAggOc7gAACCCCAAAIIIIAAAggggEAICBDAh8BFookIIIAAAggggAACCCCAAAIIEMDzHUAAAQQQQAABBBBAAAEEEEAgBAQI4EPgItFEBBBAAAEEEEAAAQQQQAABBAjg+Q4ggAACCCCAAAIIIIAAAgggEAICBPAhcJFoIgIIIIAAAggggAACCCCAAAIE8HwHEEAAAQQQQAABBBBAAAEEEAgBAQL4ELhINBEBBBBAAAEEEEAAAQQQQAABAni+AwgggAACCCCAAAIIIIAAAgiEgAABfAhcJJqIAAIIIIAAAggggAACCCCAAAE83wEEEEAAAQQQQAABBBBAAAEEQkCAAD4ELhJNRAABBBBAAAEEEEAAAQQQQIAAnu8AAggggAACCCCAAAIIIIAAAiEgQAAfAheJJiKAAAIIIIAAAggggAACCCBAAM93AAEEEEAAAQQQQAABBBBAAIEQECCAD4GLRBMRQAABBBBAAAEEEEAAAQQQIIDnO4AAAggggAACCCCAAAIIIIBACAhEhkAbq93EF0eNk+WrfzPn335dP+nVrVO1y+JE7wR27t4nD/1zlISp/z567QmPJ918/7+k0OmU5x67TZo1TjP5vp2xSP77zpeSWj9Jxr72pMdzPb2xet0mycrOlRPbNpd6ifGesnEcAQQQQAABBBBAAAEEEAhJgRobwOcczJOPv5qugsQic2E+HT+TAN6Gr2h+gUOWrzp00+Ro1S1buUGcRUWSm1dQmi0nN1+27dxrAvvSg1V48uzIsabu15+7T3p371yFM8mKAAIIIIAAAggggAACCAS/QI0N4KfO/tkE7/F1Y+WgCgzn/7xSMvdnS0pyYvBflVrawnN6nCLpTdIkJjqqlgrwsRFAAAEEEEAAAQQQQAABzwI1NoCf+P0P5lPfd+sAGfvVNNn0xy75duaPct1fLvCsod7JPJAjGzZuk117M6VRWn1p06qpJCXUrXDOsfLpoeRFxcWqjFSJiCi/1MCB7IOiRwgkJyWIvsHgTrsz9kthoVPSGqRIdNShS7NP3XQoUj3VDVKT1aB0kS3bdsv2XXtl3/4c01OdmpwkHdu3POqNiaKiYvX5d8pvm7dLVESkpDdNk9bNG0tYWJi5ubE/K0cFzdFyXGo9d1PKPe7ak2l6y4+rX09iYqLLvWfli6TEutK4Yappy5HlFhe7ZO1vW2TL9j1SfNi1rbo2br9tO/ZKQUGhOW3P3v3yx449pUU0Ob6B+azuA1k5ufLrhi2yaetOVV8DaX9CM2mgPtuRyeEolD37Dkgd9Znd7+tRA7tV+fWS4uVA1kEpKSlRbsmV3nTQoxEyMrMkWt2QSFN5SAgggAACCCCAAAIIIICALwI1MoDXw7CXqiHakZERctG5p4sO2Ea+95VMnPqDxwBe99I/p4Zgj/9ufjlPXca5Z3aRV57+P3Pc23yD7x6hAr1M+frdf5qbAGULfeXtz+WLb+bIA7cPlFuuvaT0rbsefUUFqVvl7RcflNXrNss4NexfB/U66TnhX347V75SP0emqMhIueqy3vLYPYPLBao637wff5G/vzi6tBz3uU0aNZCn7rtBstWNhIefGSWJ6ibF7C9eqRCg6xsIF107zATwX783XNq0bOIuwvLHH5f+Kn999GXpdGIr+fiNp0rLX7R0jfzjpffLBeX6TX2T46rLzpFH7r5WLrz24dL8T7/8Qelz/WTe16+W3uD4ZPwMefGNceJQN0rcKVzdyNBrJNx10xXlbrb8sHiV3PPEq3JqxzbypLJ6/rWxoof+62kZPbqeJPomjb4xdL+6jreWuY7ucv/zvy/koy+nyQU9T5X/PHOP+zCPCCCAAAIIIIAAAggggEC1BGpkAP/NtIWmZ/TM0zqYXu5Lz+9uAvjV6zfLxi07pGV6o3JYunf3+ntGyHrV8657dC8653TRPdtrf98qP/y0SqbPXWzye5uvXOHVeHHf316TvHyHOTM+LlY9PzRPXPfE60C7W5cTzVBz3TO87vc/ZPq8JWqUwXTTe33jVReV1jhl1o/y0NOjzOsuHdrIaZ3byv4DB+Xn5b+awHPV2k3qBsLFUl9NK9CB+mS1iFz/i3uWnq+ffP7NbBO8d+3UtsrBu75xokcNVJZcJa7KDlc4pnv/hz410owUOOXkE6S7Cpxd6nrpHnQ9LWLFmt9NHZdfeKbMWbhC9OiG01Rbj1ejJ9ypTp0Y83TMF9+rIPxjc5NDfydObJNuRjR89e08eXPMRDmYl29ugrjPcz+u/HWjDLz972okRLG5KRR7uLxrrjjP3PT5bOIsGTLoYtE3AtxJ9767bwZde+X57sM8IoAAAggggAACCCCAAALVFqiRAfykaQsMSL8+3c2j7m3ufFJrsyL9xO8XyH23DSgH9uEXU03wrodJ65XT9ZBrd9q6fbe8Nnq8eeltPve51X0sdpWYNuogUweiurc4So0EaHx8qgx/5NZyvcS6jvfGTZF/v/mpzFm0QtwBvA5G//XaJ6YJundY9xK7k0sN+/5i0mzT26577wde2tsEsLrHv2wA73K55LOJs81pg/tXPQjt0e/QqAV3vdV51CMI9KgHfQ3f/8+jJoB2l6OHyc//caUJyJ9Vq9kPvnu4WcTupmv6VljELlvdTBj14QRz6tMP3yx/KXOjQt+w0avi6975QSoob960obsK86h73PX3R39vOqlH3fOvb7BoH93Lvn1XhsxV9mUXzpukvme63Se0aCKnn9K+XHm8QAABBBBAAAEEEEAAAQSqI1B+cnZ1Sgiyc35RvaWb1bDmunF15Fy1KJo76WBYp2+mH+qddx83x1SPvU63X3dpueBdH9NbnL3w5B36qeiefZ2Olc9k8uGPl/52p9w2+NLSXmS9qFt4eLiZh63n0+vAUX9GPbR8svo8B9Qcdp02/7G7tNaflv0qe9X8bT2v/f9uvrL0uH6ie4r10HPda62THn6vy9UjFHRvszvNnL/MTANoeFyKnH/2qe7DXj/qmw+efrwtJOrwWgC5uQXm85Q9r2mj42TQleeVPeTx+U/L1pot5vT1vLLv2eXy6QBbD4nXIyxm/rCs3Hv6he6pH6Nu7JzWuV3p2gRxsTFmtMZlfXqY/PrmR9n0yYRDr6tz46NsOTxHAAEEEEAAAQQQQAABBNwCNa4H3r143flndy03n1vPhX9OzWHW85YXr1hngjGNoBch08GwTl07tjWPlf3hbb7Kzq3qsbqxfy5sV/bcArWo2r/f/Ez0ful6qPiRSQf27rRp66HP1LF9q9Kg0/3ekY960bxzz+oi0+YsVr3QM6WDWhRPp4/HTzeP11x+rrmBYF5U4Y/pn/7bY+7O599qhuZ7zHD4jXPPPMX0uuuF9voMeljOUMG2niPfpeMJKug+ucKcf0/lbVEjKXTSwXjZoe7u/Ce1bSELFq9WQ+oPubmP60c9ZL6yc/R7ehj9p2oI/Q8/rRS9kJ4eKbDkl/WyXk1t0NMd+h0O8HVeEgIIIIAAAggggAACCCDgi0CNCuD1HOUpM340HjqQn6HmhpdNuodVJz2MXvem6qRXg9eBsU5H22LO23ymID/8ofdLH/x/w2XDpm2mt/wcFdjqBeUaqVXb9XsvvP5JuVr3HF78LqWed9vmXasCUR3Af6fmzT9y9yDZp1ZP14vK6d7/AZf2Kle2nS90EDxy+FB54Y1PzKrxC5esFv2jU/sT0uXxeweLnt9/rJShRiPoVC8xvtKsCYd3A9h/4NBohkozVXJQXwO9PoC+KfTpxJny4J1XyydfzzA5+198tlnBvpLTOIQAAggggAACCCCAAAIIVFmgRg2h1/Oldc+0Hm6uhziXHPGfe/Gx79Ue8XqLMJ10gKgXitNJDzn3lLzNd+T5etsxK5IeEq+Dd93WCaNHyGsjhsq9t/xFBlzSS3qe0bFCFTqw12lvpufPVPYkPYy8VfNGZr69Xul+3OEh4H3PPcMsBFg2r93Pe3brKN98+JxMfP9Z+eewIWbov17ATy9kN+K/H1VsTknFQ3oagE56W7fK0n61JZxODTxspVfZOe5jet68TnoxPD0fftq8xabH3n3cnY9HBBBAAAEEEEAAAQQQQMAXgRoVwOuedZ30vOOfvn2zws/8CSNNYK8XeJu54M+5zs2bHVq0TC8Cd7TkbT5dhr6BoFOGWt3dirT4l3WmmO6nnSQtmh1/zCJbND2URw/n1p/XmzTo8kOB6AefTS1dQX1w/wu8OdWWPPoGg15kTy9YN370cFOn3nZPbxuoU1REhHnMdzjMY9k/0pscusbLV/9mtoEr+55+/tPyteaQO9+R7x/ttV4fQC+AqG8e3fHwS2a1+p7dO1VYT+FoZfAeAggggAACCCCAAAIIIHAsgRoTwOsh7rMPB+WXnNet0s+te23PO+vQYmx6T3h36nfBoYXIRqvV3Jev+s192DzqrdauU3u66+RtPp23qZoLrdPXqjdbr/quk+6NH/3pFDOH3Ryowh9JaqSATjog11uUuZOed633rz8y6WHdutdZr74+/JUx5YJWPfpg1AcT5IPPp5Y77TK1qJ1e/E+PRNDD8juf3NrMGS+XyeYXup166zc9B75s2rU307yMVKvzuxe6c28dN2/RyrJZzfPup54oeq6/7oF/bfTX5d7/YvIcWb1uk5nrflHv08u9580L3YaB/XqbrHpfeJ2C6caHaRB/IIAAAggggAACCCCAQMgL1Jg58N/N+skEqXqVcfcibJVdnUvO7yZ6m7kffl4lmap3XM97v1atZK5Xp9crsN8w9FnpovYbb3hcfflt83YzTNu9gJm3+XS9Otifu+gXmTZ3iVxy3aOqhzZJ1qzfUi74rqx9no7pGw86mNVtPvOyu6WjWsgt80C2bNqys/QGQdlz9QiAJ4deL/c8+ar5vLoHv6NanM6ptkTTK7LrXvl7hvQve4oJ3vWia+4V1YMhCM3LLxC9f/vnatu7k9o2l5bpjWSHGqa+YvXvpu16tf601GTz/KzTO5j1DSZMna8WJtxp5rvrHvov333GTAN46K9Xy7B/vinvfjxZGfwqbVs1NQvP6dX8dbrj+n5m1X7zoop/6K343lJ7yet1FvQICX3DgIQAAggggAACCCCAAAIIWClQY3rgp6jF13S6+LwzjuqjVy5PqZdgAq3v5y42efWc+Q/UHuN6v/ToqCj5WS1IpoN8Pcda99reccNlVcqnM+u54zdf3dfMhdZ7yeuec90Tf9dNV8gVF51lygtT9ZZN4eFh5qX7sex7evj4v9R2dkmJdc089Z/VkO/fN++Q9m2ai97XXCf3jQb3eXqhO72vvV55fdeeTJmq5v7rbdLyVA9+r26d5Gw1t/zIdOrhBeH09nN9enY98u1jvg5TW9Tp5H70dIL7M7ofdT7387DDDvpYr+6dVTB8khQWOo2hDuT1zZditeL+ELXfuw663eliNfLi+gF9jMOKNb+LnhKxt8yc94vVNXnzXw+YIF3frPnimzlmK754tYDdiEdvNVv3ucvSj+Fhh67Pka5l87ifay+9rZ1Og688/5if330ejwgggAACCCCAAAIIIICAtwJhanu0Spb88vb0mpdPc+xUwa7u6T5O9ezqnvPKglFv82WqVc03bd1p5sSf0KKJ2RLNFzU9fH6d2qJM96TrIeNNjj80VP9YZeblO+SPHbvNAn860NTTCSpLtzzwgglqde/8nYdvXFSWz+5jherz6p53PQQ+NSXJrL4ffXiP+CPboo30YnI68G6sFvOLqeSz7lDbCf6xfY+6QZMszZqkVbj5cWSZx3q9dOV6uf6eZ80ig7O+/E/pGgjHOo/3EUAAAQQQQAABBBBAAAFvBQjgvZWqBfnW/b5V+t/yN4mKjJQZn78s9dX0ApJ3AkOfGinT1baFegTAo3df691J5EIAAQQQQAABBBBAAAEEqiBQfgx3FU4ka80T0KvP63TROacTvFfh8v6xY4/MnL/UjNRg67gqwJEVAQQQQAABBBBAAAEEqiRAAF8lrpqbWa/y/u2MQ+sI6G34SN4LfPz1DLO+gV5EL10NxychgAACCCCAAAIIIIAAAv4QYAi9P1RDtMyiomLTcr0tGsl7AZdaUM/lKjGL8OkFEUkIIIAAAggggAACCCCAgD8ECOD9oUqZCCCAAAIIIIAAAggggAACCFgsQHehxaAUhwACCCCAAAIIIIAAAggggIA/BAjg/aFKmQgggAACCCCAAAIIIIAAAghYLEAAbzEoxSGAAAIIIIAAAggggAACCCDgDwECeH+oUiYCCCCAAAIIIIAAAggggAACFgsQwFsMSnEIIIAAAggggAACCCCAAAII+EOAAN4fqpSJAAIIIIAAAggggAACCCCAgMUCBPAWg1IcAggggAACCCCAAAIIIIAAAv4QIID3hyplIoAAAggggAACCCCAAAIIIGCxAAG8xaAUhwACCCCAAAIIIIAAAggggIA/BAjg/aFKmQgggAACCCCAAAIIIIAAAghYLEAAbzEoxSGAAAIIIIAAAggggAACCCDgDwECeH+oUiYCCCCAAAIIIIAAAggggAACFgsQwFsMSnEIIIAAAggggAACCCCAAAII+EOAAN4fqpSJAAIIIIAAAggggAACCCCAgMUCBPAWg1IcAggggAACCCCAAAIIIIAAAv4QIID3hyplIoAAAggggAACCCCAAAIIIGCxAAG8xaAUhwACCCCAAAIIIIAAAggggIA/BAjg/aFKmQgggAACCCCAAAIIIIAAAghYLEAAbzEoxSGAAAIIIIAAAggggAACCCDgDwECeH+oUiYCCCCAAAIIIIAAAggggAACFgsQwFsMSnEIIIAAAggggAACCCCAAAII+EOAAN4fqpSJAAIIIIAAAggggAACCCCAgMUCBPAWg1IcAggggAACCCCAAAIIIIAAAv4QIID3hyplIoAAAggggAACCCCAAAIIIGCxAAG8xaAUhwACCCCAAAIIIIAAAggggIA/BAjg/aFKmQgggAACCCCAAAIIIIAAAghYLEAAbzEoxSGAAAIIIIAAAggggAACCCDgDwECeH+oUiYCCCCAAAIBEigpKZGDuflVqt1ZVFSl/GRGAAEEEEAAgcAIRAamWmpFAAEEEEAAASsFtmzbLS+OGicLF6+WAkehxMXGSK9uneXBO6+S49Pql6uquNgl734yWRYtXSNr1m+RnIN5cuNVF8mwu64pl48XCCCAAAIIIBBcAgTwwXU9aA0CCCCAAAJVFnCpXvf7//66/LFjt1x75XnStnUz+XnZWvny27mybuMf8uU7z0h01KF/8jP3Z8t9f39NlvyyXtqpfJde0F1KXCWSnBRf5Xo5AQEEEEAAAQTsFSCAt9eb2hBAAAEEELBcYPL0hbLu961y89V9VY/71ab8S8/vLnv27Ze5i36RNes2S+eTW5vj/33nSxO833nDZXL3zVdKWFiY5e2hQAQQQAABBBDwjwBz4P3jSqkIIIAAAgj4LDDzh6Vyw73Pyr9e/6RcWXv3HZBbHnjB9KS7XC45ePDQnPf6KYnl8rVrnW5el0iJedyTcUAmTP1BzujSXu4Z0p/gvZwWLxBAAAEEEAh+AQL44L9GtBABBBBAoJYK9O7eWQ19j5IPP58qn02cZRT0/PUHn35DFv+yTm4Y0EfCw8OlZ/dOEhUZKSPf/UrGfPG9ONQc+P1ZOfL9nJ+l4XEp0umkQ73vsxcsE71gne6dnz5vibw3bop8oMpevW5TLRXmYyOAAAIIIBBaAmFqtdpDt+VDq920FgEEEEAAgVohcCD7oAy87e+SkZklY19/SqbMXGQC7388eJMM7Ne71OCXXzfKkPv/JfkFDomvG2t+4mLryNsvPFi6iN0rb38u73w82fS863/+IyLCRd8Q0GnApb3k6YduLi2PJwgggAACCCAQfAL0wAffNaFFCCCAAAIIlArUS4yX//zzHhN03/bQizL60+/kmivOLRe861XnP/pymsoj8ujd10rPMzqKXqxu6/bdMuH7H0QvcqfTjt37zONDap78vPEj5ZcZ78l3H78gHdq3lC++mSMTv19g3ucPBBBAAAEEEAhOAQL44LwutAoBBBBAAIFSgZPaNJchgy4W3RuvA3odpJdNOvjWC9n9c9gtcr0aVv/i3/4qE94fIW1bNTPD6hctWWOyx8ZEm8cLenWVlHoJ5nnTRsfJU/ffYJ4vXr7WPPIHAggggAACCASnAAF8cF4XWoUAAggggECpgB4+/+XkOWa+u57b/u7H35a+p5/M+mGZed3t1BNLjzdrnCb/d/MV5rWe+65TsyZp5nHbjr3m0f2Hnj+vk75BQEIAAQQQQACB4BUggA/ea0PLEEAAAQQQkKKiYrPHe1Z2rnzyxlNycrsW8vror2X+TytLdZIS65rncxauKD2mn2zYuM28rhsXax71uTpNmDrfPLr/mDl/qXmq94UnIYAAAggggEDwCkT8Q6XgbZ7vLZs2d7FEqBV66yXFVyhM9zR8P2exWaV3n5oreHxafbPab9mM3uQpm5/nCCCAAAIIWCnw7MixMk39W/XUfTfIOWeeIt1PPUnGfzdfps1dIhedc7okJtQVHaBPnr5IVv76u1mULiY6Ur6d8aOaLz9F/RsYIX974AZJUkPvmxzfQFat3Wj+7dM9+S5XiVm1/tOJMyUhPk5GPHKLxMbGWNl8ykIAAQQQQAABCwVq7Cr0usdi9sLlcv/fXpMn7rterrn83HJseiGfm+9/Xvbs3S96mOHmbbukZXojee/lYZKcdGheoDd5yhXKCwQQQAABBCwU0PPahw1/Sy4+r5u8+NSdpSVPV8H70L+NFN1j/vnb/zBD6ydNWyAvjfrUrFbvztj+hHQVvN8oHdUide6kb1j/46XRMvPwsHt9XPfM6/nzbVo2cWfjEQEEEEAAAQSCUKBGBvAbNm2TK4c8Je4d8vTiPEcG8MP/O0YmqdV29S8+OoBfvX6zDL5ruNxxfT/5642Xm0vlTZ4gvKY0CQEEEECglgroLeG27dxrgvjGDVMlrUGyWb2+Mo6snFzZum232Se+Qf16lWXhGAIIIIAAAggEmUCNnAPfvGlD+ebD5+Szt/7ukXvqrJ+kV/fOJnjXmfQKv107tZWps38uPcebPKWZeYIAAggggECABfS+7ulqobpTO7YxgXmY3lfOQ0pSQ+/19nEE7x6AOIwAAggggEAQCtTIAF6vpquD+PQmDSsldxQ6JfNAjpzQonG59/XrnYf3yPUmT7mTeYEAAggggAACCCCAAAIIIICAHwVqZAB/LK9MNf9Pp7jYOuWy6tcH8/LFWVQk3uQpdzIvEEAAAQQQQAABBBBAAAEEEPCjQK0M4KOjowypy+UqR1tUXCzharihXrXemzzlTg6hFw6nS3LyikKoxTWjqYVFLsnOc9aMDxNCn8Kp3LNycbf7khUVl8iBg4V2V1vr6ytWq8rvz8Hd7i+Cq6REMrNxt9tdscu+bIfd1VKfEsjIwj0QXwT9fdffe1LtFqiVAXyy2lJOB+rZB/PKXf3snDyz3Vy4CuC9yVPuZF4ggAACCCCAAAIIIIAAAggg4EeBWhnA6wC9RfrxsnzVhnK0y1dvkFbND82L9yZPuZN5gQACCCCAAAIIIIAAAggggIAfBWpkAK8XoNPbwq1RPzrp/dz164zMLPNa/3HFRWfLgsWr5YPPp8pvm7fLyPe+kvUb1fZzfc+uUp7SzDxBAAEEEEAAAQQQQAABBBBAwI8CNXIfeBOID3myAts9Q/rLnTdcZo7rvXKf/vf78vV380XPhddb79w48EJ54I6rSvfM9SZPhUpC4ICeA1+ofhLiIkOgtTWniXoOfEFhsSTGHVqDoeZ8suD+JHoOfJ6jWJLq4m7nldJz4A/mO6VefLSd1db6uvQc+Gy15kNyAu52fhn0HPgDOU5JScTdTnc9FzgzxyH1E2PsrJa6lICeA5+ahLvdXwY9Bz4lIUbFKnbXTH3BJFAjA/iqAOcXOGT7rgxp2ug4iTm8uN2R53uT58hzgvk1AXxgrg4BfGDcCeAD404AHxh3AvjAuBPAB8adAD4w7rpWAvjA2BPAB8Y92Gqt9V2wsXVipPXhee+eLo43eTydy3EEEEAAAQQQQAABBBBAAAEErBCokXPgrYChDAQQQAABBBBAAAEEEEAAAQSCSYAAPpiuBm1BAAEEEEAAAQQQQAABBBBAwIMAAbwHGA4jgAACCCCAAAIIIIAAAgggEEwCBPDBdDVoCwIIIIAAAggggAACCCCAAAIeBAjgPcBwGAEEEEAAAQQQQAABBBBAAIFgEiCAD6arQVsQQAABBBBAAAEEEEAAAQQQ8CBAAO8BhsMIIIAAAggggAACCCCAAAIIBJMAAXwwXQ3aggACCCCAAAIIIIAAAggggIAHAQJ4DzAcRgABBBBAAAEEEEAAAQQQQCCYBAjgg+lq0BYEEEAAAQQQQAABBBBAAAEEPAgQwHuA4TACCCCAAAIIIIAAAggggAACwSRAAB9MV4O2IIAAAggggAACCCCAAAIIIOBBgADeAwyHEUAAAQQQQAABBBBAAAEEEAgmAQL4YLoatAUBBBBAAAEEEEAAAQQQQAABDwIE8B5gOIwAAggggAACCCCAAAIIIIBAMAkQwAfT1aAtCCCAAAIIIIAAAggggAACCHgQIID3AMNhBBBAAAEEEEAAAQQQQAABBIJJgAA+mK4GbUEAAQQQQAABBBBAAAEEEEDAgwABvAcYDiOAAAIIIIAAAggggAACCCAQTAIE8MF0NWgLAggggAACCCCAAAIIIIAAAh4ECOA9wHAYAQQQQAABBBBAAAEEEEAAgWASIIAPpqtBWxBAAAEEEEAAAQQQQAABBBDwIEAA7wGGwwgggAACCCCAAAIIIIAAAggEkwABfDBdDdqCAAIIIIAAAggggAACCCCAgAcBAngPMBxGAAEEEEAAAQQQQAABBBBAIJgECOCD6WrQFgQQQAABBBBAAAEEEEAAAQQ8CBDAe4DhMAIIIIAAAggggAACCCCAAALBJEAAH0xXg7YggAACCCCAAAIIIIAAAggg4EGAAN4DDIcRQAABBBBAAAEEEEAAAQQQCCYBAvhguhq0BQEEEEAAAQQQQAABBBBAAAEPAgTwHmA4jAACCCCAAAIIIIAAAggggEAwCRDAB9PVoC0IIIAAAggggAACCCCAAAIIeBAggPcAw2EEEEAAAQQQQAABBBBAAAEEgkmAAD6YrgZtQQABBBBAAAEEEEAAAQQQQMCDAAG8BxgOI4AAAggggAACCCCAAAIIIBBMAgTwwXQ1aAsCCCCAAAIIIIAAAggggAACHgQI4D3AcBgBBBBAAAEEEEAAAQQQQACBYBIggA+mq0FbEEAAAQQQQAABBBBAAAEEEPAgQADvAYbDCCCAAAIIIIAAAggggAACCASTAAF8MF0N2oIAAggggAACCCCAAAIIIICABwECeA8wHEYAAQQQQAABBBBAAAEEEEAgmAQI4IPpatAWBBBAAAEEEEAAAQQQQAABBDwIEMB7gOEwAggggAACCCCAAAIIIIAAAsEkQAAfTFeDtiCAAAIIIIAAAggggAACCCDgQYAA3gMMhxFAAAEEEEAAAQQQQAABBBAIJgEC+GC6GrQFAQQQQAABBBBAAAEEEEAAAQ8CBPAeYDiMAAIIIIAAAggggAACCCCAQDAJEMAH09WgLQgggAACCCCAAAIIIIAAAgh4EIj0cDykDu/akymzFiyTjMwsadW8sfTp2VUiIyPKfQZv8pQ7Qb3YsXufrFjz25GHJSY6Ss49s0uF4xxAAAEEEEAAAQQQQAABBBBAwF8CIR/Az164XB5+ZpQ4Cp1yQosm8vZH38g7LSbL2NefkNg6McbNmzyVAS9esU4ee/btCm8lJyXIuRMI4CvAcAABBBBAAAEEEEAAAQQQQMBvAiEdwBc4CuXx5/4nzZs2lFHPPyCpKUmig+6b73teRn04UR64faB4k+dYulM/flGOT6tfmi0srPQpTxBAAAEEEEAAAQQQQAABBBCwRSCk58CvWb9ZsrJz5bI+Z5rgXYt17dRWzu7WSWarIfU6eZPHZDzKH3o4fkREeOlPeHhIsx3lk/IWAggggAACCCCAAAIIIIBAsAqEdA+8GzW1fpL7qXlMb5Imi5aslpKSktLjR8sTdowu9Y+/ni4J8XGmF/6cHqdI3bg6peXyBAEEEEAAAQQQQAABBBBAAAE7BEI6gG/XOt3Mc397zCTp2L6VNG6YKtt27JUtf+wyc+KLiovFmzxRkZ4Z4mJjZNrcJWoovkP2ZBwwgfx7Lz8iJ7ZJN9fnYH6RHdfJ0jqKXSXiUj+h2HZLIWwuTLvrH9zthdffddztNde1udQNVNwD467t+XvGXnvdYaB/cLfbXZS74G4ve2ltfN9LKWx74v6+H6Pv0bb2VLei+FjPsVd1y6xN54Wpf3D+7KYOwU8+e8FyGTb8TcnNKzBD3PUv67pHPTkpXuZ+/ar5RN7kqeyjFxe7TJnu91at3SS3D3tJWqU3ljEjHzeHCwqL3W+HzGNRcYnonzrRTAWw86LpYMZZ5FLu5XdIsLMNtbEu7V6o3GNxt/XyK3bRfz/GxfB9txNe/4ue71DudXC31V1VlldQLHVxt5Pd1JVbUKTcCQbshtfBO0GY3eoiNeX7zu/Cvn13Qv5vvN49OsuMz16WlSq4LioqVgvapcngu0dIs8ZppTLe5CnNXOaJnvdeNp3croX07q7qm7e09HAofgEdTpe6Y00gWXoRbXqig0gdTIbid8YmIr9Uo2+aHLphRUDjF2APhWrzQmcx33cPPv46rP+O0TdO+HvGX8KVl6tHPeSrAB73yn38dVTfsNIBDe7+EvZcrg7gcffs46939Pc9JipCdVb6qwbKDQWB8hFqKLS4kjbq+ek9up4kPbt1lF83bJXM/dkysF/vcjmPlcehVrTfvTdT/QPsKHfekS+278qQI+fTH5mH1wgggAACCCCAAAIIIIAAAghYLRDyPfDbdu6VHSqorqP2fF+2aoO8MXq8mg/fUvpd0L3Uyps80+ctUUPx35Jh/zdIbhx4oTn39odfkg7tWsrpp7SX+PhYmfT9ArNN3T239C8tmycIIIAAAggggAACCCCAAAII2CFgSQDvcrnklzUbZaFa+X3XnkzJPJBt2p5SL1EaHpci3U89STqe2FL8sf3a2t+2ytCnRpr66iXGS78Le8iwuwaVq8ubPJWtRN9ILYr37iffyptjJpry9XZyN1/dV24ddIkd14Y6EEAAAQQQQAABBBBAAAEEECgV8HkRu29n/igvvP6J7N13oLRQd6CuA3t3alC/ngqsr5GLz+vmPmTJo7OoSLZs2y3xcbHmZkFlhXqTp7Lz9DFHodPclChWK9o3bXycHG3Fek9lBNtxPQe+UP0kxFly/ybYPl7QtkfPgddzUxPjooK2jTWxYXoOfJ5a1CupLu52Xl89B/5gvlPqxUfbWW2tr0vPgc/OdUpyAu52fhn0HPgDOU5JScTdTnc9Bz4zxyH1E2PsrJa6lEBGlkNSk3C3+8uwL9shKQkxzIG3Gz7I6qt2AP/Hjj3yzCsfyoKfV5mt1S7sfZpc2Pt0tYhcQ0lLTTZfrN1798uW7bvlu1k/mZ+cg3lmrvpT999QbpG5IDOp8c0hgA/MJSaAD4w7AXxg3AngA+NOAB8YdwL4wLgTwAfGXddKAB8YewL4wLgHW63VCuD1kPRr7/qn2Ut8yKC+csd1/SQm5uh3nfUicW99NEne+2SKGt4eJmNff1Lan5AebB61oj0E8IG5zATwgXEngA+MOwF8YNwJ4APjTgAfGHcC+MC461oJ4ANjTwAfGPdgq7VaY6gPZB+UpMS68ta/HpQ2rZp69Zl0gH/vLX+Ri1Qv/R2P/Ft0GSQEEEAAAQQQQAABBBBAAAEEEPBOoFoBfPMmDeWj156UxmqRt6omHfCPff0pCWcDw6rSkR8BBBBAAAEEEEAAAQQQQKAWC1QrgNcry/uSGqXV9+V0zkUAAQQQQAABBBBAAAEEEECg1glUK4A/llJ+gUO2qsXrsrJzpWV6I0lNSTrWKbyPAAIIIIAAAggggAACCCCAAAJHEbA8gP/imznywhufSG5egalWbynXrUt7eVjtzd6mZZOjNIW3EEAAAQQQQAABBBBAAAEEEEDAk4ClAbzeJu7FN8aJniN/fs9Tzcr0ezMOyFdT5srjz/1Pvvjf057awXEEEEAAAQQQQAABBBBAAAEEEDiKgKUB/NTZP0tefoGMHHGvpDX4c558g9R6JrAvUFvJ1TnGdnNHaStvIYAAAggggAACCCCAAAIIIFBrBcKr+8m378qocGpcXB3Re6Fm7M8u996ejP0SEREukRER5Y7zAgEEEEAAAQQQQAABBBBAAAEEvBOodg/88P98qHrbHXLfbQPklJNPMLWd1qmtxNeNlZuGPied1bG6sTGye+9+Wbl2k/Tu0VkiIwngvbss5EIAAQQQQAABBBBAAAEEEECgvEDEP1Qqf8i7V9FRkTJl5o/y4effy6q1G6V188aS3iRNepx2sjgcTlm4ZLWs/e0PcblK5OLzusnj917H8HnvaP2eq1hdE/0TE1XtARh+b2NNrECbFxVrd25k2Xl99d9BTuVeJxp3W91LRAqLXLjbia7qUoPgxOF0SWwM33c76RW7FBTibqe5u678wmKJi6l2f5S7GB6rKJDnUO51cK8im8/Z85V7rPq+h4X5XBQFhLBAWIlK1W1/obNIPp0wU94e+43sP5AjF/Y+Te4Z0l+aN22ofokoMT96FXpScAnoX+4K1U9CHH/x2nlldDBToH7RSIyLsrPaWl+XU7nrXzSS6uJu55dB36w6mO+UevHRdlZb6+vSNwqzc52SnIC7nV8GPX3wQI5TUhJxt9Nd/wabmeOQ+okxdlZLXUogI8shqUm42/1l2JftkJSEGAJ4u+GDrD6fomvdC3/9gD4y9eMX5e4hV8r8n1ZKvxsfl6deeE927ckUgvcgu9o0BwEEEEAAAQQQQAABBBBAIGQFfArg3Z86Ts11v/P6y2TauJfk5mv6yrczFsnF1z0iz40cK5lHLGjnPodHBBBAAAEEEEAAAQQQQAABBBDwXsCnMdQ6OJ8xf6ns2ptpVpg/58xT5IHbB8oNqlf+zTET1fD6WfLl5Llyw8A+cvPVfSUhPs77lpETAQQQQAABBBBAAAEEEEAAAQRKBao9B/63zdvl6jueFr23e9nU6cRWMvqVRyRG7feut5p7ffR4mTRtgZzQool89e4zZbPyPEACzIEPDDxz4APjzhz4wLgzBz4w7syBD4w7c+AD484c+MC461qZAx8Ye+bAB8Y92Gqtdg/8W2MmmR71f//9LmnSqIG4il0ye+Fy+e87X8qEqT/IVZedI40bpsqzj90qt157sTkWbB+e9iCAAAIIIIAAAggggAACCCAQKgLVDuB/+HmlDLi0t9nf3f1h27RqKp9OnCUbt+50HzKPLdMbyf1qaD0JAQQQQAABBBBAAAEEEEAAAQSqJ1DtRex07/qcBctlT8YBU7PeNk6vQq9Xn2+rAnkSAggggAACCCCAAAIIIIAAAghYJ1DtHvgbBl4oj454W84ZcJ/o7eSKXS4pVsPoGx6XIv0u6GFdCykJAQQQQAABBBBAAAEEEEAAAQSk2gG8DtI7tGsp30xfKMtWblDz4WNFD5W/5vLzJDIyAloEEEAAAQQQQAABBBBAAAEEELBQoNoBvG5D86YN5e6br7SwORSFAAIIIIAAAggggAACCCCAAAKVCVR7DnxlhXEMAQQQQAABBBBAAAEEEEAAAQT8I1CtAP7n5WvlxVHjRC9cV9Wkz9HnLlq6pqqnkh8BBBBAAAEEEEAAAQQQQACBWitQrQBeL1j3/qffyX1/e0327ju0Cr03gjqvPkefW53g35s6yIMAAggggAACCCCAAAIIIIBATRSo1hz4ju1byaArz5NPx8+URUvWyA1XXSiX9zlTmjRqUKnRtp17ZeLUH+SDz6ZKXn6BObfTia0rzctBBBBAAAEEEEAAAQQQQAABBBCoKBCmesKrPg7+cDmr1m6Sf/z7ffl1wxZz5MQ26Wphu+OlUVp981rvCb952y5ZvW6z6XFv17qZ/OPBm6RD+5YVW8IR2wQcTpcUqp+EuGrdv7GtnTWtosIilxQUFktiXFRN+2hB/Xmcyj3PUSxJdXG380IVFZfIwXyn1IuPtrPaWl9XsatEsnOdkpyAu51fBpf6VepAjlNSEnG3013/BpuZ45D6iTF2VktdSiAjyyGpSbjb/WXYl+2QlIQYCQuzu2bqCyYBnyK4k9u1kM/e+ruM/26+TJ+3VH5U89rXrD8UzLs/ZJ2YaOnZrZOcf3YXueKisyQ8vFqj9t3F8YgAAggggAACCCCAAAIIIIBArRTwKYDXYjog739xT/Oj70BnZR+UzP05BjMlOUGSEuMlnNtEtfLLxYdGAAEEEEAAAQQQQAABBBCwTsDnAL5sU3SgnpyUYH7KHuc5AggggAACCCCAAAIIIIAAAgj4JsB4dt/8OBsBBBBAAAEEEEAAAQQQQAABWwQI4G1hphIEEEAAAQQQQAABBBBAAAEEfBMggPfNj7MRQAABBBBAAAEEEEAAAQQQsEWAAN4WZipBAAEEEEAAAQQQQAABBBBAwDcBAnjf/DgbAQQQQAABBBBAAAEEEEAAAVsECOBtYaYSBBBAAAEEEEAAAQQQQAABBHwTsGQbueH/HSMOh1MG9z9f2rVu5luLOBsBBBBAAAEEEEAAAQQQQAABBCoIWBLAl5SUyFffzjU/XTq0MYH8BT27SkQEHfwVxDmAAAIIIIAAAggggAACCCCAQDUELAngnxh6vfTq1lk+GT9d5v+4UpauXC9pqcly9eXnysBLe0lKcmI1msYpCCCAAAIIIIAAAggggAACCCDgFghTvecl7hdWPG7bsVfGTZgpX02ZK1nZuRIdFSl9zz3D9Mqf1LaFFVVQho8CDqdLCtVPQpwl9298bE3tOb2wyCUFhcWSGBdVez50EHxSp3LPcxRLUl3c7bwcRcUlcjDfKfXio+2sttbXVewqkexcpyQn4G7nl8GlfpU6kOOUlETc7XTXv8Fm5jikfmKMndVSlxLIyHJIahLudn8Z9mU7JCUhRsLC7K6Z+oJJwPIA3v3hHI5C+fdbn8nYr6a7D0mnE1uZQP7C3qdLZGRE6XGe2CtAAG+vt7s2Ani3hL2PBPD2ertrI4B3S9j7SABvr7e7NgJ4t4S9jwTw9nqXrY0AvqyGfc8J4O2zDuaaLJ+kXugskknTFsiQB14oDd4b1K8nZ53eQVau3STDhr8l5131gKzfuC2YXWgbAggggAACCCCAAAIIIIAAAkElYNkY6u27MuTTibPkq8lzZX9WjvmQXTu1lUFXnCfnn32q6XHXw+vHfPm9Wexu3/4sladJUGHQGAQQQAABBBBAAAEEEEAAAQSCVcCSIfRvjpkor7/3teghZLF1YqTfBT1k0JXnSZuWlQfoOQfz1NyNMImvGxusLjW6XQyhD8zlZQh9YNwZQh8Yd4bQB8adIfSBcWcIfWDcGUIfGHddK0PoA2PPEPrAuAdbrZb0wOue9fQmaXKN6m2/4qKzjhmYJ8THBZsD7UEAAQQQQAABBBBAAAEEEEAgqAUsCeCH3voX0fPcSQgggAACCCCAAAIIIIAAAggg4B8BSxax2/zHLulw7hC567H/VGjl6E+nmPf0IwkBBBBAAAEEEEAAAQQQQAABBKonYEkA/830heJyueQ+1RN/ZLruLxdIakqiTPx+wZFv8RoBBBBAAAEEEEAAAQQQQAABBLwUsGQI/e+bd0iTRg2kTaumFaqNioyUXt07y9dT5pkgPzzcknsGFeqpzoFdezJl1oJlkpGZJa2aN5Y+PbtW2J/emzzVqZtzEEAAAQQQQAABBBBAAAEEEKiKgCUBvO59T6jreWG6iIhwKVFLhbpcJRIs8fvshcvl4WdGiaPQKSe0aCJvf/SNvNNisox9/Qmzkr5G9CZPVbDJiwACCCCAAAIIIIAAAggggEB1BSzpDtcB8IZN2+S3zdsrtCMv3yHzf1wpzRodV6F3u0Jmmw4UOArl8ef+J82bNpSZn78iX77zjIx+5RHZsPEPGfXhRNMKb/LY1FzLq9l/YJ+sXbfc8nIpEAEEEEAAAQQQQAABBPwvsOrXZZK5f5//K6KGoBOwJIAfcGkv07t++0MvyWcTZ8n6jdtk+arfZOS7X8nVdz4t23bulSv7nh00H37N+s2SlZ0rl/U5U83PTzLt6tqprZzdrZPMVkPqdfImj8kYQn8UOApk7KunSsx3aXLKmtNkyuuNZcGPM0LoE9BUBBBAAAEEEEAAAQRqr8BC9bu7/h2+3dIuEvZNA/O7vf4dn1R7BCwZQt+hfUt59O5r5aVR4+Tplz+ooHf+2afKTVf3rXA80AdS6x8K3t3t0HvZL1qy2gz3dx87Wp6wsDB3tpB4/Gzck3JD6tLStvZN3iEzll4jX+/8R+kxnvhPoFhNISlS001iIiP8VwklVxAw7sXKPQr3Cjh+PFCspk0VFeHuR+JKi3ZJiRQ6XVKH73ulPv46WKLcHbj7i9djuSXqnQJnscTyffdo5K838gqLJS6af1f95eup3Hz1fU/L+Kf0Tc4wWZIjSmSw+t3+Q/07/o0veTqN4zVMwJIAXpsM7n++nHV6B/l2xiLZuHWnFKq55elqiPoZp7STM0/rEFRs7Vqnm3nub4+ZJB3bt5LGDVNl2469skVth6fnxBcVF4s3efQCfVm5zqD6bEdrTJM8dXOl/D0LOS9J/QWQd/fRTuM9qwUKrS6Q8rwSCJ3/Vb36OCGTCffAXCrccQ+MQGBq5fseGPeiwFRb62s94nd57aF/x8/KfS5kaJLqRoVMW4OxoWFqcTl9A7PWpdkLlsuw4W9Kbl6B6EX29AJ7ukc9OSle5n79qvHwJo9T9TCFShr3Rje5PvXncs3NU81fkVvJ3wTlcvECAQQQQCBUBPQ/6qE1PixUZI/eTtyP7uOvd/XohzC+8f7i9Vgu7h5p/PqGdu9cN1vijpgEPSbjNLnmrkV+rdvKwqMij/gAVhZeC8qyNIB3qXsBe/bul2I1TPjIFB0VKQ3q1zvycEBf5xzMk5VrN6lhnsVqQbs0GXz3CElvnCYfvfZEabu8yVOaOcifLPpplpy64VyJKvOb3XtZV8uQv44L8pbXjOYVqps9BWrIWWIcdx3tvKL6Jlueo1i422unuqiRTCVyMN8p9eKj7a24ltemp4xkq5FhyQm42/lV0L//HMhxSkoi7na66y6ozByH1E+MsbNa6lICGVkOSU3C3e4vw75sh0wYe6MMSfq0tGqn+v9gyQkzpdvp55Qe40nNFrBkCL3eRu7FUZ+aBez06u2VJb3i++Qxz1f2VsCOJcTHSY+uJ5n6p87+Wa3kmC0P3Xl1ufZ4k6fcCUH8Qv+PvSZxufw47QGpK9slvs2TMuTa64K4xTQNAQQQQAABBBBAAAEE3AI33zlOvv3+UsldP0JywxrJ6ee/LN3adXK/zWMtELAkgJ80bYF8+PlUSWuQIs0S4swq9JdfeKYZkq5Xc9er0nc/HCgHi6leGX/HrgypUydGlq3aIG+MHq/mw7eUfhd0L22iN3lKM4fIkxPV/+CtWk0zixwlxFly+UPkk9NMBBBAAAEEEEAAAQRCX+DiC1UHnP4h1UoBSyK4qbN+lpiYaPnif0/L9LmLzUr0j90zWHTvtV4c7rKbHpc60cE1rGztb1tl6FMjzUWvlxgv/S7sIcPuGiTh4X/OyfAmT6381vChEUAAAQQQQAABBBBAAAEEbBewJIDfs++AtG/dTFLqJUiy+tFpd8Z+E8A3adRAunRoI19NmSsP/bX88HTbP22ZCnt17yQT3h8h8XGx0vC4lDLv/PnUmzx/5uYZAggggAACCCCAAAIIIIAAAv4T+LO72Yc69EL2TuehvSSaNjrOlLRO9XC7kw7qs7Jz5UD2QfehgD/qLeBaN2/sMXjXDfQmT8A/CA1AAAEEEEAAAQQQQAABBBCoFQKWBPD1kxNl87ZdUlzskjatmpqe93c/mSKZB3Jku5pn/tOyX81WbXXj6tQKVD4kAggggAACCCCAAAIIIIAAAlYLWBLAt27RxOynvuSXdRKu9lK/5vJzZd3vW6VX/6Fy0aCHJSMzSy465wzTo231B6A8BBBAAAEEEEAAAQQQQAABBGqDgCVz4O+66XIZ3P98Mwdeo917S3/Rw+rnLFwhObl50rt7Z3nwiO3ZagMunxEBBBBAAAEEEEAAAQQQQAABqwQsCeDHT5lvVp9//N7rzBB6vZL7/bcPND9WNZRyEEAAAQQQQAABBBBAAAEEEKjNApYMof9t83b5ecU6iY6Oqs2WfHYEEEAAAQQQQAABBBBAAAEE/CZgSQDfpmUT08A/duzxW0MpGAEEEEAAAQQQQAABBBBAAIHaLGBJAK8XqKuXGC8Tp/5Qmy357AgggAACCCCAAAIIIIAAAgj4TcCSOfBLV643+6l/O/NHSUysK/FxsRUanKL2gr/xqosqHOcAAggggAACCCCAAAIIIIAAAggcW8CSAH72guWy9retprZx42dWWmvzpg0J4CuV4SACCCCAAAIIIIAAAggggAACxxawJIC/4/p+MuCSXketLSaGBe6OCsSbCCCAAAIIIIAAAggggAACCBxFwJIAvmmj40T/kBBAAAEEEEAAAQQQQAABBBBAwD8Clixi55+mUSoCCCCAAAIIIIAAAggggAACCLgFLOmBf+GNcTJl5iJ3mZU+pjdOk/f/+1il73EQAQQQQAABBBBAAAEEEEAAAQSOLmBJAB8VGSEx0dGV1rRvf5bk5TukVXrjSt/nIAIIIIAAAggggAACCCCAAAIIHFvAkgD+/tsHiv6pLM2Yv1TuffJV6X9Jz8re5hgCCCCAAAIIIIAAAggggAACCHgh4Pc58Oed1UVaN28sb344wYvmkAUBBBBAAAEEEEAAAQQQQAABBCoT8HsArytt27qZbNyyU3LzCiprA8cQQAABBBBAAAEEEEAAAQQQQOAYAn4P4A/m5svKXzdKQnycRKq58iQEEEAAAQQQQAABBBBAAAEEEKi6gCVz4Md+NV1++GlludpLpETy1eJ1azZsMT3vtwy6WC10F1UuDy8QQAABBBBAAAEEEEAAAQQQQMA7AUsC+F9VkD5n0YpKa0xMqCuX9ekhQ1QAT0IAAQQQZthO1wAAQABJREFUQAABBBBAAAEEEEAAgeoJWBLA//3BG+WxewZXaEF4eJjE1ompcJwDCCCAAAIIIIAAAggggAACCCBQNQFLAvgwCZPNf+yUmJhos+J82Sbs2L1P9h/IlmaN08w8+LLv8RwBBBBAAAEEEEAAAQQQQAABBLwTsGQRu+nzlshVdzwt73/6XYVal65cb957a8ykCu9xAAEEEEAAAQQQQAABBBBAAAEEvBOwJICfMX+phIeHy323DahQ66Xndze98tPmLq7wHgcQQAABBBBAAAEEEEAAAQQQQMA7AUsC+C3bdqsgvZGkpiRVWmv3rifJjl0Z4iwqqvR9DiKAAAIIIIAAAggggAACCCCAwNEFLAng68bVUcF5scea9F7wUWoLucgI9oH3iMQbCCCAAAIIIIAAAggggAACCBxFwJIAvl2rprJp606ZvXB5haq27dwreo58q/TjJSwsrML7HEAAAQQQQAABBBBAAAEEEEAAgWMLWLIK/U1XXyRfTZkn9z75qvS7oIeccvIJkpuXL/N+XCmLV6wzQ+dvG3zpsVtDDgQQQAABBBBAAAEEEEAAAQQQqFTAkgA+rUGKjBx+r/ztxdEy/rv55sddm95a7oFbrpI+vU5zH+IRAQQQQAABBBBAAAEEEEAAAQSqKGBJAK/rPP2U9jLh/RGyRPW4b1TD6fWCdXrv947tW0qD+vWq2CyyI4AAAggggAACCCCAAAIIIIBAWQFLAvi8fIfM+mGp1K0bK727d5Yep51cWseKNb/LT8t+lS4d2sjxafVLj/MEAQQQQAABBBBAAAEEEEAAAQS8F7BkEbtvZyySYcPfkqUrN1SoOb/AYd57c8zECu9xAAEEEEAAAQQQQAABBBBAAAEEvBOwJICf/9MvEh0VKXdc169Crd26nCidT2otcxauqPAeBxBAAAEEEEAAAQQQQAABBBBAwDsBSwL4bTszpHWLxqL3g68sdVIB/N59B6TQWVTZ2xxDAAEEEEAAAQQQQAABBBBAAIFjCFgSwNdPTpSs7FyPVengPT4u1vTSe8zEGwgggAACCCCAAAIIIIAAAggg4FHAkgD+5LYtZPuuDBn71fQKFekF7KbNWSxtWzet8B4HEEAAAQQQQAABBBBAAAEEEEDAOwFLVqG/+Zq+8vWUefLsqx/JtzMXySknnSC5eQUyT82N37l7n4SFhcnQWwd41yJyIYAAAggggAACCCCAAAIIIIBABQFLAvh4tX3ce688Ik+//IHZMm75qt9KK0pLTZbHh14np3ZsU3qMJwgggAACCCCAAAIIIIAAAgggUDUBSwJ4XWXzpg1ltAri9VD6TVt3iqPQKc2bNJT0JmkSGRlRtVaRGwEEEEAAAQQQQAABBBBAAAEEyglYFsC7S23cMFX0jzvpleenzV0sK9dukgduH+g+zCMCCCCAAAIIIIAAAggggAACCFRBwPIA3l33slUbZOLUBfLd7J8kOyfX9NATwLt1eEQAAQQQQAABBBBAAAEEEECgagKWBvBbt++Wid8vkEnTFsi2HXtNS6KjIuX8s0+VK/ueXbWWkRsBBBBAAAEEEEAAAQQQQAABBEoFfA7gs1Tv+pSZP8okFbgvX/3n4nW6hqsvO0ceuOMq0YvckRBAAAEEEEAAAQQQQAABBBBAoPoC1Q7gFy1dIx+rfd/nLvpFnEVFpgVtWzWTSy/obhauu/fJV6Vd62YE79W/NpyJAAIIIIAAAggggAACCCCAQKlAtQP4Dz77zgTvaQ1SpJ8K2vv16SGtmzc2Ba9et6m0Ap4ggAACCCCAAAIIIIAAAggggIDvAuG+FlFS4hKXyyXFxcW+FsX5CCCAAAIIIIAAAggggAACCCDgQaDaPfD33vIXaaS2i/tu5k/y3rgp5ueEFk1Mb3y62hOehAACCCCAAAIIIIAAAggggAAC1gmElajkS3F6/rueBz/p+x9kzsIVovd9d6eB/XrL/Wrv96SEuu5DPAaBgMPpUtfJJQlx1b5/EwSfIvSaUFjkkoLCYkmMiwq9xodwi53KPc9RLEl1cbfzMhYVl8jBfKfUi4+2s9paX1exq0Syc52SnIC7nV8Gl/pV6kCOU1IScbfTXf8Gm5njkPqJMXZWS11KICPLIalJuNv9ZdiX7ZCUhBgJC7O7ZuoLJgGfA/iyH0bv9/7drJ/MVnJ6RXp9byAyMkLOOr2D9L+4p5x3Vpey2S17vmtPpsxasEwyMrOklZqH36dnV1Nv2Qr0jYWFS1bLCtWuLh3ayOmntBe9xd3R0o7d+2TFmvIr6+v8MdFRcu6Z/vksR2uPVe8RwFslWbVyCOCr5mVVbgJ4qySrVg4BfNW8rMpNAG+VZNXKIYCvmpdVuQngrZKsejkE8FU3s+IMAngrFEO/DEsD+LIceh/4iapXftK0haL3h2+uhtVPHvN82SyWPJ+9cLk8/MwocRQ6RQ/hX79xm3kc+/oTElvn0J1BPULgoWfeUCvix8mJbdJl2coNqgfaKSNHDJVuXU702A69p/1jz75d4f3kpASZP2FkheOhcoAAPjBXigA+MO4E8IFxJ4APjDsBfGDcCeAD404AHxh3XSsBfGDsCeAD4x5stR69C9qH1jZp1EDuuukK86N74xevWOdDaZWfWuAolMef+5+5OTDq+QckNSXJ1HPzfc/LqA8nygNq+L5OL44aJ/WTk9QNhOckPDxc8vIdcsHVD8ob748/agDvrnXqxy/K8Wn13S8ZtlIqwRMEEEAAAQQQQAABBBBAAAG7BHxehd6bhnY+qbXceu0l3mStUp416zdLVnauXNbnTBO865O7dmorZ3frJLPVkHp3ys3Nlwb1k0zwro/FxcaoofaNpFitnu9N0tMAIiLCS3/0TQASAggggAACCCCAAAIIIIAAAnYK1IhINFUF52VTepM00UP43evzXdH3LFnyy3q567H/iN6jfsHi1bLy143yFzUv35v08dfT5X9jv5Fvpi+U3LwCb04hDwIIIIAAAggggAACCCCAAAKWCvhtCL2lrfRQWLvW6Wae+9tjJknH9q2ksdrWTgfuW/7YZebEF6m96aMiI+WeIf3l5+Xr1Gr5K9RK+ctNaQMu7WUW1vNQdOlh3Vs/be4SKXA4ZE/GAUmIj5P3Xn7EzKXXmfbnFJbmDZUnes6Y3nogFNseKsaVtVOb65tKuFem479juPvP9mgl4340Hf+9p91daiV6/p7xn7GnkvU8eNw96fjvuP6dBnf/+R6tZNyPpuOf9/T3/cDB0Is9jtRgp5QjRar22m+L2FWtGdXPPXvBchk2/E3TM66HuetfXMLU3grJSfEy9+tXTcGPjnhb9cCvk9GvPCo79+4THfDrXvjbBl8q9902wGPlxcUuM2zenWHV2k1y+7CXpFV6Yxkz8nFzWC8YFGpJL6bmdJZI3diIUGt6SLfXqb5PjkKXxMeG9H2zkLsGRco938G2iXZfuGK1jVyuo4htE22G1/8GHsxX7mybaKu8vjmbnVskSfFsV2knvA5msnIL2a7STvTDdengnSDMfngdvCfVjQ759bgiwtkHz5dvT8hHEr17dJYZn70sK1VwXVRUrBa0S5PBd4+QZo3TjEvm/myZrIa+60BdL6ynf7p2bCtDnxopemj8X2+83GwLVxmiviFQNp3croX07q7qm7e09HAofgHD1Q2OsLASCcW2l8KH4JNil3YX3G2+di7cbRY/VJ3+xVr/88zfMwHhx91mdve9fL7v9sLrv2d0wv2Qg91/4m63+KH6tDv7wAfGPlhqLR+hBkurqtgOPay9R9eTpGe3jvLrhq2ig/aB/XqbUvTe8HpYW5bao96dTA99vQTJLygsndPuUCva796bqY453Nkqfdy+K0OOnHNfaUYOIoAAAggggAACCCCAAAIIIGChQMj3wG/buVd2qKC6jtrzfdmqDfLG6PFqPnxL6XdBd8PUqnljaXJ8A/li8hw1b725nHnayWaruSkzf5QBl/SSFBXI6zR93hI1FP8tGfZ/g+TGgReaY7c//JJ0aNdSTj+lvcTHx8oktS+83g7vnlv6m/f5AwEEEEAAAQQQQAABBBBAAAG7BEI+gF/721YzHF6D1UuMl34X9pBhdw0q3TJOD4N/7dmh8sRz78iDT79R6qp768sG4rpX/sjUSC2K9+4n38qbYyaat/R2cjdf3VduHWT9lnhH1s1rBBBAAAEEEEAAAQQQQAABBMoKhPwids6iItmybbfEx8VKw+NSyn62cs/1AjN79h2QfZnZJp+7571cpkpeOAqdsmtPphSrFe2bNj7OrGpfSbaQOuRwuqRQ/STEhfz9m5By14sHFhQWs6iXzVfNqdzzHMVq0RcWl7KTvkgtYncw38niUnaiq7r0wqrZuU4Wl7LZXU/VO5DjlJTEaJtrrt3V6TnwmTkOqZ8YU7shAvDpM7IckpqEu930+7IdkpIQwxx4u+GDrL6Qj+D0NnGt1TD5YyXdw56Wmmx+jpW37Psx0VGi95UnIYAAAggggAACCCCAAAIIIBBIgRqxiF0gAakbAQQQQAABBBBAAAEEEEAAATsECODtUKYOBBBAAAEEEEAAAQQQQAABBHwUIID3EZDTEUAAAQQQQAABBBBAAAEEELBDgADeDmXqQAABBBBAAAEEEEAAAQQQQMBHAQJ4HwE5HQEEEEAAAQQQQAABBBBAAAE7BAjg7VCmDgQQQAABBBBAAAEEEEAAAQR8FCCA9xGQ0xFAAAEEEEAAAQQQQAABBBCwQ4AA3g5l6kAAAQQQQAABBBBAAAEEEEDARwECeB8BOR0BBBBAAAEEEEAAAQQQQAABOwQI4O1Qpg4EEEAAAQQQQAABBBBAAAEEfBQggPcRkNMRQAABBBBAAAEEEEAAAQQQsEOAAN4OZepAAAEEEEAAAQQQQAABBBBAwEcBAngfATkdAQQQQAABBBBAAAEEEEAAATsECODtUKYOBBBAAAEEEEAAAQQQQAABBHwUIID3EZDTEUAAAQQQQAABBBBAAAEEELBDgADeDmXqQAABBBBAAAEEEEAAAQQQQMBHAQJ4HwE5HQEEEEAAAQQQQAABBBBAAAE7BAjg7VCmDgQQQAABBBBAAAEEEEAAAQR8FCCA9xGQ0xFAAAEEEEAAAQQQQAABBBCwQ4AA3g5l6kAAAQQQQAABBBBAAAEEEEDARwECeB8BOR0BBBBAAAEEEEAAAQQQQAABOwQI4O1Qpg4EEEAAAQQQQAABBBBAAAEEfBQggPcRkNMRQAABBBBAAAEEEEAAAQQQsEOAAN4OZepAAAEEEEAAAQQQQAABBBBAwEcBAngfATkdAQQQQAABBBBAAAEEEEAAATsECODtUKYOBBBAAAEEEEAAAQQQQAABBHwUIID3EZDTEUAAAQQQQAABBBBAAAEEELBDgADeDmXqQAABBBBAAAEEEEAAAQQQQMBHAQJ4HwE5HQEEEEAAAQQQQAABBBBAAAE7BAjg7VCmDgQQQAABBBBAAAEEEEAAAQR8FCCA9xGQ0xFAAAEEEEAAAQQQQAABBBCwQ4AA3g5l6kAAAQQQQAABBBBAAAEEEEDARwECeB8BOR0BBBBAAAEEEEAAAQQQQAABOwQI4O1Qpg4EEEAAAQQQQAABBBBAAAEEfBQggPcRkNMRQAABBBBAAAEEEEAAAQQQsEOAAN4OZepAAAEEEEAAAQQQQAABBBBAwEcBAngfATkdAQQQQAABBBBAAAEEEEAAATsECODtUKYOBBBAAAEEEEAAAQQQQAABBHwUIID3EZDTEUAAAQQQQAABBBBAAAEEELBDgADeDmXqQAABBBBAAAEEEEAAAQQQQMBHAQJ4HwE5HQEEEEAAAQQQQAABBBBAAAE7BAjg7VCmDgQQQAABBBBAAAEEEEAAAQR8FCCA9xGQ0xFAAAEEEEAAAQQQQAABBBCwQ4AA3g5l6kAAAQQQQAABBBBAAAEEEEDARwECeB8BOR0BBBBAAAEEEEAAAQQQQAABOwQI4O1Qpg4EEEAAAQQQQAABBBBAAAEEfBQggPcRkNMRQAABBBBAAAEEEEAAAQQQsEOAAN4OZepAAAEEEEAAAQQQQAABBBBAwEeBSB/PD+nTd+3JlFkLlklGZpa0at5Y+vTsKpGREeU+U6GzSBYuWS0rVv8mXTq0kdNPaS/RUbWarZwPLxBAAAEEEEAAAQQQQAABBOwRqLWR6OyFy+XhZ0aJo9ApJ7RoIm9/9I2802KyjH39CYmtE2P05y76RR565g2JrxsnJ7ZJl08nzJJCp1NGjhgq3bqcaM8VohYEEEAAAQQQQAABBBBAAAEElECtDOALHIXy+HP/k+ZNG8qo5x+Q1JQkWbxindx83/My6sOJ8sDtA82X48VR46R+cpJMHvOchIeHS16+Qy64+kF54/3xBPD874MAAggggAACCCCAAAIIIGCrQK2cA79m/WbJys6Vy/qcaYJ3Ld61U1s5u1snma2G1LtTbm6+NKifZIJ3fSwuNkYNtW8kxS6XOwuPCCCAAAIIIIAAAggggAACCNgiUCsDeLdsqgrOy6b0JmmybcdeKSkpMYev6HuWLPllvdz12H9k9bpNsmDxaln560b5y8U9y57GcwQQQAABBBBAAAEEEEAAAQT8LlArh9C3a51u5rm/PWaSdGzfSho3TDWB+5Y/dpk58UXFxRIVGSn3DOkvPy9fJ3MXrZA5as68TgMu7SX9QzyAjwgPUwvx1ep7N37/H6uyCrR7DO6V0fj1WDjufvX1VLhilzrR5RcF9ZSX49YJhIeF4W4dp9clhYlyj+H77jWYRRnV111iY2rlr7IWCVa/mDi+79XH8+FM831X33tS7RYIU73Nh7qba5nD7AXLZdjwNyU3r0AiIsLF5SqRMPUvQXJSvMz9+lWj8eiIt1UP/DoZ/cqjsnPvPtEBv+6Fv23wpXLfbQNqmRgfFwEEEEAAAQQQQAABBBBAIJACtTaA1+g5B/Nk5dpNUlRUrBa0S5PBd4+Q9MZp8tFrT0jm/mzp1X+oCdRvufYSc430vY6hT42URUvXyLzxIyUmOiqQ1466EUAAAQQQQAABBBBAAAEEapFArR5HnRAfJz26niQ9u3WUXzdsNUH7wH69zeXXe8O7VMCelZNb+nUwPfT1EiS/oND03Je+wRMEEEAAAQQQQAABBBBAAAEE/CxQaycObdu5V3bsypA6as/3Zas2yBujx6v58C2l3wXdDXmr5o2lyfEN5IvJc9Qe8M3lzNNONlvNTZn5owy4pJekqECehAACCCCAAAIIIIAAAggggIBdArV2CP30eUvMcHgNXS8xXvqed4YMu2uQWtztz3saGzZtkyeee0dWq23n3En31o949DYCeDcIjwgggAACCCCAAAIIIIAAArYI1NoA3llUJFu27Zb4uFhpeFyKR2w9733PvgOyLzPb5KPn3SMVbyCAAAIIIIAAAggggAACCPhRoNYG8H40pWgEEEAAAQQQQAABBBBAAAEELBeo1YvYWa5JgQgggAACCCCAAAIIIIAAAgj4SYAA3k+wFIsAAggggAACCCCAAAIIIICAlQIE8FZqUhYCCCCAAAIIIIAAAggggAACfhIggPcTLMUigAACCCCAAAIIIIAAAgggYKUAAbyVmpSFAAIIIIAAAggggAACCCCAgJ8ECOD9BEuxCCCAAAIIIIAAAggggAACCFgpQABvpSZlIYAAAggggAACCCCAAAIIIOAnAQJ4P8FSLAIIIIAAAggggAACCCCAAAJWChDAW6lJWQgggAACCCCAAAIIIIAAAgj4SYAA3k+wFIsAAggggAACCCCAAAIIIICAlQIE8FZqUhYCCCCAAAIIIIAAAggggAACfhIggPcTLMUigAACCCCAAAIIIIAAAgggYKUAAbyVmpSFAAIIIIAAAggggAACCCCAgJ8ECOD9BEuxCCCAAAIIIIAAAggggAACCFgpQABvpSZlIYAAAggggAACCCCAAAIIIOAnAQJ4P8FSLAIIIIAAAggggAACCCCAAAJWChDAW6lJWQgggAACCCCAAAIIIIAAAgj4SYAA3k+wFIsAAggggAACCCCAAAIIIICAlQIE8FZqUhYCCCCAAAIIIIAAAggggAACfhIggPcTLMUigAACCCCAAAIIIIAAAgggYKUAAbyVmpSFAAIIIIAAAggggAACCCCAgJ8ECOD9BEuxCCCAAAIIIIAAAggggAACCFgpQABvpSZlIYAAAggggAACCCCAAAIIIOAnAQJ4P8FSLAIIIIAAAggggAACCCCAAAJWChDAW6lJWQgggAACCCCAAAIIIIAAAgj4SYAA3k+wFIsAAggggAACCCCAAAIIIICAlQIE8FZqUhYCCCCAAAIIIIAAAggggAACfhIggPcTLMUigAACCCCAAAIIIIAAAgggYKUAAbyVmpSFAAIIIIAAAggggAACCCCAgJ8ECOD9BEuxCCCAAAIIIIAAAggggAACCFgpQABvpSZlIYAAAggggAACCCCAAAIIIOAnAQJ4P8FSLAIIIIAAAggggAACCCCAAAJWChDAW6lJWQgggAACCCCAAAIIIIAAAgj4SYAA3k+wFIsAAggggAACCCCAAAIIIICAlQIE8FZqUhYCCCCAAAIIIIAAAggggAACfhIggPcTLMUigAACCCCAAAIIIIAAAgggYKUAAbyVmpSFAAIIIIAAAggggAACCCCAgJ8ECOD9BEuxCCCAAAIIIIAAAggggAACCFgpQABvpSZlIYAAAggggAACCCCAAAIIIOAnAQJ4P8FSLAIIIIAAAggggAACCCCAAAJWChDAW6lJWQgggAACCCCAAAIIIIAAAgj4SYAA3k+wFIsAAggggAACCCCAAAIIIICAlQIE8FZqUhYCCCCAAAIIIIAAAggggAACfhIggPcTLMUigAACCCCAAAIIIIAAAgggYKUAAbyVmpSFAAIIIIAAAggggAACCCCAgJ8ECOD9BEuxCCCAAAIIIIAAAggggAACCFgpQABvpSZlIYAAAggggAACCCCAAAIIIOAnAQJ4P8FSLAIIIIAAAggggAACCCCAAAJWChDAW6lJWQgggAACCCCAAAIIIIAAAgj4SYAA3k+wFIsAAggggAACCCCAAAIIIICAlQIE8FZqUhYCCCCAAAIIIIAAAggggAACfhIggPcTLMUigAACCCCAAAIIIIAAAgggYKUAAbyVmpSFAAIIIIAAAggggAACCCCAgJ8ECOD9BEuxCCCAAAIIIIAAAggggAACCFgpQABvpSZlIYAAAggggAACCCCAAAIIIOAnAQJ4P8FSLAIIIIAAAggggAACCCCAAAJWChDAW6lJWQgggAACCCCAAAIIIIAAAgj4SYAA3k+wFIsAAggggAACCCCAAAIIIICAlQIE8FZqUhYCCCCAAAIIIIAAAgj8P3v3AR9F0T5w/EmAhIQUEnqTbgNBEJWigKgoYkWwYW+v9VXxFQv2vwiv9VVUEAsq2AsooIgoTQEFFFBQAZXeCZBAIP0/z+Cdl+Qu2SRXk9/yCbc3O7sz+91Lbp/dnRkEEEAgQAIE8AGCZbMIIIAAAggggAACCCCAAAII+FOAAN6fmmwLAQQQQAABBBBAAAEEEEAAgQAJEMAHCJbNIoAAAggggAACCCCAAAIIIOBPger+3BjbQgABBBBAAAH/CvznkdHyx7pN0uHwVvLIXVcV2/hN9zwrm7en2fQoiZK4mjHSpmUTueCs3tLusJaF8k/4+Cv5+PM5klgrTl57ZqjUqF74NODdSV/LB5Nnma1EyUevPiLRUVGF1ucNAggggAACCIRWgDvwofWndAQQQAABBHwKrN+0Tb6Y+b2s/GO9TJw2V9J2pRfLq8H92vVbpEnDutKwXoocyMqWj6bMlktufkzmLFhWKP/2nbvtthYvWymfTZ9XaFlObq6MnTDZLv/9j3UiBQWFlvMGAQQQQAABBEIvQAAf+mNADRBAAAEEEPAq4Aqyzzmth+Tl5cuUrxd4zVevTm15Yfht8tLIO+TjVx+VJ+7/l+Tm5smbH0zzmj8hPk5ef/dzyfcI0qd8NV+27dgt8XGxXtchEQEEEEAAAQRCL0AAH/pjQA0QQAABBBDwKjDZ3CVvWD9V7rnlEompUV0mT//Oa76iif1P6SaJCfGyes3Goovs+6svPkPWmLv2X81eZN8XmEB+3PtfyDEdDpXORx3qdR0SEUAAAQQQQCD0AgTwoT8G1AABBBBAAIFiAkt+WS36CH3/k7tKUmIt6dm1o6xYuVb+WLOpWN6iCfsyD8j+A1ly1BGtii6y78/q210a1EuVV96eYt/P+X6Z3e71l57lNT+JCCCAAAIIIBAeAgTw4XEcqAUCCCCAAAKFBD77+277meZuuk79T+lqX13p9o3Hf3oXPSs7R1b9tUH+8+hL9hH6vr2O9cjxz2yN6tXkygtPl19XrZXvFv4s48zj9Ie3OUROOO6ofzIxhwACCCCAAAJhJ1C4+9mwqx4VQgABBBBAoOoJaIdy02b9IG1bNpVDWzezAL26HS3adn3KjPly+3UDJcqjh/gNm7dL+5P+6aFe27GPHHa9nHVqd594g87sJS+/9Zk8+OQ42bItTZ5+6CafeVmAAAIIIIAAAuEhQAAfHseBWiCAAAIIIOAWmD1/qexJ3yc1Y2Pl1mHPudOjoqNssL1wyW9yXKcj3Ona3v2mK8+VfNPR3cumJ3m9E9+8aUP3cm8zcTVj5ZIBp8hLb0wyeRtI397e79Z7W5c0BBBAAAEEEAiNAI/Qh8adUhFAAAEEEPApoJ3X6R32uqnJstX0DO/6adSgjl3H1Tu9awPJpo385QP72sfin3v0FtNjfZ7cfO+zsmHTdlcWr6+DTQB/WOtDbPDPmO9eiUhEAAEEEEAgrAS4Ax9Wh4PKIIAAAghUdYE9GftE78Brj/BvPndvIQ4d9u2UC+6U6bMXygO3XyaxsTGFlusbvTP/8J1Xyv3/fU3+dffT8vaL90vtpIRi+TRB0z957VGvy0hEAAEEEEAAgfAT4A58+B0TaoQAAgggUIUFvvjme9E28K7O6zwp9C55/5OPF+1l/utvf/RcVGj+vH4nynWDz7RDxd1y33P2kfpCGXiDAAIIIIAAAhEpUOkD+K/mLLInMN6Ozu70vaKPIY56/RP53Jww7c3cXyybkzzFViIBAQQQQACBcgp8/vUCqVG9upzmo036mace7JV+qsmnU7Xo6EId2rmKve3a8+02fvpllb0br+muju9cr668nq8lLfPMxzwCCCCAAAIIBF8gygw7UxD8YgNfYm5unsyav0TuePAFGWYeM7zonD6FCt20dadcdcdI2bZ9lxzSpIGs2bBFWjVvLK8/M1RSkhNtXid5Cm2UNwgggAACCCCAAAIIIIAAAggESKBStoHXMXDPu/oBKenaxOvvfS679+yVT98YbgP45SvXyOCbHpP3Jn0jN15xjuV2kidAx4XNIoAAAggggAACCCCAAAIIIFBIoFI+Qt+iWUOZ8tYI+eDlhwrtrOebL2f+IDqmrt5916ndoS2kS8fD5MtZC93ZnORxZ2YGAQQQQAABBBBAAAEEEEAAgQAKVMoAXtsOahDvawxcHR83bXeGtG3ZpBCtvt9sHq3XyUmeQivzBgEEEEAAAQQQQAABBBBAAIEAClTKAL40r7Rd6TZLfFzNQln1vXZkp73/OslTaOUIepObVyBZOfkRVOPKUdW8fHXPqxw7E0F7oe4HsnEP9iHLxz3Y5LY87dVmfxaf92Djq3sm7sFmt+XhHhJ2yTyQG5qCq3ip+nmvlJ2XVfHjWtbdr5IBfExMDeuUn184iM3NyxMdokd79HWSp6zY4ZJfA5psAvigH46DAXzhz1zQK1EFC9RAkgtWwT/whp0LJ8FnFx0nngtWwYcvMKfUBwjggw5/8IIVgWTQ4U2BXDgJhbpeoDWfdyL40OCHUalVMoBPSU6wgXr63sxChyI9I1Nq6zITwDvJU2hl3iCAAAIIIIAAAggggAACCCAQQIEqGcBrgN6yeSNZYsbG9ZyWLF8lrVscbBfvJI/nuswjgAACCCCAAAIIIIAAAgggEEiBShnAawd0OizcCvOjk47nru93pO2x7/W/c08/UeYtWi5vfvilrF6zUUa9/oms/NMMP9fvxDLlcWdmBgEEEEAAAQQQQAABBBBAAIEACkSZsdIrXUsKG4hffX8xtluvHiA3XH62Tc/Ly5dHnn5DJk77VrQtfLVq0XLFoNNkyL8ukCjTDl4nJ3lsxgj7T9sDaxv4xPjqEVbzyK5udm6+bZuaFH+wD4bI3pvIqX2Ocde2esm1cA/mUdPOMvfuz5HaCTHBLLbKl6V9baTvy5GURNyD+WHQvgd2Z+RIahLuwXTXM9i0jCypkxQbzGIpywjs2JMldZNxD/aHYWd6lqQmxppYJdglU144CVTKAL4swPsPZMnGLTukWeP6Evt353ZF13eSp+g64fyeAD40R4cAPjTuBPChcSeAD407AXxo3AngQ+NOAB8ady2VAD409gTwoXEPt1Kr/C3YuJqx0ubvdu++Do6TPL7WJR0BBBBAAAEEEEAAAQQQQAABfwhUyjbw/oBhGwgggAACCCCAAAIIIIAAAgiEkwABfDgdDeqCAAIIIIAAAggggAACCCCAgA8BAngfMCQjgAACCCCAAAIIIIAAAgggEE4CBPDhdDSoCwIIIIAAAggggAACCCCAAAI+BAjgfcCQjAACCCCAAAIIIIAAAggggEA4CRDAh9PRoC4IIIAAAggggAACCCCAAAII+BAggPcBQzICCCCAAAIIIIAAAggggAAC4SRAAB9OR4O6IIAAAggggAACCCCAAAIIIOBDgADeBwzJCCCAAAIIIIAAAggggAACCISTAAF8OB0N6oIAAggggAACCCCAAAIIIICADwECeB8wJCOAAAIIIIAAAggggAACCCAQTgIE8OF0NKgLAggggAACCCCAAAIIIIAAAj4ECOB9wJCMAAIIIIAAAggggAACCCCAQDgJEMCH09GgLggggAACCCCAAAIIIIAAAgj4ECCA9wFDMgIIIIAAAggggAACCCCAAALhJEAAH05Hg7oggAACCCCAAAIIIIAAAggg4EOAAN4HDMkIIIAAAggggAACCCCAAAIIhJMAAXw4HQ3qggACCCCAAAIIIIAAAggggIAPAQJ4HzAkI4AAAggggAACCCCAAAIIIBBOAgTw4XQ0qAsCCCCAAAIIIIAAAggggAACPgQI4H3AkIwAAggggAACCCCAAAIIIIBAOAkQwIfT0aAuCCCAAAIIIIAAAggggAACCPgQIID3AUMyAggggAACCCCAAAIIIIAAAuEkQAAfTkeDuiCAAAIIIIAAAggggAACCCDgQ4AA3gcMyQgggAACCCCAAAIIIIAAAgiEkwABfDgdDeqCAAIIIIAAAggggAACCCCAgA8BAngfMCQjgAACCCCAAAIIIIAAAgggEE4CBPDhdDSoCwIIIIAAAggggAACCCCAAAI+BAjgfcCQjAACCCCAAAIIIIAAAggggEA4CRDAh9PRoC4IIIAAAggggAACCCCAAAII+BAggPcBQzICCCCAAAIIIIAAAggggAAC4SRAAB9OR4O6IIAAAggggAACCCCAAAIIIOBDgADeBwzJCCCAAAIIIIAAAggggAACCISTAAF8OB0N6oIAAggggAACCCCAAAIIIICADwECeB8wJCOAAAIIIIAAAggggAACCCAQTgIE8OF0NKgLAggggAACCCCAAAIIIIAAAj4ECOB9wJCMAAIIIIAAAggggAACCCCAQDgJEMCH09GgLggggAACCCCAAAIIIIAAAgj4ECCA9wFDMgIIIIAAAggggAACCCCAAALhJEAAH05Hg7oggAACCCCAAAIIIIAAAggg4EOAAN4HDMkIIIAAAggggAACCCCAAAIIhJMAAXw4HQ3qggACCCCAAAIIIIAAAggggIAPAQJ4HzAkI4AAAggggAACCCCAAAIIIBBOAgTw4XQ0qAsCCCCAAAIIIIAAAggggAACPgQI4H3AkIwAAggggAACCCCAAAIIIIBAOAkQwIfT0aAuCCCAAAIIIIAAAggggAACCPgQIID3AUMyAggggAACCCCAAAIIIIAAAuEkQAAfTkeDuiCAAAIIIIAAAggggAACCCDgQ6C6j/SISt6yLU1mzvtJdqTtkdYtmkjfnl2kevVqhfbBSZ5CK5g3m7bulKUrVhdNltiYGtKnR+di6SQggAACCCCAAAIIIIAAAgggECiBiA/gZ81fInc9OlqysnOkbcumMnbCFHm15VR5+8VhElcz1ro5yeMNeNHS3+Xex8cWW5SSnCh9PiWALwZDAgIIIIAAAggggAACCCCAQMAEIjqAP5CVLfeNeEVaNGsoo0cOkbqpyaJB91W3j5TRb30mQ64fJE7ylKb75TtPSqMGddzZoqLcs8wggAACCCCAAAIIIIAAAgggEBSBiG4Dv2LlGtmTvk/O7tvDBu8q1qXjYXJi144yyzxSr5OTPDZjCf/p4/jVqkW7f6KjI5qthD1lEQIIIIAAAggggAACCCCAQLgKRPQdeBdq3TrJrln72rxpA1mweLkUFBS400vKE1XKLfV3Js6QxIR4exf+pO6dpFZ8Tfd28/L/KcOdGOYz+cZFaSKx7mFOW2L18s1nBfcSiQKyEPeAsJa6UetucvF3plQqv2ZQd51w9ytrqRvT71WdcC+Vyq8Z/mbH3a+qzjfG5925lT9zqnspoYs/iwvItqpF8zhzRWAjOoA/vE1z28597PjJ0uGI1tKkYV3ZsGm7rF2/xbaJz83LEyd5alT3zRAfFytfzVlsHsXPkm07dttA/vVn7pYjD21u3dP35VTEPyTr6heeCSUlfV9+SMqvqoXq6Z1eVIrEz0wkHzPcQ3P01F2DST7vwfXHPbjenqVpEM/n3VMkOPN6ToN7cKyLloJ7UZHAv9fPe0Zm5MUeRWVSEmOKJvG+DAJRJqDQ7/uInWbNWyJDHxsj+zIP2Efc9YRR76inJCfInInP2/1ykscbQF5evt2ma9kvv/0l1w99Slo3byLjR93nSo6416ycfMk2P4nxvi9cRNxORUCFs3Pz5UB2niTF14iA2laeKuYY98ysPEmuhXswj2puXoHs3Z8jtRP4kg6mu96Z0ZNqTo6CqW4uVplTqd0ZOZKaxOc9mPJ6BpuWkSV1kg52WhzMsqt6WTv2ZEndZNyD/TnYmZ4lqYmxEX8HPthula28iI/genc/Wr7+4Bn52QTXubl5pkO7BjL4luFySJMG7mPlJI87s8eMtnv3nNof3lJ6dzPlzf3RM5l5BBBAAAEEEEAAAQQQQAABBAIuUDhCDXhxgSlA26d379JOenbtIL+uWidpu9Jl0Fm9CxVWWp4s06P91u1psv9AVqH1ir7ZuGWHFG1PXzQP7xFAAAEEEEAAAQQQQAABBBDwt4Bf78BrELw9bY/s2p1h65lSO1HqmaHdYmMD90jZhs3bZZMJqmuaMd9/+mWVvDRukmkP30rOOrWb28pJnhlzF5tH8V+WoTdfLFcMOs2ue/1dT8lRh7eS4zodIQkJcTJ5+jw7TN2t1wxwb5sZBBBAAAEEEEAAAQQQQAABBIIhUOEAPic3V96b9I15rHyx/GgCaG037jnpY+id27eVk088Ri46t4+U1GGc53pO539bvU5ue2CUzV47KUHOOq27DL3pYvEc6s1JHm890Tc2neK99u7nMmb8Z3b7OpzcVRf2k2sv7u+0euRDAAEEEEAAAQQQQAABBBBAwC8CFerEbuGS3+SRp9+Qv0yv7xowH9PhUNMGvaE0blDHVm7z1jRZu3GLvWutgX1Ls+zBIVfYO9p+qb3ZiF5AWLthqyTEx0nD+qleN+skj9cVTWJWdo5s2ZZmLkzkSbMm9f1+AcJXuYFMpxO7QOr63jad2Pm2CeQSOrELpK7vbdOJnW+bQC6hE7tA6vreNp3Y+bYJ5BI6sQukbsnbphO7kn0CtZRO7AIlG1nbLVcAn7E3U0aMels+/fI709t7olx7SX850zyyXtc8Lu9t2mnapE/5ap688vZU2bUnQ845rYfce+tgOySbt/ykBVaAAD6wvr62TgDvSyaw6QTwgfX1tXUCeF8ygU0ngA+sr6+tE8D7kglsOgF8YH1L2joBfEk6gVtGAB8420jacrk6sVu+co0N3s/u212mjB8hV154us/gXTHqpCTJFRecLlMnjLTBuwb+v/z+VyQ5UVcEEEAAAQQQQAABBBBAAAEEQipQrjbw2o795ivPlZvMT1mm5MRa8vi910mzxvVF25MzIYAAAggggAACCCCAAAIIIICAM4FyBfDa1l1/yjvdeMU55V2V9RBAAAEEEEAAAQQQQAABBBCokgLleoS+Skqx0wgggAACCCCAAAIIIIAAAgiEUKBcd+BLqm+aGQN+wsfT5ddVayU9I1PatGhiO7jr0vEw8TZUW0nbYhkCCCCAAAIIIIAAAggggAACCBwU8HsAf/O9z8qyX/+UuJqxUjM2xnZW99HU2XL1Rf3kzhsuxB0BBBBAAAEEEEAAAQQQQAABBMoh4NdH6HVceA3eH7v7Glk07WX59tNR8v3U0dKnRyd579NvpEDH+2BCAAEEEEAAAQQQQAABBBBAAIEyC/g1gP9j7SaJjo6Wvr2OdVdE78L3NgF85v4s2bf/gDudGQQQQAABBBBAAAEEEEAAAQQQcC5Q7kfoR7/5qXQ4spX0OPYod2ltWzaV/Px8Gf7cBDnvjBMkPq6mbNu+S978YJrUr1tbEuLj3HmZQQABBBBAAAEEEEAAAQQQQAAB5wLlDuD/XLdZXhg3UbRzutuvGyid2re1Q8sNOKOnTJr2rXz65bfuWsTG1JCRw653v2cGAQQQQAABBBBAAAEEEEAAAQTKJhBl2qWXq2F6Xl6+TDJB+ktvTJIt29KkZ9cOctu1A+XwNofI9p27ZcacxZK+N1Ma1EuRbl3aSYO6KWWrGbkDJpCVky/Z5icxvtzXbwJWt8q84ezcfDmQnSdJ8TUq826G3b7lGPfMrDxJroV7MA9Obl6B7N2fI7UTYoJZbJUvKy+/QNL35UhKIu7B/DDkm1Op3Rk5kpqEezDd9Qw2LSNL6iTFBrNYyjICO/ZkSd1k3IP9YdiZniWpibFmZK9gl0x54SRQ7gDetRPZObm2g7pX3p4iu8wQcqf1PlZuvXqAtGjW0JWF1zATIIAPzQEhgA+NOwF8aNwJ4EPjTgAfGncC+NC4E8CHxl1LJYAPjT0BfGjcw63UCndiF1Ojulw+sK98+c6TcsvV58m3P/wsZ11xnzzwxOuyeevOcNtf6oMAAggggAACCCCAAAIIIIBARApUOIDXvc7KzpFq0VFyw2Vny/T3npKrzJjvn3+9QM649G4Z+cI7krYrPSJxqDQCCCCAAAIIIIAAAggggAAC4SJQ7kbQ+uj802PelylfzZfd6XulWrVo6d6lvVxwdm8Zcv0ge1d+zPjP5L1J38hHU2bLvy47S64bfGa47Df1QAABBBBAAAEEEEAAAQQQQCCiBMp9B/5jE5RP+Pgrad60gfQ/pZv07XmsrPprg9x2/yhZuuIPqZuaLPffdplMnTDSjgv/2fR5EQVDZRFAAAEEEEAAAQQQQAABBBAIJ4Fy34F/66PpcmrPY+R/j97q3p89Gfvk5EFDZO73y6Tjka1tepOGdeXxe6+VHWl73PmYQQABBBBAAAEEEEAAAQQQQACBsgmU+w58Tm6uJCXUKlRaTTPee0xMdck2beKLTnpHngkBBBBAAAEEEEAAAQQQQAABBMonUO478F06HCafTv9Ocs148Ic0rS85pk389z/+KhkZmXJ+/17lqw1rIYAAAggggAACCCCAAAIIIICAV4FyB/BDb75YoqOjZcbcRbIv84DdeM3YGPn3tefbdvFeSyMRAQQQQAABBBBAAAEEEEAAAQTKJRBVYKZyrfn3SllZ2bLyzw2SmBAvjeqnSqwJ4pnCWyArJ1+yzU9ifLmv34T3DoZp7bJz8+VAdp4kxdcI0xpWzmrlGPfMrDxJroV7MI9wbl6B7N2fI7UT+E4IpntefoGk78uRlETcg+meb06ldmfkSGoS7sF01zPYtIwsqZMUG8xiKcsI7NiTJXWTcQ/2h2FnepakJsZKVFSwS6a8cBKocASnAftRR7QKp32iLggggAACCCCAAAIIIIAAAghUOoFydWK3ccsOWbN+S7kxdN0Nm7aXe31WRAABBBBAAAEEEEAAAQQQQKCqCZQrgF+/aZtcestwO957WcF0jHhdd/3mbWVdlfwIIIAAAggggAACCCCAAAIIVFmBcgXwdVKSTBvqHBuIjxj1tuzdt79UQM2jeTV413XrpDCsXKloZEAAAQQQQAABBBBAAAEEEEDgb4FytYFv27KpTH5rhIx4foJM+Pgr+XDKbOnTvZOcdtKx0qJZQ2ncoK7d/JZtabJmwxb5ctZC+XruYjlgOrw7tecxcu+tg6VBvVQOAgIIIIAAAggggAACCCCAAAIIOBSocC/0s+Yvkf++8K6s27i1xCKbNa4v99x6ifTudnSJ+VgYeAF6oQ+8sbcS6IXem0rg0+iFPvDG3kqgF3pvKoFPoxf6wBt7K4Fe6L2pBD6NXugDb+yrBHqh9yUT2HR6oQ+sb6RsvVx34D13TgNy/dGh5OYvXi561z1tV7rNkmoetW9ohpbrdkw7ObRVU8/VmEcAAQQQQAABBBBAAAEEEEAAgTIIVDiAd5WlATpBukuDVwQQQAABBBBAAAEEEEAAAQT8K1CuTuz8WwW2hgACCCCAAAIIIIAAAggggAACpQkQwJcmxHIEEEAAAQQQQAABBBBAAAEEwkCAAD4MDgJVQAABBBBAAAEEEEAAAQQQQKA0AQL40oRYjgACCCCAAAIIIIAAAggggEAYCBDAh8FBoAoIIIAAAggggAACCCCAAAIIlCZAAF+aEMsRQAABBBBAAAEEEEAAAQQQCAMBvwTw3/7ws6zdsDUMdocqIIAAAggggAACCCCAAAIIIFA5BfwyDvy0mT/IpGnfygnHHSWDB5xiX6OioiqnGHuFAAIIIIAAAggggAACCCCAQAgE/BLA9z+lq6xZv0Xmfr/M/jRv2kAuOe8UObffCZIQHxeC3aJIBBBAAAEEEEAAAQQQQAABBCqXQFSBmfy1S7//sU7emfi1TPlqvhzIypb4uFg55/QTZLAJ5lse0shfxbCdCgpk5eRLtvlJjPfL9ZsK1qbqrJ6dmy8HsvMkKb5G1dnpMNjTHOOemZUnybVwD+bhyM0rkL37c6R2Qkwwi63yZeXlF0j6vhxJScQ9mB+GfHMqtTsjR1KTcA+mu57BpmVkSZ2k2GAWS1lGYMeeLKmbjHuwPww707MkNTFWeNA52PLhVZ5fA3jXrmXszZSJ5pH69yZ97W4b371LO/N4/anSs1tHieZT56IKySsBfEjYhQA+NO4E8KFxJ4APjTsBfGjcCeBD404AHxp3LZUAPjT2BPChcQ+3UgNyC7ZWrTg5pEl9adqonjuAn7douehP08b15JJzT5ZBZ51k79CHGwj1QQABBBBAAAEEEEAAAQQQQCAcBfwawKftzpBPPp8jH3w2UzZu2WH397DWh5j28CdLu8NamPRZ8un07+SJl96TQ1s3k27HtAtHE+qEAAIIIIAAAggggAACCCCAQNgJ+CWA/231Ohn33hcyffZC07Y6V6pXryZnnNzVBu6d2rd17/RDd14h/752gLz/6UxJSU50pzODAAIIIIAAAggggAACCCCAAAIlC/glgJ/w8VcyZcZ8aVA3RS44+yTzeHxvqZOS5LVkDdxvuPxsr8tIRAABBBBAAAEEEEAAAQQQQAAB7wJ+CeCPbtdGepnO6fr06CzVqkV7L4lUBBBAAAEEEEAAAQQQQAABBBAot4Bfou0+J3QWfYxe274XnWbNWyKjXv/ELi+6jPcIIIAAAggggAACCCCAAAIIIOBMwC8B/Kdffitj3vrMDJOVW6zUxg3qyNgJU8zP5GLLSEAAAQQQQAABBBBAAAEEEEAAAWcCfgngFy393Q4JN/i8U4qVerC3+SPl+x9/LbaMBAQQQAABBBBAAAEEEEAAAQQQcCbglzbwW7alSesWTWzv896KbduqqXy38BfJys6R2Jga3rKEJE3rPXPeT7IjbY+tf9+eXYrtg5M8Iak8hSKAAAIIIIAAAggggAACCFQpAb8E8PqY/LJf/5T8/HyJji5+U3/thq122LhwCt5nzV8idz062l5UaNuyqX3M/9WWU+XtF4dJXM1Y+yFwkqdKfVrYWQQQQAABBBBAAAEEEEAAgZAJFI+2y1GVzh0OtXexR77wjh0H3rWJvZn75b1PvxHtyK7DEa1cySF/PZCVLfeNeEVaNGso33z4rHz86qMy7tm7ZdWf62W0acuvk5M8Id+RclTgl19/knfGnCLTXmsvU794sxxbYBUEEEAAAQQQQAABBBAIhcCcb6fKO6OOlgmjjpMFPxTvQDwUdaLM4Ar45Q78peefKp99+Z28/ckMmT57kRx5aAvJNMH7T8tXS25untSoXl3+c+OFwd2zEkpbsXKN7EnfJzdefo7UTU22Obt0PExO7NrRXGz4SYZcP0ic5CmhiLBcpL/kx6zqI+3r/F29XVfK66M/l6tvfD8s60ulEEAAAQQQQAABBBBA4KDAp588KlfFPC5Rf5/L56/uIx9veE7OH/BviKqQgF8CeA3Q33zuXvnfKx/JJBPIzzaPp+ukj9NrYDzs35dKq+aNw461bp2DwburYs2bNpAFi5dLQUGBK0lKyhMVFSU5ufnuvOE+s3rBUOlat3AtL078QOaPnVY4kXeBE9CPVlTgNs+WfQjg7gMmwMm4BxjYx+Zx9wET4GTcAwzsY/O4+4AJcLJxX8X5TICRi29+QFxGodNIfZQ6dvOTJh65pXjmME6pUd0vD4GH8R4Gtmp+CeC1ikmJteTBIVfI/XdcLpu37pQs85h6syb17d33wO5C2bd+eJvmtp372PGTzaP9raVJw7qyYdN2Wbt+i20Tn5uXJ07y6IWLzKy8slcgRGs0qrGmWMlx5venW0J6sXQSEEAAAQQQQAABBBBAILwF2sRtj6h4RDWTCeAr9KGKMneb9dpllZu0Xf7Qx8bIvswDUq1atOmAr0D0jnpKcoLMmfi89XCSJ5Lg3nrzLrm8xlOFqvz1nnqS3vjhQmm8CYyA6eNRcs1/MfzRCgywj61a9zzjXoOrvT6IApJs/qRKTk6eGXmkWkC2z0a9C+gXelZ2ntTE3TtQAFMP4B5AXd+bxt23TSCX7Def9zj+zgSS2Ou289b9TwbWWVVo2eu7zparb/60UBpvKreA3wJ47Wl+yoz5oq/55mS56NSgforcdeNFRZND+j5jb6b8/Ntftp1+i2YNZPAtw6V5kwYy4YVh7no5yePOHOYzB7IOyMdjT5R+tRdLUnSBTN/dRFKPHS9djzspzGteOaqXbZpb6IlGUnz4DKVYOWRL3gtt5qJPyiTXwr1kKf8uzc0rkL37c6R2Qox/N8zWShTIM1dO0vflSEoi7iVC+XlhvrkXsjsjR1KTcPczbYmb01tQaRlZUifp4OhBJWZmoV8FduzJkrrJuPsV1cHGFi1bJuvmnC/9UlaLXij/fNcR0u38adK08SEO1iZLZRHwyyP0f63bLBfd+Kjs3bffp4v2+B5uAXxiQrx079LO1vnLWQslbVe6/OeGwp3tOcnjc6fDbEHN2Joy+NaFsmX7Dlm6cZ2ccXTnMKsh1UEAAQQQQAABBBBAAAFvAi1bHCbHHLVK1qxdLTExsTKocTNv2Uir5AJ+CeAnfPyVDd6H3nyx6d19r7xs2pZ/9f7T5tHJGjLdBMaPPTdebr7y3LCi3LB5u2zaskNqmjHff/pllbw0bpId6u6sU7u56+kkjztzBM2k1E6VWrVqR1CNqSoCCHjzS3YAAEAASURBVCCAAAIIIIAAAgioQMsWbYCowgJ+CeBX/bVBtAf3KwadJp9Nn2c5q0VHSZ2UJLno3D4y/uPpMv6j6XLGyV3Dhvq31evktgdG2frUTkqQs07rLkNvutj2nO+qpJM8rry8IoAAAggggAACCCCAAAIIIBBIAb8E8Dqmep2Ug0Oy1TVBu07aFr5BvVTbMZz29D75q3mSnZNrOpLyS5EVNunVraN8+sZwSYiPk4b1U71uz0keryuSiAACCCCAAAIIIIAAAggggICfBfzSLbMOIbdtxy5btfaHt5Ro05v7N9/95K7q+k3b7Pz+A1nutFDP6BBwbVo08Rm8a/2c5An1flA+AggggAACCCCAAAIIIIBA1RDwy+3wxg3qyI8/r7Tjvzcy8xrEvzvpazlgxoLXYdqWrfjDjrWebAJ9JgQQQAABBBBAAAEEEEAAAQQQKLuAXwL4M03Hb/FxNSVtT4ZoAP/Y3dfKxTc9Kh9OnmVrFB8XKw//56qy1441EEAAAQQQQAABBBBAAAEEEEDACvglgG/WuL6c2vMYadaont1o6xaNZdbHz8nCpb/JXjPWepejD5cGdVMgRwABBBBAAAEEEEAAAQQQQACBcgr4JYAf9/4X8tGU2fLh2EfkyL8fk9e77r26dixntVgNAQQQQAABBBBAAAEEEEAAAQQ8BfzSiV1KcqLdZrQZOo4JAQQQQAABBBBAAAEEEEAAAQT8L+CXAL7bMe1szRYt/d3/NWSLCCCAAAIIIIAAAggggAACCCAgfgngO3doKyccd5S8PGGybDXDyWnP80V/wmkIOY47AggggAACCCCAAAIIIIAAApEm4Jc28I88/aZ8+8PPdt/7DLzDq0GLZg1l6viRXpeRiAACCCCAAAIIIIAAAggggAACJQv4JYA/rHWzUjusq1+PXuhLPhQsRQABBBBAAAEEEEAAAQQQQMC3gF8C+MsG9hX9YUIAAQQQQAABBBBAAAEEEEAAgcAI+KUNfGCqxlYRQAABBBBAAAEEEEAAAQQQQMAl4Jc78D/89Kv8sWaTa5teX5OTE+SMPsd7XUYiAggggAACCCCAAAIIIIAAAgiULOCXAP6z6fNk4hdzSyxJO7EjgC+RiIUIIIAAAggggAACCCCAAAII+BTwSwB/8bl97DBy3kr5ctZCmT57oVx1UT9vi0lDAAEEEEAAAQQQQAABBBBAAAEHAn4J4Nsd1lL0x9vU9ZgjZd7CX+T7xStkYP9e3rKQhgACCCCAAAIIIIAAAggggAACpQgEvBO72kkJckzHw2TOgmVSUFBQSnVYjAACCCCAAAIIIIAAAggggAAC3gQCHsBroVFRInsz98vu9L3e6kAaAggggAACCCCAAAIIIIAAAgiUIuCXR+g3bN4uO3buKVRUgRTI/v1Z8r3poX72/KVy7NGHS0pyYqE8vEEAAQQQQAABBBBAAAEEEEAAAWcCfgngx7z1WYm90NeoXl2uG9zfWY3IhQACCCCAAAIIIIAAAggggAACxQT8EsD37n601ElJKrbx6OhoaVg/VXp0aS9NG9crtpwEBBBAAAEEEEAAAQQQQAABBBBwJuCXAP6UE48R/WFCAAEEEEAAAQQQQAABBBBAAIHACPilE7s167fINUOekMefn1Cslh9NnW2XzZq3pNgyEhBAAAEEEEAAAQQQQAABBBBAwJmAXwL4T76YKwt+XCE65nvRqU/3TrJ0xR/y5odfFl3EewQQQAABBBBAAAEEEEAAAQQQcCjglwB+xe9rJLV2ovTp0blYsammbXzvbkfLL7/9WWwZCQgggAACCCCAAAIIIIAAAggg4EzALwH8noy90qSR707q6tWtLZlmSLnsnFxntSIXAggggAACCCCAAAIIIIAAAggUEvBLAN+iWSP5a+1mSc/YV2jj+qagoECWLl9te6OPqeGXPvOKlUECAggggAACCCCAAAIIIIAAApVdwC8B/Ek9OsnezP3y7wdGiXZop1NObq5tF3/fiFdsG/gTjjuqsluyfwgggAACCCCAAAIIIIAAAggETMAvt8TP6HO8fDP3R/li5vfS/7J7JDmpluSYx+X1sXmdGjWoI3dcPyhgO8GGEUAAAQQQQAABBBBAAAEEEKjsAn4J4BXpqYdulJ7dOspE0yP9X+s2S5T516ZFEzmu0xHyr8vOlvi42Mpuyf4hgAACCCCAAAIIIIAAAgggEDABvwXwWsOz+3a3PwGrLRtGAAEEEEAAAQQQQAABBBBAoIoK+KUN/PLf/5JTL7xT7vq/McUYx3803S775PM5xZaRgAACCCCAAAIIIIAAAggggAACzgT8EsB/+uV3smnrTrnkvJOLlXp+/16yb/8B+WDyrGLLSEAAAQQQQAABBBBAAAEEEEAAAWcCfgngV/6xXhrUS5VO7dsWK1Xbvp/UvZNoHh1SjgkBBBBAAAEEEEAAAQQQQAABBMou4JcAfn9WttRNTfZZekKtONsrfW5ens88LEAAAQQQQAABBBBAAAEEEEAAAd8Cfgngtbf51Ws2ymbzGH3RyY4Hv3iFNGlUT2pU92ufeUWL4j0CCCCAAAIIIIAAAggggAAClVbALwF8/1O6SZa5C/+vu5+W2QuWSnrGPtmyLU0++GymXHvnkza4P633sZUWkR1DAAEEEEAAAQQQQAABBBBAINACfrkl3r1LO7lu8Jny6jtT5aZ7ni1W545HtpYbrzinWDoJCCCAAAIIIIAAAggggAACCCDgTMAvAbwWdft1A6V3t6Nl4rS58te6zbbN+yFNGshxnY+Q8/qdKNFRUc5qRC4EEEAAAQQQQAABBBBAAAEEECgm4LcAXrd8dPs29qdYKSZhw+bt0tS0g2dCAAEEEEAAAQQQQAABBBBAAIGyC/g1gC9a/MYtO2TKV/Nl8vTvRAeQmzp+ZNEsvEcAAQQQQAABBBBAAAEEEEAAAQcCfg/g9+7bL9Nm/WCC9nmyeNlK99jvvbp2dFAdsiCAAAIIIIAAAggggAACCCCAgDcBvwTweXn5MveHZTZon/ndT5KVnWPLatKwrpzVt7ucaXqpb3lII2/lk4YAAggggAACCCCAAAIIIIAAAg4EKhTA//LbX/KZeTz+i2++l7TdGba41NqJcrzpuG7OgmVy7SX95YKzT3JQDbIggAACCCCAAAIIIIAAAggggEBJAuUO4O99fKwJ3ufZbdeMjREdC17vtPc4tr38tnqtDeBLKphlCCCAAAIIIIAAAggggAACCCDgXKDcAfzu9L22lKOOaCVPPXgjPcw7NycnAggggAACCCCAAAIIIIAAAmUWiC7zGn+v0LZVM6levZr8/Oufcsald8uN9zwjn3+9QA5kZZd3k6yHAAIIIIAAAggggAACCCCAAAI+BMp9B37I9YPkqgtPt+3f9VF6bfOuP/FxsdLu0BY+iiMZAQQQQAABBBBAAAEEEEAAAQTKIxBVYKbyrFh0nTXrt9gO7XT4uE1bd9rFqSlJ0u+k42z7+I5Hti66Cu9DJJCVky/Z5icxvtzXb0JU88guNjs3Xw5k50lSfI3I3pEIq32Occ/MypPkWrgH89Dl5hXI3v05UjshJpjFVvmy8vILJH1fjqQk4h7MD0O+OZXanZEjqUm4B9Ndz2DTMrKkTlJsMIulLCOwY0+W1E3GPdgfhp3pWZKaGCtRUcEumfLCScBvAbxrp/R6gI7/roG8jgev48Lr1KXjYfLmc/e6svn1dcu2NJk57yfZkbZHWrdoIn17drGP93sWkp2TK/MXL5ely1dL56MOleM6HSExNUoOYPVCxNIVqz03Y+djY2pInx6di6VHSgIBfGiOFAF8aNwJ4EPjTgAfGncC+NC4E8CHxp0APjTuWioBfGjsCeBD4x5upZYcwZajtlHmkpAG6/pz322Xio4Lr4/Yb9y8vRxbK32VWfOXyF2PjrZjz7dt2VTGTpgir7acKm+/OEziah68MqiP9v/n0ZckoVa8HHloc3n/05nmDnSOjBp+m3TtfKTPQhYt/V20t/2iU0pyovT5NHID+KL7w3sEEEAAAQQQQAABBBBAAIHwF/B7AO+5y3qn+nTzCL3+7D+Q5bnIL/PaYd59I16RFs0ayuiRQ6RuarJo0H3V7SNl9FufibbT1+nJ0e9JnZRkmTp+hERHR0vm/iw59cI75aU3JpUYwLsq+eU7T0qjBnVcb3lsxS3BDAIIIIAAAggggAACCCCAQLAEyt0LfVkr6LobXtb1Ssq/YuUa2ZO+T87u28MG75pX7/yf2LWjzDKP1LumfeYx/np1km3wrmna0V7rFo0lLz/flaXEV+1tv1q1aPePXgRgQgABBBBAAAEEEEAAAQQQQCCYAgG9Ax+sHalrgnPPqXnTBrLAtHfX9vj6SP+5/U6Ql8dPlpvu/Z/cfOU5sicj0w5/98Adl3uu5nP+nYkzJDEh3t6FP6l7J6kVX9OdVzsli7RJ26ZqO8lIrHukWXvWV83zcfckCcq8dTd/C/i8B4XbXYheHzUfd9zdIsGZUXNtF8znPTjerlIMuegP7i6R4L7iHlxvV2m4uySC+5qVE3mxR1GhmjHViibxvgwCER3AH96muW3nPtYE5x2OaC1NGtaVDZu2y1rTI35Wdo7k5uVJjerV5darB8jCJb+bYe6WymzTZl6ngWf2kgFn9CyVSu/WfzVnsRnfPku27dhtA/nXn7nbtqXXlTUYjrRJAxq9uBGJdY80a8/6HgwkI/Mz47kfkTavF000oOHzHtwjp5168XcmuOZamprrPz7vwbVXd/1Dg3uw3Q9esMI9uO6u0nB3SQTvVf/U5OTqDcrglUlJ4Sfg917og72Ls+YtkaGPjZF9mQfsI+56sq533VOSE2TOxOdtde4ZPtb0jP+7jHv2Htm8fadowD9v0XK5bvCZcvt1A31WOS8v327TleGX3/6S64c+Ja2bN5Hxo+5zJUfcK73Qh+aQ0Qt9aNzphT407npixzBywbfXC4UMIxd8d3qhD765lqjBDMPIhcaeXuhD404v9KFxD7dSI/oOvGL27n60fP3BM/KzCa5zc/NMh3YNZPAtw+WQJg2sddqudJk6Y74N1Js2rif606XDYXLbA6NEH42/8YpzRDvb8zZpu3fPqf3hLaV3N1Pe3B89k5lHAAEEEEAAAQQQQAABBBBAIOAChSPUgBcXmAK0fXr3Lu2kZ9cO8uuqdaJB+6CzetvCdGx4vTK+J2Ofu3B7h752oukZP9veudcFWaZH+63b00rtLX/jlh1StM29e8PMIIAAAggggAACCCCAAAIIIBAggYi/A7/BjC+/yQTVNc2Y7z/9skpeGjfJtIdvJWed2s2StW7RRJo2qicfTZ1t2q23kB7HtrdDzX3xzfcysH8vSTWBvE4z5i42j+K/LENvvliuGHSaTbv+rqfkqMNbyXGdjpCEhDiZbMaz12Hqbr1mgF3OfwgggAACCCCAAAIIIIAAAggESyDiA/jfVq+zj8MrWO2kBDnrtO4y9KaL3UPG6WPwLzx+mwwb8arc+chLble9W+8ZiOtd+aJTY9Mp3mvvfi5jxn9mF+lwcldd2E+uvbh/0ay8RwABBBBAAAEEEEAAAQQQQCCgAhHfiV1Obq6s3bBVEuLjpGH9VJ9Y2kPstp27ZWdaus3nuvPuc4W/F2hv9lu2pUme6dG+WZP6tlf70tYJ9+V0YheaI0QndqFxpxO70LjTiV1o3OnELjTudGIXGnc6sQuNu5ZKJ3ahsacTu9C4h1upEX8HXoeJa2Meky9t0jvsDeqm2J/S8nou1w7udFx5JgQQQAABBBBAAAEEEEAAAQRCKVApOrELJSBlI4AAAggggAACCCCAAAIIIBAMAQL4YChTBgIIIIAAAggggAACCCCAAAIVFCCAryAgqyOAAAIIIIAAAggggAACCCAQDAEC+GAoUwYCCCCAAAIIIIAAAggggAACFRQggK8gIKsjgAACCCCAAAIIIIAAAgggEAwBAvhgKFMGAggggAACCCCAAAIIIIAAAhUUIICvICCrI4AAAggggAACCCCAAAIIIBAMAQL4YChTBgIIIIAAAggggAACCCCAAAIVFCCAryAgqyOAAAIIIIAAAggggAACCCAQDAEC+GAoUwYCCCCAAAIIIIAAAggggAACFRQggK8gIKsjgAACCCCAAAIIIIAAAgggEAwBAvhgKFMGAggggAACCCCAAAIIIIAAAhUUIICvICCrI4AAAggggAACCCCAAAIIIBAMAQL4YChTBgIIIIAAAggggAACCCCAAAIVFCCAryAgqyOAAAIIIIAAAggggAACCCAQDAEC+GAoUwYCCCCAAAIIIIAAAggggAACFRQggK8gIKsjgAACCCCAAAIIIIAAAgggEAwBAvhgKFMGAggggAACCCCAAAIIIIAAAhUUIICvICCrI4AAAggggAACCCCAAAIIIBAMAQL4YChTBgIIIIAAAggggAACCCCAAAIVFCCAryAgqyOAAAIIIIAAAggggAACCCAQDAEC+GAoUwYCCCCAAAIIIIAAAggggAACFRQggK8gIKsjgAACCCCAAAIIIIAAAgggEAwBAvhgKFMGAggggAACCCCAAAIIIIAAAhUUIICvICCrI4AAAggggAACCCCAAAIIIBAMAQL4YChTBgIIIIAAAggggAACCCCAAAIVFCCAryAgqyOAAAIIIIAAAggggAACCCAQDAEC+GAoUwYCCCCAAAIIIIAAAggggAACFRQggK8gIKsjgAACCCCAAAIIIIAAAgggEAwBAvhgKFMGAggggAACCCCAAAIIIIAAAhUUIICvICCrI4AAAggggAACCCCAAAIIIBAMAQL4YChTBgIIIIAAAggggAACCCCAAAIVFCCAryAgqyOAAAIIIIAAAggggAACCCAQDAEC+GAoUwYCCCCAAAIIIIAAAggggAACFRQggK8gIKsjgAACCCCAAAIIIIAAAgggEAwBAvhgKFMGAggggAACCCCAAAIIIIAAAhUUIICvICCrI4AAAggggAACCCCAAAIIIBAMAQL4YChTBgIIIIAAAggggAACCCCAAAIVFCCAryAgqyOAAAIIIIAAAggggAACCCAQDAEC+GAoUwYCCCCAAAIIIIAAAggggAACFRQggK8gIKsjgAACCCCAAAIIIIAAAgggEAwBAvhgKFMGAggggAACCCCAAAIIIIAAAhUUIICvICCrI4AAAggggAACCCCAAAIIIBAMAQL4YChTBgIIIIAAAggggAACCCCAAAIVFCCAryAgqyOAAAIIIIAAAggggAACCCAQDAEC+GAoUwYCCCCAAAIIIIAAAggggAACFRQggK8gIKsjgAACCCCAAAIIIIAAAgggEAyB6sEoJFzL2LItTWbO+0l2pO2R1i2aSN+eXaR69WqFqpudkyvzFy+XpctXS+ejDpXjOh0hMTWqNFshH94ggAACCCCAAAIIIIAAAggER6DKRqKz5i+Rux4dLVnZOdK2ZVMZO2GKvNpyqrz94jCJqxlr9ecsWCb/efQlSagVL0ce2lze/3SmZOfkyKjht0nXzkcG5whRCgIIIIAAAggggAACCCCAAAJGoEoG8AeysuW+Ea9Ii2YNZfTIIVI3NVkWLf1drrp9pIx+6zMZcv0g++F4cvR7UiclWaaOHyHR0dGSuT9LTr3wTnnpjUkE8Pz6IIAAAggggAACCCCAAAIIBFWgSraBX7FyjexJ3ydn9+1hg3cV79LxMDmxa0eZZR6pd0379u2XenWSbfCuafFxseZR+8aSl5/vysIrAggggAACCCCAAAIIIIAAAkERqJIBvEu2rgnOPafmTRvIhk3bpaCgwCaf2+8EWbxspdx07/9k+e9/ybxFy+XnX/+U88/o6bka8wgggAACCCCAAAIIIIAAAggEXKBKPkJ/eJvmtp372PGTpcMRraVJw7o2cF+7fottE5+blyc1qleXW68eIAuX/C5zFiyV2abNvE4Dz+wlAwjgA/7BpAAEEEAAAQQQQAABBBBAAIHCAlHmbvPB282F0yv9u1nzlsjQx8bIvswDUq1atOTnF0hUVJSkJCfInInP2/2/Z/hYcwf+dxn37D2yeftO0YBf78JfN/hMuf26gZXeiB1EAAEEEEAAAQQQQAABBBAIH4EqG8DrIcjYmyk///aX5ObmmQ7tGsjgW4ZL8yYNZMILwyRtV7r0GnCbDdSvuaS/PWJ6reO2B0bJgh9XyNxJoyQ2pkb4HElqggACCCCAAAIIIIAAAgggUKkFqnQb+MSEeOnepZ307NpBfl21zgbtg87qbQ+4jg2fbwL2PRn73B8Ae4e+dqLsP5Bt79y7FzCDAAIIIIAAAggggAACCCCAQIAFqmQbeDXdsHm7bNqyQ2qaMd9/+mWVvDRukmkP30rOOrWbJW/dook0bVRPPpo624wB30J6HNveDjX3xTffy8D+vSTVBPJMCCCAAAIIIIAAAggggAACCARLoMo+Qj9j7mL7OLxC105KkH4nHy9Db7pYYmr8c01j1V8bZNiIV2W5GXbONend+uH3XBfSAP6rOYukbcumdhx7V730Vdvzz1+8XP5at9kma10Pa32IZ5YS53en7zUd9i2TtRu2mOHymtgnExLi4wqt4yRPoRUq0Rtf7kV3UZtYaHOLbse0K7rI63vNO/f7n+1IB7VNHwzdu7QXHRHBc8K9+Ofd5bM3c78sW/GneYpmrRzIypaLzukjdVKSXIt9vuLuk8YuKOnznp2Ta//WLF2+Wjofdagc1+mIQn87S9qyE3cneUoqI9KW6dNeS8yF5BUr10ra7nTp1L6tHN/5yGKmFfk74MTUSZ5Isy2pvk7cK/q96sTUSZ6S9iMSlznZZyd5fO27k3Wd5PG1/UhNL22fnfxOlLbveu68YPEKydyfJR3btZau5m+Z51RaHTzzVpb5su7zGtOp9q+r10rvbkfbTredOODuRKny5KmyAXxObq4JVLeKBqgN66f6PKL6S7dt527ZmZZu84Xyzru21Z9lesO/48EXZNjtl9lAxbPi19/1lHy38Bf3xYW03RnS8pBGMn7UfaZzvpKfGNi0dadcdcdI2bZ9lxxi+gFYY4L4Vs0by+vPDHWv6ySPZ30qy3xp7p77OXXGfNM54svS7rCW8sHLD3ku8jqvny/N//nXC+wFGT1m2dk5Mmr4bbZ5h66Eu/fPu9osWvq73PnIS7b5S2MzmkS66dfipRG32wBIl/uacPclI7ZPkJL+zuhFvv88+pIk1Io3Tyc1l59+XiXZOQc/s0VP1IqW4sTdSZ6i24309598PkceeOJ1iY2NkXqpyfYJsfi4WHni/hvkpB6d7O5V5O+AE1MneSLduWj9nbhX5HvViamTPEXrHenvneyzkzy+HJys6ySPr+1HarqTfXbyO1HS/n8x83vRDqCTTBPV+PiadoSnywb2lXtuucSu5qQOJW0/EpeVdZ+3bEuTi258VLab2GP6e0/ZkbJK22/cSxOqhMvNB4spAgRW/rm+oF3vKwuO7HWF/Xl30tfFav3mh18WLFvxh03PN93qv//pNzbvS29MKpa3aML//e+tguPOuKHA3H23i375/a+CjidfU+C5rpM8Rbcb6e+duLv20YxYUHD0KdcUdDr12oJB1z/sSi7x9Yclv9pj9M7EGTafuYNcMPC6BwvOuXKYez3cryjw9nlft3FrQYeTry64+o7/Fmzbsct65eXlFZgLLm47XzO4e5dx8nk/8/J7C06/ZGiBWutk7lAWdD/r5oLLbh3ufaMeqU7cneTx2GSlmDV3qwomTfvW/dldv3FbwbH9/uW3vwNOTJ3kqRTYHjvhxL0i36tOTJ3k8ahypZh1ss9O8vjCcLKukzy+th+p6U722cnvhK/91+8E0/mz/U52fT+Mev0Te47zx5qNdjUndfC1/UhNL8s+7923v+Dcq++35996vm+a+5a627iXSlQpM1TpTuwi6XpMi2YNZcpbI0q8q3u5ucp5lGnHr5N2uHf2aT3s62Zzd9012UeMzZU9ExS6kuzrlzN/kF7mUR29+65TO9Puv0vHw+TLWQvte/3PSR535koy48Rdd9UEk3LrsOfl/DN7yYnHd/C69/994R17VdX8gXYvn2bca5q7boPO7G3TdGSDC846SfRRqD/XbrJpuLu5Cs28bIZ1zMvLl4fuvELq1altl0VHR9thIT0z4u6pUfK8k8/7PvP5rVcnWdRaJ71T3LpFY8nLzy+08fK6O/mdKFRQJXhzfOcj5Bzz91qHNNWpaeN65u/v4ebpmx3uvXP6dwB3N1mpM07cnXyvakG4l8rtzuDkd9xJHtzdpI5mnJg6+Z3w5b7455X2rvElA05xfz/o3Xc9H3WdSzqpg6OdiaBMTvfZ3HizTxTmmKcw777lYq97OHvBUnseOWPOYvdy3N0UVWrm4NlCldrlyNzZGtWr20esmzdt6HgHtHM+c9lJWjZv5F5Hx7v/+dc/5Y81B4NDXZBl/ljoo9ttWzZx59MZfe8K/p3kKbRyJXnjxF1HKrjxnmelw5Gt5L5bB/vc8z9N3wRqr803XJM+KqVBU/Xq1VxJtn8DfbN5205Hx8a9YiWaceI+a94SObRVM/nKfJENG/mqPPz0G7aJSVEG3IuK+H7vxP3cfifI4mUr5aZ7/2f7bZi3aLn9XJ9/Rs9CGy6Pu26gtN+JQoVU0jd6Iqf9C2gTKJ3K8vcX9/J/KIq6e9uSt+9VzYe7Ny3vaU5+x53kwd27r69Up6ae6/v6nfD2ed+8Nc2u6nkumZxYS+qbC+yuc8ny1MGzPpE473Sfhz83QX4xQ1uP/u8QSTZ9c3mbdIhrPY/csWuPezHubooqNfNPj21Varcr/85mmc68nh7zgW2/fl6/E907XLNmjDz3f7e628nrAv2DoFN8XE376vpP32sHYRpwOsmjJ/9VbVKb2+5/XmJjYuTph252X3X25nDjFeeIDlOYaNoOuyZ1rWXaiXlOekdTJ72ogrunzD/z+iTJrj0Z9icmprptI/bzb3/Kh5Nnya1XD5AbLj/bnRl3N4VfZtR34ZLfTYeXS2W26ZNDp4HmyZMBRQL48rjrtkr7ndA8lX168Y1Joh3W6dMlOpXl7wDu5f90FHUvuiVf36uaD/eiWr7fO/kdd5IHd9/G3pY4NfVc19fvhK/Pu65b/FwyVtLM97VO5amDXTGC/3Oyz6apjmj/A+OevUeaNa4vP5tA3tuknZvqOfwRbZu7F+v2dcLdTVIlZqpexFUFDqv2EH2LCSr1Eewx5kqe9rLvmqLNo0ynnHiM6619jTGPbeukV1o9p9y8PNH81cyjsk7yeK5bVeZfe/dz+eX3NfLqU3dJurkTrz/7D2RJjunUS6+6ppjhBvWxeJ2ObtemGEsNM+pB0UePXe/1ggjuxchsgl7c0OnOGy6Uqy/qZ+e199ybzJMQL705Sa4yabhbFr//d+/jr5jP9k6Z9vYTsnn7ThlrmjJ8NGW2vVh4+3UD3eWV5/OuK5f2O+EuoJLOmP4wZMxbn8nlg06Tvr2OtXtZlr8DuJfvg+HN3XNLJX2vaj7cPbVKnnfyO+4kD+4lOxdd6tTUtV5JvxO+Pu+6rj7p6TnlmqZurqcMy1oHz+1E6nxp+6zn6k+8+K49n9FOtfXccfffFzy279htOoyNE32SQafGDerYH08L3b5OuHuqVP55HqGvZMdYh7y54e6nbc/QL5iezHV4p9KmFDN0mQbq2oO355SekSk6rJm2dXWSx3PdqjK/J/1gwD74lsfk5AuG2B8dCWDlnxvs/DwzX9JUJyVZMoq46yP5OtVJTcLdB54+kqefy8z9B9w59DPcu/vRtl38mvUHh1J0Lywyg3sREIdv9Uq/jrSgQ/VpO+1jTTvtsU/+R04+obPoyZ4+6l3SVJq7ruskT0llRPIyvSCoj1Fqu+u7b/6nDWRF//46MXWSJ5JtS6q7L3fXOuX5XtV1nZg6yeOqR2V5dbLPTvL48nCyrpM8vrYfqell2efSfie8GbiGby16TpO+d5/UNaNr6FSWOngrIxLTStvnjL/7RXp6zPvu80j9HtBJzy1HPP92ibuNe4k8lXYhAXwlOrRbd+ySy//9uKz8Y4O8/uzd0v3Y9sX2TtvEb92eZh89di3UQEjbyes4xJ7TkuWr7HjwmuYkj+e6VWVeH9We9s4ThX66d2ln27Frejcz75r0kVi112PgmtqYfgb+WrtZXEG7pi8xbV+td7NGuLugirzq1fymjerZC1Wei7RtmE716qS4k3F3U1R4ZkfaHtEnHTw/r9pBkT5psv9Atmig45rK467rlvY74dp+ZXrVp58ef36CPDv2Q9GnGO7+e8gl1z6W5e8v7i610l9Lc9ctOPle1Xy4q4KzycnvuJM8Whruzsw1lxNTJ78Tui1v7m1bNtVF8pM5d3RNOp653uhobYYl1slJHVzrVpbX0vZZH4cveh459O8LuOPMubxrXj20GY+eR2ozQteEu0uiar0SwEfI8dY7W8tXrpEV5kcnHRNY3+sJtWu65Kb/k99Wr5MrLzzdPuI6ffZCcf3oWOY66Ul2n0FD5I6HXnStZl/PPf1E0c6otB3O6jUbxQz9Ye8ie7afd5Kn0EYrwZvS3PWxJm2v5Pmj7ZD0kVdN0x7mXdPdZrx3tdcvPtekPU/r9MB/X5Pf/1gn2jHbuPe+sD3Zu65Y4+79837NxWfIgh9XiLbR05OE8R9NF+2ZtVfXjoX6eMDd9Wkr/bW0z3vrFk3shZOPps4W7VlX77TM/O4n+eKb72Vg/15+cXfyO1H6nkRWjqdf/kDe/mSGad7UWZo3beD+u61/v80wQnZnnP4dKO/nHXfv7k6+V/UA4e78d87JZ81JHtydm2tOJ6ZO/hb5ctfRSNof3lJeeH2i/W5esXKtPPzUONucrf/JXW1lndTBZqxE/5W2zzHmEXjPc0idd42s08TcqEg1F8hd0+fmu1bPI82wo64kOwoM7m6OKjMTpYPjVZm9jeAd1Ueyz7v6/mJ74NlhV8dTrhFXoF404/zJL0qSCTa1fXaX0/9lH63XK3uuSYfjesT04j3R/FHQK7A6nNEVpg3mkH9dYIcA0XxO8ri2V1lenbgX3dfbHxxlepBPk/fHPFRo0Q13PyNzv18m3332QqF+CTQQevDJ1913L49u30ae/79/m0fNkuz6uP/D6Pl51zvBT41+3wbu+pnVSR/lfuSuq2x7bNdauLskSn918nnXIQ6HjXjVXkB0bbFn1w4y/J7rCp1olNddt1na74Sr3MryqsHfFNM0wdv00JAr5IKzT3L89xd3b4re05y4O/le1a3j7t3YV6qT33EneXD3Jew9vTRTJ78TumVf7hu37JBb7vufvQGk+bQPpicfvFH0yUTXVFodXPkq02tZ9/mLmd/Lfx4ZLV+9/3ShNu8Tv5gr95sbPg/ccbltyuYywt0lUXVeCeCrzrF2tKca4OsfAr0C6OoErOiKTvIUXYf3JQtoMLp+4zZJTIgvFAR5roW7p8Y/8+qidykb1E2xF6n+WVL6HO6lG3nLodd9t+3cLTvT0kU73fG8Q+Atf9E0J+5O8hTdblV4X5G/A05MneSpCs7+3Ecnpk7y+LNO4bAtJ/vsJI+vfXGyrpM8vrYfqenB2Oft5vshc3+WHNKkvvsmkKdXMOrgWV44zAdjn3EPhyMdnDoQwAfHmVIQQAABBBBAAAEEEEAAAQQQqJAAbeArxMfKCCCAAAIIIIAAAggggAACCARHgAA+OM6UggACCCCAAAIIIIAAAggggECFBAjgK8THyggggAACCCCAAAIIIIAAAggER4AAPjjOlIIAAggggAACCCCAAAIIIIBAhQQI4CvEx8oIIIAAAggggAACCCCAAAIIBEeAAD44zpSCAAIIIIAAAggggAACCCCAQIUEqj1spgptgZXdAvsyD8jX3y6W1Ws22h9dUCclyb28pJltO3bLVbePlJaHNJLGDeuWlNUuW75yjaz6c70ZY7OB17y/rV4nH02ZLes2bpX6Znzs+LhYr/lKStT9mbNgqdmnH+XHn1dKQq2aUjc1udgqu9P3yvTZi8zPQtm5K10aNagjMTVquPM53Y5rhaysbPlq7iKpUb261E5OcCXzigACCCCAAAJBEvhu4c+i5xp6TrNlW5o0b+r9fKNodcp6PqPnENNm/iCtWzSWatGF7yvl5ObKl2aZLv9z3SZ7PpMQH1e0yFLf6xjcP/2yyp7PzJq/RLJzcu25SrVqhcsrMPnmfv+zfP71ArvfSQm1pHbSP+chTrfjWaEFP66Q9Zu2SbPG9T2TmUcAAQTKLVC93GuyYjGBXbsz5L8vvGvTt+/cLTdcdra0vaZpsXzeErKzc+wXZfrefd4WF0pbs36L3Pv4WEmtnSQ9jj2q0DL9Urrkpv+Tv9Ztli4dD5NNW3fKQ0+Ok0sH9pW7b764UN7S3tzx0Avy3cJfTDmJNuv/XvnIXmAYP+o+SUk+mKbbv+qOkbJt+y57MeHVd6ZKq+aN5fVnhrrzONmOqy765Xm32bevzAWBIf+6QK65+AzXIl4RQAABBBBAIEgC496bZoPY9Ix90thcmD/x+A6OSi7L+Yxu+/lXP5b3P5spvbp1dJ83aEFp5obAleb84o81m6Rls4ay05xjPTv2Q3lxxO1ybMfDHdXFlWnSF3PlgSdel9jYGKlnbkS8PH6yvbHxxP03yEk9Otlsev4x9LGXbfDewpSXZsp7avT7Mmr4bdK9Szubx8l2XGXq69QZ8+022x3WUrq9fHAbnsuZRwABBMojQABfHjUf6zRtXE9mffw/u7Rd7yt95KpY8tlX3me/zHQrqUcXv7s//sMv5ddVa+WDlx8S/cLQ6Z7hY+Utk37tJf0dPxGg651gvqxvvXqAHHVEK9Evtg8nz5JHnnlT3pv0jdx4xTmaRV5/73PZvWevfPrGcBvA69X6wTc9ViiPk+3YjZn/9Mt5nrlowIQAAggggAACoRN49em7bOF3PPSifeLP3zV58Y1J8pL58TU9Ofo9+XPtZtGbBp2POlQy9mbKJTc/Jo889YZMGjdcqlev5mvVYulNGtaTx++9Ts48pZvoXfcNm7bLgGsfkOfMxQNXAL9o2e82eL//9svk4nNPlixzY+XSWx6TJ15815T3mN2mk+24CtcnF+//72sSG/PPE4muZbwigAACFREo/OxQRbbEuj4F9I75RTc+agNrVyZ9ZEzT5i9e7kpy9Dp65BCZOn6kHN2ujdf8O9L2SHRUlNSrk+Je3uHIVhJl0nLz8txpTmYuN3ftNXjXSdc/+7Qe9nWzuevumvTRtl7djnY/yt/u0Bb2zv+Xsxa6soiT7WhmfeT/TXOh4ZmHb7braplMCCCAAAIIIBA+Av++/3l54/1phSr00FPj7AX4QomlvLns/FPt+cyt1wzwmnP+4hX2XEeDd50SE+LtjYi/zDnVmg1bvK7jK/H4zkfIOeYcxvXIvN5w6WLu4m/ausO9ij6mX9PcoR90Zm+bpoH3BWedJKv+2mAuJGyyaU62oxm1+eKtw56X88/s5fjJBVsA/yGAAAIOBAjgHSBVNMu+zP3y869/irYFd03Z2bk2TQP5skxNTPt4fbTLV5v2fid3lRo1qturxl/M/F627tgl7386U0447ihpYNrCV2TS9mN6J75l80Z2M3p1Wh8xa9uySaHN6nvPIL/QQvOm6HZ0+bxFy+XRZ9+UB+643P2oWtH1eI8AAggggAACoRXQPnY2bvkn8NXaaDv5tWUMqpMSa9nzmbopxfvWce1h3dTCTxq62uHrHfSKTPn5+bJ0+WrbLNC1HW3nr+dXnnf227Y82Axy87Z/bly48uurt+3sMc0CbrznWdGbJ/fdOtgzO/MIIICAXwQI4P3CGD4b6WDumN9x/SD75XrXo2Okz8A7ZK+5gPD0QzdVqJLasdzTYz6w7dPO63ei3Za2T9MpPq6mfXX9p++1TO18pujkbTv6xa/t5K+8sJ8M7N+r6Cq8RwABBBBAAIEqJtCpfVuZPX+pzPzuJ3vzYO++/fYGgDLojZGKTPr4vt5A8exnR89pasUXPZ852AGw3qzwNhXdjp733GaeUIiNiTHnXTdLdJFO+bxtgzQEEECgrAK0gS+rWJjnnzFnsQ20n3zwRtFg/gPTMcwbH0yTwabd2PumXXx52mJpx3i3mC8kfYRszH+HuHtkjfm7XZdegfac9FF9fYy/aG+yvrZz1/+NkUNbNZOLzulje7p1Peq/x3y5bt2eJg3qpXpunnkEEEAAAQQQqOQC2hZdzztuGfacDYT1XMN1d7xh/Trl3vt3Js6QMW99JpcPOk369jrWvR19ejGvyPmM672OilN08rad1979XH75fY28+tRdoh306c/+A1mSk5Njz29STKfA5TkPK1o27xFAoGoLFP+LVLU9/LL3+pi5t6lAvKd7y1vetLfNF9OhrZrKGX2Ot5vQntwPbd1M7jY9q377w89y8gmdy7Rpfez/1vufk2Ur/pQXTE+sx3U6wr1+ihniTQP1dNOxjOeUnpFph3/zvPJc0nb2pO+TlX+sl1MvvNNzM6I92mvnez999WqhdN4ggAACCCCAQOgE8gsKX7gPRE10GN6JpvO4ZSv+MM310qVhvTqmt/pvbH855R2STQPsZ17+wPbNU3RknjrmUf4/1m4stCv6OLxOdYo8yu9rO3o+owH7YNP5XdHp5AuG2PMoV6d5RZfzHgEEEHAqQADvVKoM+VwBresOdXLiwTFE9+w5+EWgmyoI0JffNtPmPS8v3z5u5uoEzjUW/U7TwZ1r0mHu9DpD/bq1XUnFXrX9/E2mHddWM0Tc68/ebe/oe2bSAF3bwy8xbeM9pyXLV5nxXP9pF1/adia8MMzU+Z8O9rT+/S+7xz7adsHZJ3lumnkEEEAAAQQQCKLAnoy9EmMeCXdNOi665/mMphfkB+YGhd4kcHXam7k/y/YSrx3nep676KP1+kh9bTO8ra+723r3fuQL78g7E7+W268bKNcNPtO1O+7XNqb/nhlzFokG7cmmfb5OS0w7eXuu0+xg3z+lbeeGy8+WS8472b1NnXnUjN6zfeceMxzdv00Hw77PuQqtxBsEEECgBAEC+BJwyrJIh0/ToDjJ9JL6yedz7R/8/qd0tZvQ3k51bPRxH3xh70xv3LLd3F3+vCybd+fV8VAPZGeLfmFpoKvlxpleU3X7OukX25vmkXkdGuWS806R7Wm77aNi2oGd9sCqkw7F0mfQENEvq4mv/Z9N8/afjievnbpom/otpgMX/XFNfXp0to+ynXv6ieaR/fdt7/E9jm0vX3zzvaz8c4MdrsWVt7Tt6PiynpPrkXz9Mm7aqJ7nIuYRQAABBBBAIIAC2ofN13MXS/OmDe3TcT8uW2WDXleRPc147fp03PTZCyWuZqxMmvatLDV3yU/teYwri6PXbTt223OUDZsPdkj366p1kpxUy3SM21RizOPsOs0w9WhmzqHWbdxmz2Wio6Ll30V6rb/zkZfkOzP87JS3RthO6LwV/rS56/72JzNsHbUjPK27azrSjJ6j5xp6jjTmzU/lATP0281XnWs6402Tce99YXuRr2vGjtfJyXZcwb9r+9ovUExMptmP+q4kXhFAAIEKCRDAV4jvn5UXL1sp/zVXd3U6rPUhMuy2SwsFnzpu+v/MGOdX3DbCXiE+57QTbNuuKCk8VFrR9/+UcHDutgeeFx1CxTVdcP3D9pH5ia8/ZpNuu/Z82+bqNfP4+StvT7Fp+sU0ctj1EmsCfZ1+WPKb7Tn1UjOES0mTDkmnk47NXnSaP/lF0R5krzBtyNas2yxPjX7fjpWqQ7RcfVE/Obtvd/cqTrbjzswMAggggAACCIRMQJu83TfiYNO1VPMYu3ZcO+is3u76aKC7yJxH6PjwOvXs2uHgULJFhn4t7Xzmg8kzZbQJmF3Tdf950s7qULnaG7xOQx5+0d6s0IC+45Gt5YOxD5sLCw3sMv1PO43T86/uXdq513Ev9JjZYe6A6/SV6SdIfzynh4ZcIfq0n54raf9BDz75unz97Y82y9Ht28j/Db3and3JdtyZ/55RliI0RbPwHgEEECiTQJRprx2Y557KVI3KkXnXngzJzc3z+YhUvqHWYLepuQrrurocqD3XO/SbzDAveuW3caO6tq26q6zHnhsvX3z9vXzz0bM+Hzdz5XX6qm2+dFgZvcLs6xE2p9siHwIIIIAAAgiETkC/03ft2Wvanaf47Eldh4uNi4t1d2wbiNrq3flsM2StPg3gGsPds5yFS3+TK28bKaNHDrEXEjyXlXdez9XWmzv+Ou58qul0jgkBBBAINwHuwPvxiKSYR75LmrQtl+tR95Ly+WNZQq0423mdt20tMGOuDzyzl18DbX2Mro1Hu3dv5ZKGAAIIIIAAAuEvoN/p+lPS1KhI87eS8pZ3WWnN6BYsWmHvyJ94/FHlLaLYenqu5nmXv1gGEhBAAIEQCzAOfIgPQLCL13bzJ594jAweUPLj88GuF+UhgAACCCCAAAJlETjEPE5/378vNY+oF26OWJZtkBcBBBCINAEeoY+0I0Z9EUAAAQQQQAABBBBAAAEEqqQAd+Cr5GFnpxFAAAEEEEAAAQQQQAABBCJNgAA+0o4Y9UUAAQQQQAABBBBAAAEEEKiSAgTwVfKws9MIIIAAAggggAACCCCAAAKRJkAAH2lHjPoigAACCCCAAAIIIIAAAghUSQEC+Cp52NlpBBBAAAEEEEAAAQQQQACBSBMggI+0I0Z9EUAAAQQQQAABBBBAAAEEqqQAAXyVPOzsNAIIIIAAAggggAACCCCAQKQJEMBH2hGjvggggAACCCCAAAIIIIAAAlVSgAC+Sh52dhoBBBBAAAEEEEAAAQQQQCDSBAjgI+2IUV8EEEAAAQQQQAABBBBAAIEqKUAAXyUPOzuNAAIIIIAAAggggAACCCAQaQIE8JF2xKgvAggggAACfhAoKCiQjL2Zkrk/yw9bYxMIIIAAAgggEAyB6sEohDIQQAABBBCorAI9zr5F0jP22d2Lio6S+LiaUjspQY7pcKgMPLOXdGrftty7PmveEvlu4S9y5YWnS5OGdcu1HV/bWLdxm5xx6d1yeJtD5ONXHy3XtlkJAQQQQAABBIIrwB344HpTGgIIIIBAJRPIzcuTGjWqy4AzesqZp3STjke2luzsHJk07Vu59JbhMnbC5HLv8U+/rJJ3Js6Q7Tt2+30bcTVjpWvnI219y71xVkQAAQQQQACBoApwBz6o3BSGAAIIIFAZBRIT4uWRu65y71p+fr58OXuh3D/yNXn+tU+kaaN6csbJXd3Lw2Gmft3a8tozQ8OhKtQBAQQQQAABBBwKEMA7hCIbAggggAACTgWio6Ol30nH28fpbx32nAwb+ar07NZREuLj7CYWL1spL70xSTZs3i470vbYO/htWjSRywb2ldN6H2vzvP3JDJn69QI7P/z58ZKUUMvOX3RuHzm1Zxc7P91cJHjrw+ny+x/r/r+9M4HTqXrj+GMLIVvW7ET2vYhIWiSylChCRFH+lrQoS5ZEIjstCC2KyNhpQVJC2bNm37OMdez/53dm7jt33nlX89K87u/xMXPvueeee8733HvnPud5znPkthQppMQ9+eWN9s9KwXw5/ZZRvXIZaffmECmlHgMdX3zK5J8y8ydZtGSVdGjVUKbNWaLu++vlgnoTVKlQQnp1bSmRp87K0E+myh9rNuvc+SipWKao9NGBizszpTfnWz/81cvKx98kQAIkQAIkQALBEaACHxwv5iYBEiABEiCBgAlUr1RaFfJ7Za4q4uv//kcqly9uzt22c5/8/ucmo2jfV7aonIu6IGs2bJcu746SoX1eNQo6FOSoqIsm/6nT5+Ty5Stm+3xM2thJETJi/HRJnjyZVKlYUg4c+leW/bFeVq3dIrMnvS85smU2Sra3Mq6o6z/qAPd/S3btPWTSVvz1tyTRxII6qIABhrk/rZB/9hyUvQeOyHkNeod01GfJb2tkzMSZ0qNzc6sICaRerszcIAESIAESIAESCIpA7F/toE5jZhIgARIgARIggUAIwCoOBX7tph0uBb6aKvY/fjtEsmfN5Cpizcbt0vSVfhKx4FejwLdpWkfOnD0vn301Rwa+85KUKVHIlXf3vsNGUS5cIJeMG/yGZMp4hzkGC3rfjyaZc6BU+yrjvA4aeJNq95WSXq+1kGxZMsmZc+el/gvdZfP2PVKjSlnp2bmFwP0edXuyxduyfNVGVzGB1st1AjdIgARIgARIgASCIsAgdkHhYmYSIAESIAESCI5AvtzZzQk7du53nZhTreNQ3k9EnjYW75mqtMMCnyJ5ckF0eH8y/+c/5NLly8blPkP6tII59/hfq8a9kixZUvl7225/Rfg83qF1Q6O8IxPc/suXLGzyd2rztFHeTXqa1FJO0/fsPyyHjx43x290vcxF+IMESIAESIAEHEyAFngHdz6bTgIkQAIkcOMJHDoSrdzmyZXNdbGTp85I94HjZIkuE3dV12O3i/u+/Zi1vXvfIbPZ44Pxgv/ucujoCfekBO2nVWUdcvXK1TjlpEmTyuyfORulCr/Iza5XnMpwhwRIgARIgAQcQIAKvAM6mU0kARIgARL47whs3rbHXNyyYmOn7euDZeOWnXJ/xRLy9BPVpUDeHCYQXN3mbwdU0bPnoky+ts3qxgsghwNpbo9WrAMqLIBMWN/ekyTTYH12udn1sl+b2yRAAiRAAiTgBAJU4J3Qy2wjCZAACZDAf0IASnrEwl9NoLlSxQuaOhw7ccoo7/cUyiOfDuoap17eFGWsNW+XvDHW/LIl7pZqlUrZD3nddi/Da8YEHLieeiXgcjyVBEiABEiABBxHIO7QueOazwaTAAmQAAmQQOgJXFO3eCzB1r7bUIm6cNEstWYtIffv8ZPmgvbo70jYseuAnIuxrFs1Sn9HWrN54PAxK8n8xtxzyKjPZ5i58GYn5geCzi35fa0ryVsZrgwh3AimXiG8LIsiARIgARIgAccQoAXeMV3NhpIACZAACdwoAqfPnJOeOhcdgeVgYd+pS65ZSnfnto2k3mNVXZfOnyenZMqQziwr17HHCClWOJ9s12XlFi1dHU8ZL67HIFh7/ci/J8ya7MWL5JMH7y8jVe8taZaNQ4T4+rWqGrd5uOv/vPwvKV4kv2AJO4i3MrB8XaglmHqF+tosjwRIgARIgAScQIAKvBN6mW0kARIgARK4YQSSJEliFOvv5i41EeAzpk9nFPSGtatJo7oPSqmiBeJc+zZdd/3Dnu2la98x8sMvq83/1KlSSvNGj8o3ET+LFueS+8oVlQ6tGsp0LfsjVeIh3To0Nb+H9e1glpL7cvoiGfrpNJOGH3Bjr1m1nGvfWxmWAp/UdkG0BWL9tgqx8ri7+Fv5ktrmyAdaL6ts/iYBEiABEiABEgicQBJ184sb/jbwc5mTBEiABEiABEjgOglcUNf6HbsPmrPz58kuUOK9Cf5UY431dGlvl8wxa75beXEM1vkTkWcEy9PdkS6NdSjOb19lxMkYop1A6xWiy7EYEiABEiABEnAEASrwjuhmNpIESIAESIAESIAESIAESIAESCDcCTCIXbj3IOtPAiRAAiRAAiRAAiRAAiRAAiTgCAJU4B3RzWwkCZAACZAACZAACZAACZAACZBAuBOgAh/uPcj6kwAJkAAJkAAJkAAJkAAJkAAJOIIAFXhHdDMbSQIkQAIkQAIkQAIkQAIkQAIkEO4EqMCHew+y/iRAAiRAAiRAAiRAAiRAAiRAAo4gQAXeEd3MRpIACZAACZAACZAACZAACZAACYQ7ASrw4d6DrD8JkAAJkAAJkAAJkAAJkAAJkIAjCFCBd0Q3s5EkQAIkQAIkQAIkQAIkQAIkQALhToAKfLj3IOtPAiRAAiRAAiRAAiRAAiRAAiTgCAJU4B3RzWwkCZAACZAACZAACZATIugrAAAdQklEQVQACZAACZBAuBOgAh/uPcj6kwAJkAAJkAAJkAAJkAAJkAAJOIIAFXhHdDMbSQIkQAIkQAIkQAIkQAIkQAIkEO4EqMCHew+y/iRAAiRAAiRAAiRAAiRAAiRAAo4gQAXeEd3MRpIACZAACZAACZAACZAACZAACYQ7ASrw4d6DrD8JkAAJkAAJkAAJkAAJkAAJkIAjCFCBd0Q3s5EkQAIkQAIkQAIkQAIkQAIkQALhToAKfLj3IOtPAiRAAiRAAiRAAiRAAiRAAiTgCAJU4B3RzWwkCZAACZAACZAACZAACZAACZBAuBOgAh/uPcj6kwAJkAAJkAAJkAAJkAAJkAAJOIIAFXhHdDMbSQIkQAIkQAIkQAIkQAIkQAIkEO4EqMCHew+y/iRAAiRAAiRAAiRAAiRAAiRAAo4gQAXeEd3MRpIACZAACZAACZAACZAACZAACYQ7ASrw4d6DrD8JkAAJkAAJkAAJkAAJkAAJkIAjCFCBd0Q3s5EkQAIkQAIkQAIkQAIkQAIkQALhToAKfLj3IOtPAiRAAiRAAiRAAiRAAiRAAiTgCAJU4B3RzWwkCZAACZAACZAACZAACZAACZBAuBOgAh/uPcj6kwAJkAAJkAAJkAAJkAAJkAAJOIIAFXhHdDMbSQIkQAIkQAIkQAIkQAIkQAIkEO4Ekod7A1h/EiCBW5PA6nVb5cixE6ZxyZImlWxZMknJogUkaZIkfhu8Z/9h2bh1l898pYsVkpzZMvvME+zB6XOXyox5y2TyiLeDPTVs86/ZuF227NgrT9WuJsmTJwtJO/YdPCrrN/9jykoiSSR16pRStFBeyXpnhpCUH0ghsxYtlzvSpZHqlUoHkj3kea5evSqdeo6Uy1euyvC+HULGNuQVvQkFbtX7q8eg8fJ4jfukZeNaN+GK/80lQn3PXdF7Z+HSla7GpEieXO7KfqcUvTuvK+1Gbxw/eVoWLV0l95a5R/LnyXGjL+ex/B27Dki3/p/IYw9WlNbPPeExT2JKRL916jlCrly9JiP6/U+SJaOtLTH1D+tCAomBABX4xNALrAMJkEA8Ap9+OVt+WbHOfLzggwaSO2dWGTOgs98Pwd9Wb5I+QybGK9Oe0L/bi1Lvsar2pARvHz0W6XfgIMEX+Y8KOHTkuDzc+DUZ2vtVebhaeVct8HH++Tfz5YmalSRt8tSu9IRsrFyzWboPHCdJdeBGrl2Tq/of2y0aPSZd2zVOSNHxzvXWrqGfTpMCqnD8Vwr8VzN+lGUrN8iU0T0cpbzjXvro06my9odxrr4qXDC3Kl/3yrDPpsmD95eRfLmzu46F44anNqIdob7nLly8JF17jzGIoARa71EMhOI9mjF9upDie659X7krRxYZ1ONlV7kYjMO7uPfrL/h9b7tOCuHGNX139B7yufk70uzpR0NYcmiK8vT+QV91bPO0NHm5j0yatkBeaPx4aC7GUkiABG4ZAlTgb5muZENI4OYTWLdOZEz096G0aydSqlRo61CscF6Z+klvuXjpsqxc87d0eXe0vKYfpNPH9fF5oUZ1H5SGtR9w5Wneob+kSpVSPhn0mistebLQWItdBSaSjbWH1sroVaMlWdJk0r5CeymRtURIagYlGh/D+GeXDq0aSusmtSVtmtAo7/ay530xUHLlzCJHj52UASO/kgnfzJOHqpaVciUL27MlaNtbu6aP66sM/xvL15F/T8rwcd9J22Z1BMqrkwT319WYATt7u2F5X7hkpfT5aKKMH/Km/dCN2b4SJbJnqv6fJnJXbZF8TUWSpw3Jtby18Ubdc13aNjKW5wsXLsqsRb/Ju4M/l7GTIqRbB21TCOWKeo1cU6uxXYoXzie/zBguadPebk++adsz5v0i8BIC25S3pbhp1w30Qt7eP4Xy3SXtWtSTURO+l1o6eJUjxN5igdaP+UiABBInASrwibNfWCsSSPQE5s4VecLmjTh2rMicOSK19Vs31HJbiuRSpWJJafD4A/LFd4tkw+ad0m/YZHmpWV2pUaWs63I//fqnfPLFbPmwZzvJpZYgS5Ko2z1c7+FCagnc7PsP/9J83EWXX0Le0g/a9Oo2DcGH3/fzl0mf11vJ+ClzZfuu/dLymVpSs2o5mTh1gczWD2FYl3JkzWzq0PHFp6KLViUX502aulD26/FHqleQF9Vt82ZYDSO2REi9KfWi66E/x6wcIwuaLZBHCybc8vS/7sNNuUM+nirjvp5rWGKqwILFK2XqrMXyxch3zHGLG/rKE4PJ0xbK/J//kI91MCXt7bFKf//hX8jxE6flw146EuQmWTJnkNbPPmHO27Zzv1Hgd+09JG+pW2yvLi1cLsEnT52Rl98cIuiLyuWLy+Gjx6WjuqHXe7SKLP5tjazZsF2K6qBQ80aPykNVypmreGvXQB0wyKnuxq++0MDke7Pfx5Ip4x1yUa2aP/yyWnBPYdrAM/VqyIejpwi8PrJlyShNGz6sg0fVXC3446+/1XL8nZlmcIcqMTUfKC9dXmokqXVAyZtMVqsbyne3vFl1gHv9oqWrJbla6ho+Uc3ks5QTDHbBkrtIld0TkWfknkJ5jNdCmeKFvF3OpP/8618yYvwM+Wf3AaMs5MudzfTxcHXhhYATBk7sLuy9PpwgGe5IK51VQYSMnRwhEQt+lX+PR+rEhyRSpFBu6dC6oVQsfY857u/eWLl2s3m+odQ0aRc9SFelYgnBIBGeX/TFS28Mlr82bJOyJe42Zd6wH4v15Xb4p+ji90eIbNH7/4kNuu9/Co+vOvlqo/2e83fvbtu5T3p8MN7nOzBThjviVCVlytvk6TrV5bOv5gjOt+SrGT/I0t/XydiBXawkmfvTCn1+F8jX6gGCe9Ff340YN12267O5Z/8RV9+93q6J5Lkrq3TQe6fry42lQukiphyU9aQ+k3gX7D/0r0l/760XZdrsJTJzwTI5feacedfD3d16H+OeR71xf+Gc3Fpum6Z1pO4j97vq7GljzMSZZuoFFGK7HDh8TPoNnSyr9J7D34XS+nwcP3lK3u/WxngKBMIE07wGjPxSDh4+LueiLkh2ff6frvOgtGryuLmUvz5EJm/vHxzDe2q8vms//3Z+yAdbUD6FBEggfAnEfs2GbxtYcxIggRAQqFAhuEK2b4+f/7nnRAr51hPinbRqVbwkrwn4sIPlvIhaJU+dPmsssnYFfvzX89RN9Eoc5d1TYWfOnZemr75nPsXhlh2pZX03Z4n8s+egTBnT03ywwgq6au0WadC6hxTKm1OVuczGBfX9EV8JPu7ur1BcGj9ZQ7b8s9co9JYCD7fVwWO/kfq1qko6VdjGT5knl1SpGtj9JU9V8Zp25eoVue+z+7we93Rg2/Ft8ZIbT2ssBTMWjJfuLQGW+xUvroh3GK7kf2/bLaWLFTRKYZKk0YoMrOPWfHWcZHGDIuiJAT7iYU2fOf9Xo+ziHLiRfv39T9LJGgRBopvs2nfIpJSNUUTPah+u//sfOXtOLaUxcvHiZZMGRR5yPuqi2ceAz+MP3WcsWvMX/yFQhJfPGmU+3L21CwoO5p9bslX3t/6wV6AIN1dX3A1bdhmFFYM7ZVSZfEE/2uH6D6XqgftKCQYdcP+06vKB7peUXq+1kG3/7NN750fjxdC94/NW0fF+b9q6Wx6rXjGexdCqQ4l78suz9R+SvaosQXEqXCCXa0Cil84Vh/KF+eJF784j30T8LC06vi8zJ7zndRAJSuWr7wwz3g6d1HUXfTtF+wPPkiWbt+8xcSisffzGoFaWTOldSXg+q1cuY57Py3ouynil21D58dsh5lnwd29kzZzRtOXw0RPG6oiCC+WPVbzwzN2p1wOfoBT4nZNVAR/mqqffDVjfIzfGzRa5SWSWDkSkCMLtPH8zkSKd4pTjq432e87fvQuF1N878Nz5C3GujR300bETkVK7Zuy7Bc/fpq274uTFIAyeL9jT8aT767tSxQtKeh3MwYAOLMYQxKy4cOGSKefUmbMmDeVA8d2977BR0uEuDiX14We6SGbtWwy2Xbp8Wd/t8/X8jNLsqUfMeQNHfS2IMYKBQTyDGAR8671PJHvWTK4BIpPR9gPvdSjq73aNq+TDE6HF//qbAa76j1eVYhoT4Mdlf5p6njsf/T4JhAn+juTLld0M2GFw7teVG827H3Wqre8bf32IgQNv7x80A8dr1bjXvHdtzeImCZAACQgVeN4EJEAChsDq1QkHERkpEopyrJpcunRFDv97Qk5GnjYWooiFy81c6xRqkW9Sv6bAYrVVlSIoMFt27DGWOVhy/Ml3c5aqtfeUTBr+tpQvFe2OnTdXNmOR+W3VRrlfrX4QzLv++IMurg9E1OX1PmN07nwV6a+WGkvaPFfH2jQfXXMmDzAB0JCID9ivvv9RYEEyc7pdOX1vwM129cGEd8rJKP1gDqKc5Ek9/1l4Si13sLDWfKCcPFLN92gPPjy9MUAArTIlCsmUmT+5FPhvZ/2s3JIJrmGXJb+vVYUgjRlY+XL6D3Jv2aLX5VLe783WZjABZaNvG7TqLrCMw6sjmHZBOR3Vv6MZ4IGSsUSt+rVUUUY8BUgjrX/luq/oh/wGc72R46cLFK0xA2Itm7CKw3vDlwK/VQeF6jxS2ZTp/gMf/KPe72TqgGN/rt8qi39dYxT4g6qswEX6WX023umoyqMKLJTVGnaUCTqQhHnInmTsxAhVvtLI3MkDXQGz9h04atrnKb+3NFhcIZhr/a8qiejTt9//zDyj1nPm697AM4g+XrZifRxLv3U9PD8YQEJQu6Ak6rDI8YQ/S3J6a1CXlWw14uX310b3E3zdu4G+A7foOxIKLyzM02Yv1YGh26TOw57vL/fr2/d99R3uyyyZ00vuHFnj9B3uI3dBObMnvW8GdXBs997DsuKvTTJrYn+XZwoGaZb9sd4o8BgkxMBXu+ZPSvuW9U1xiInwQIMOMueH313vZ/frWPdJ2RJxp9zMVCs+FHtMqcI7AJJXFfHFy9e4F+FzH23GfwgGDYvpdAG8E9aohwgUeEt89aG/90+5knfL7B9+s4ribxIgARIwBDx/qREOCZCA4wgEYwkHnEmTRIarV6ld/qfets2b21MStg2L1ENPdzaFwIUW1pc3Xn3W7DdQC/cwdRWeospxT3Wjxgdepgzp1LJUye9F4eoJF2YoA5bA5RqyTa2KlgKPgQLL/dcc0w9huPdWi/loMyfoD1hcLEmqFiVEL7cEcxdhKYOlGBb5QAWW8FVtg3BP0IIn/DVBRq0cFecSnSt3lqYlm8ZJ87UD1+eEij8Gz6mC+YZawaFEl9UP1KnqOvuEKhSw3tll8Mffml1YzCpqFOtxQ96wHw54O0P62HJzxPQV3F6DFQwmwJ0YAiUE/Zw+XWyfYh/TMWC9g2yOUTTrv9Dd7OPHMVWiYAWF9c4+hcDKAGUFkbtzZrvTSorzG22x6oAD2XUKB5QRyA71ekCcgkrli5l9/IDb/906wGV3mXYdjNnAKgK4/xMa7RqeDoPGTDHTUi5fjrXeR12ItQT7uzfc6+a+j+dp7aYd7sm+9/M/L56Uaa8nXbsssriujr7ZlM9k2s81dN5QMPPgU2XzeolAD/i6dwN9B87/eYX8qNM+MP0DK0XM0dgS17MCR0L7zmozyrG/C+9UxR/Pk31aCQYD4PUBwbQZDIDC9X7hkth34nn1MIA7vTfBfY2Bqdt1FQu7IB3TCSrETO2wHwtm+8zZ8wLPAATyxDNtSZR6/tjFVx/a83naxv2O62BwjvPgPRFiGgk4kwAVeGf2O1tNAvEIlI8NLB7vmKeEgqr7wsN2snqnQp7Xb+TevUUyhHClr/wabXrAOy9JmttTGfdefORZgg9AWCmx9BLmQsKq2Vzd4aFA+RN8yGLOsF1hwTUgl9Xd3ZvAPR4Cd8lAJWmMq3mg+a18UKTL5wiuU/JnyG/csyevmyxJ9V/z0s2lV/Vekj5lrJuzVf7N/O3O4FFdzgkfvvBMMAqrekNg7ri7RKjb91057lSvh7EC1/dF+vGOpaDs4h5Uz37M03ayEAYv9ORRYaVBkcbAQ9V7S0o9HWxyl1RqBfUkepqRmHECT1nipOEetqKLX7wUfX9a97KV8XYdrMI0Dm+C6Qh2hcpbvqvXYqcUuOc5oV4yz3d4T+7On0uG6bJ3hQvklki1Sj7dppd71jj77vcGDsYgiJPP2sHgBdgGJVCkg1Wm7/9CZENfkaPLdBSknEixbuoTXj2oy/rKHGQLTFHu926g78COrZ8yQewQr+K13qNlyNhvZVDPl+MMBAXNVGvkqe98tdnbMeuZsR9PkiQ2gKQ1AASPA3gw2CWzDlB5E7TJ04AkBlNTpUwRb4qKezn+mIAlBpPAt2LZe8xAbtP2/dyLibPv3odxDnrYsQbrrud+8VAck0iABG4RAslvkXawGSRAAjeZABT1kSNFBgyIvnDaWCNnyGqC9b8x39ebPNegpgl8hMBlcGluogHFAhF8BMItERYea03k3//cZE5FcCRvggEFCJa3s6z02A/WPR7n3AjJlDqTjKo9SgY8PMB8uKa9LXSdkiomgrM1iJGQ+mMgxgqmtV29GuBejWBrngQfsO+pi/q+Q0fNWs4IFIc5sOnTRbctMjJ6bi3OveZDwfRUNtJC2S77NVDvfLoM3XFVbBH40PoQRx6jWOhxT4J5w1je6+CRaKu6pzze0vLeFX1//q4B9SqVi7bCYx70hi075WENnudNsDb4Wo3UbRd3ZR3eEXbWyGuPOI7Acgig93r7JsZbAsejNLBXsIKBDfDB82wfsLPKgSWyiA4O3HDJoYEf8f/8QZHUOUJ6OX9tDOZiwbwDMfi1c28DEzcBqzsg3gEEgeJg5cVAkDWoeU0t3sFKarVqR12Ma30OtgxP+QvkyWmS4RHlfh/7UrIRKwWu7VE6kJZK62YJ7vfIU2dlp8Y8sdamt8d7QD5/TOCJhZgX8Ap7Vv8OXa/4e//gfoenzvV4TFxvnXgeCZBA4icQO8SZ+OvKGpIACSRCAlDcb4TyHkhTixTMYyJjI5hWzarl4wXZ8lZGff3oggUe6xMj+jKs+KM/n2ksKNacRk/nFtBgdpij+50GU/rok6lm3v0cHQior3OqE5Okuy2dhFJ5R9vgio1YA9/PW2aCiIFbQgQBAGFI3anR5Js2jA5U5a089NXI9zpKRp0i0UGDrWFeLRQQ9MeEb+eZYHGIXv1i1w+9FeE1PdTtsl+o5TOPmcj37wz4zKycABdzRN72Z5UuXDCXnrfDXlRA2wXz5TQRvRHNe5JeB8Hp3ug3VuDO3qTeQ17LwPQFxJJARGzMlX5v2BdmZQH7CdUql5alK9aapdwwgGVZH608pYoWNO7ZiG2AIGV4LpAnWKmsgeogWCsdQRPXaSA1S6A0rft7x3XFQbDKCPp3iJV3XN9XG4OtX7DvwJeff9LMf//0y9kmKByuh77F4MswXboQgRdHf/69jJwwI9iq6NSN4ub85RpHBPeANZUk6ILcTsAKHtUqlZLhupoDYmHgfY9rYOWKD9STx5tYSzBiGTm7YJoVBtQQHX+aBi+dqFHeMaXHLv6YYEoXItcj3gXmzi/X3910VQzULRjx9/5B3a12BFMu85IACdzaBKjA39r9y9aRQFgT8OT+6N6gR3WZNogVrdj9uKd9WDOG9H7FLAPX7q0hJppxMnV1h5KIuZEQLwZSGagu/ZiPjcjJDVv3NOda85U9nWO5h9otsJ7qFA5pWNZpt0aDb9S2l3TqOcJUGe2y91OgDLJlySSlihWQbBpp2t2q5sk1F9HHR2vwNljTXn5zsMCyjHWSj2pUa0RZ7z14olQoVSS6TlojuyS1ueO60m1ZPLYrTqsQiRsn2E7CnklyT9P9mKR6j1U1weSW/LZWGr/c2/wfovP64WbuS+AVgikDUKrs4rkOmmqrAu5PWBUR4LFlxwGCoIzdOz3vsorby7O2EUEf0a6xlByU7jUbtxkvB+s4fiNwI6J1d+41yizVh2jdee5Sd+aYi6N/0B8IPNZcI3z3GDRBCuaNjiBv3R/2elpluz8fUNawPN/Hk2eZgY6vdcUHS+BZgCjmlteMlR5uv721EZxsXWma5e/eRSZv70DXc+QGvq8GdYQXS28dwMQgD+7HZ+rWkC91iU48S1gGEwOVdnErwhxy7ztEtkdZbV//0NwDmzWwqCVWyzyVgzRrVQsrv/lty/z+2221nZh685XUa/mOtOk6yMyHv0dXWvAm8BpBfJKIBcvjZMFAF5afhHW7l96nH38xy0x1sWcKhEn7lvXMUo6vvD1U2mibEbvCk0u/vz709P5BXTDwNk9XlMBqEhQSIAESsBNIou5HnFpjJ8JtEiCBsCLQstMADRJ3TqaP6xN0vWHRw1JcmDcfbIAgzG8+pMtdwaXb7p4ZdCXC7AT8yTioQdoyqzXcGuy4niZAEXukyWvSvkV9eel5DRh2nYI+3KWusLlyZg0o/oG3y4SqXd7Kx1x/fJBjaSzLTdlbXlgu67boJm2b1TXxHbzl85WOVRbgPgwlG4HLAhEE1kMdofjACo+I2gunxPVqgNKDqS3uAQet8vFc7DlwxCzlaA9KZh0P9DcGak5qxP6s+nzB2on+aaZLPyKy/efDdD76LSDubbzeJiXkHWi/JvofruVwMU+IHNN7D/e4t3skIWXDzd+6Bz0py+5lT521WPoNmywzxvU1Hjv242a1hOMnzTP55/ptZtDh2497SfEi+V3ZAmGyY9cBEywPg1jXK57eP/AMGK7LREZodP6E9sn11ovnkQAJJE4CtMAnzn5hrUiABAIggKWGMA+x6VMPB5A7fhYoBpgPH6zyjpKgvOJcJynvaDcs7vBgSIjyjnK+nL7IKGaN6j6I3esW9CFc6QMJXujrIqFql7drYF143Gf+lHecD6vhq60ayphJET6jx3u7FtLhmgsugSrvOAdzbf0pXWiDrzy4L2C9TIjyjrrguQIH9C8EUwI2btklvV5rafZvhR/ubbyeNiX0HWi/Jvo/FIoiFGtf94j9msFu4/nB9JlAlHeUjVgbiKPS44Px8TxaUBY8gXx5RwXCBBb9hCjvqKf7+wfz8zGNAV4toegTXINCAiRw6xCgAn/r9CVbQgKOI7Dsj3VmKbg6ASwd5zg4ibjBsDZhbjPmvmPpP0p8As8/9YhUUjfmwRoxHAHdbrZAeYZikhhki7piz1q4XDq0auAKOpYY6pUY6sB3oO9egGLcq0tLOR91USZPXeA1MwacEE8gVcq4S855PeEGHoBnwKAx35j4Li2fqXUDr8SiSYAEwpUAXejDtedYbxIgARIgARIgARIgARIgARIgAUcRoAXeUd3NxpIACZAACZAACZAACZAACZAACYQrASrw4dpzrDcJkAAJkAAJkAAJkAAJkAAJkICjCFCBd1R3s7EkQAIkQAIkQAIkQAIkQAIkQALhSoAKfLj2HOtNAiRAAiRAAiRAAiRAAiRAAiTgKAJU4B3V3WwsCZAACZAACZAACZAACZAACZBAuBKgAh+uPcd6kwAJkAAJkAAJkAAJkAAJkAAJOIoAFXhHdTcbSwIkQAIkQAIkQAIkQAIkQAIkEK4EqMCHa8+x3iRAAiRAAiRAAiRAAiRAAiRAAo4iQAXeUd3NxpIACZAACZAACZAACZAACZAACYQrASrw4dpzrDcJkAAJkAAJkAAJkAAJkAAJkICjCFCBd1R3s7EkQAIkQAIkQAIkQAIkQAIkQALhSoAKfLj2HOtNAiRAAiRAAiRAAiRAAiRAAiTgKAJU4B3V3WwsCZAACZAACZAACZAACZAACZBAuBKgAh+uPcd6kwAJkAAJkAAJkAAJkAAJkAAJOIoAFXhHdTcbSwIkQAIkQAIkQAIkQAIkQAIkEK4EqMCHa8+x3iRAAiRAAiRAAiRAAiRAAiRAAo4iQAXeUd3NxpIACZAACZAACZAACZAACZAACYQrASrw4dpzrDcJkAAJkAAJkAAJkAAJkAAJkICjCFCBd1R3s7EkQAIkQAIkQAIkQAIkQAIkQALhSuD/skoVV0q7kWwAAAAASUVORK5CYII=",
+      "text/html": [
+       "<div>                            <div id=\"ef714f22-0224-4f27-b17d-0166b17bcc5a\" class=\"plotly-graph-div\" style=\"height:800px; width:1000px;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"ef714f22-0224-4f27-b17d-0166b17bcc5a\")) {                    Plotly.newPlot(                        \"ef714f22-0224-4f27-b17d-0166b17bcc5a\",                        [{\"line\":{\"color\":\"blue\"},\"mode\":\"lines+markers\",\"name\":\"PyTorch\",\"showlegend\":true,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:04:12\"],\"y\":[99.0,99.0],\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"line\":{\"color\":\"green\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (no quant)\",\"showlegend\":true,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:04:12\"],\"y\":[99.0,99.0],\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"line\":{\"color\":\"orange\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (quant)\",\"showlegend\":true,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:04:12\"],\"y\":[99.0,99.0],\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"line\":{\"color\":\"blue\"},\"mode\":\"lines+markers\",\"name\":\"PyTorch\",\"showlegend\":false,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:03:05\"],\"y\":[99.0,99.0],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"line\":{\"color\":\"green\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (no quant)\",\"showlegend\":false,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:03:05\"],\"y\":[99.0,99.0],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"line\":{\"color\":\"orange\"},\"mode\":\"lines+markers\",\"name\":\"tinyRuntime (quant)\",\"showlegend\":false,\"x\":[\"2024-07-18 12:00:00\",\"2024-07-19 04:03:05\"],\"y\":[99.0,99.0],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"}],                        {\"template\":{\"data\":{\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"white\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"#C8D4E3\",\"linecolor\":\"#C8D4E3\",\"minorgridcolor\":\"#C8D4E3\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"white\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"#C8D4E3\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"white\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"radialaxis\":{\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"yaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"},\"zaxis\":{\"backgroundcolor\":\"white\",\"gridcolor\":\"#DFE8F3\",\"gridwidth\":2,\"linecolor\":\"#EBF0F8\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"#EBF0F8\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"},\"bgcolor\":\"white\",\"caxis\":{\"gridcolor\":\"#DFE8F3\",\"linecolor\":\"#A2B1C6\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"#EBF0F8\",\"linecolor\":\"#EBF0F8\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"#EBF0F8\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"matches\":\"x2\",\"showticklabels\":false},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.575,1.0],\"title\":{\"text\":\"Accuracy (%)\"}},\"xaxis2\":{\"anchor\":\"y2\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Datetime\"}},\"yaxis2\":{\"anchor\":\"x2\",\"domain\":[0.0,0.425],\"title\":{\"text\":\"Accuracy (%)\"}},\"annotations\":[{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"x86\",\"x\":0.5,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":1.0,\"yanchor\":\"bottom\",\"yref\":\"paper\"},{\"font\":{\"size\":16},\"showarrow\":false,\"text\":\"ARM\",\"x\":0.5,\"xanchor\":\"center\",\"xref\":\"paper\",\"y\":0.425,\"yanchor\":\"bottom\",\"yref\":\"paper\"}],\"legend\":{\"orientation\":\"h\",\"yanchor\":\"bottom\",\"y\":-0.2,\"xanchor\":\"center\",\"x\":0.5,\"itemclick\":false,\"itemdoubleclick\":false},\"font\":{\"size\":14},\"margin\":{\"t\":100,\"b\":50},\"height\":800,\"width\":1000,\"showlegend\":true,\"title\":{\"text\":\"Accuracy History\"}},                        {\"displayModeBar\": false, \"responsive\": true}                    ).then(function(){\n",
+       "                            \n",
+       "var gd = document.getElementById('ef714f22-0224-4f27-b17d-0166b17bcc5a');\n",
+       "var x = new MutationObserver(function (mutations, observer) {{\n",
+       "        var display = window.getComputedStyle(gd).display;\n",
+       "        if (!display || display === 'none') {{\n",
+       "            console.log([gd, 'removed!']);\n",
+       "            Plotly.purge(gd);\n",
+       "            observer.disconnect();\n",
+       "        }}\n",
+       "}});\n",
+       "\n",
+       "// Listen for the removal of the full notebook cells\n",
+       "var notebookContainer = gd.closest('#notebook-container');\n",
+       "if (notebookContainer) {{\n",
+       "    x.observe(notebookContainer, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "// Listen for the clearing of the current output cell\n",
+       "var outputEl = gd.closest('.output');\n",
+       "if (outputEl) {{\n",
+       "    x.observe(outputEl, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "                        })                };                });            </script>        </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#| label: fig-accuracy\n",
+    "#| fig-cap: \"Accuracy\"\n",
+    "\n",
+    "plot_progress(\"Accuracy\", \"Accuracy (%)\", \"Accuracy\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e1db9f6-2055-4f30-9e92-644e7ddd1345",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
For now, I’ve visualized the first plot with a dark background and the second plot with a white background to see how they appear on our website. You can check how they look at https://harukadoyu.github.io/njtest/hello.html#runtime-optimization-progress

I also modified Github Actions to execute `performance.ipynb` to keep the results up-to-date.

Related to https://github.com/ninjalabo/tinyRuntime/issues/148