### PR TITLE
refactor: centralize brand colors into custom.scss palette

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -71,7 +71,7 @@ website:
           - text: Report a Bug
             href: https://github.com/ninjalabo/ninjalabo.github.io/issues
     right: 
-      - text: "<a href='https://studio.ninjalabo.ai/' style='background-color: rgb(185, 185, 1); padding: 10px 20px; color: white; border: none; border-radius: 0.5rem; text-decoration: None; margin-right: 10px;'>Try Free</a>"
+      - text: "<a href='https://studio.ninjalabo.ai/' style='background-color: var(--brand-accent); padding: 10px 20px; color: white; border: none; border-radius: 0.5rem; text-decoration: None; margin-right: 10px;'>Try Free</a>"
         href: getstarted.qmd
         
   sidebar:

--- a/custom.scss
+++ b/custom.scss
@@ -1,2 +1,22 @@
 /*-- scss:defaults --*/
-$link-color: rgb(185, 185, 1);
+// Brand palette — single source of truth for the yellow/olive accents.
+$brand-accent:        rgb(185, 185, 1);
+$brand-accent-dark:   rgb(101, 100, 39);
+$brand-accent-light:  rgb(241, 240, 150);
+$brand-accent-soft:   rgb(184, 184, 107);
+$brand-bg-yellow:     rgb(73, 73, 45);
+$brand-accent-shadow: rgba(155, 154, 69, 0.63);
+
+$link-color: $brand-accent;
+
+/*-- scss:rules --*/
+// Expose the palette as CSS custom properties so plain CSS (styles.css)
+// and inline styles can reference the same source.
+:root {
+  --brand-accent:        #{$brand-accent};
+  --brand-accent-dark:   #{$brand-accent-dark};
+  --brand-accent-light:  #{$brand-accent-light};
+  --brand-accent-soft:   #{$brand-accent-soft};
+  --brand-bg-yellow:     #{$brand-bg-yellow};
+  --brand-accent-shadow: #{$brand-accent-shadow};
+}

--- a/styles.css
+++ b/styles.css
@@ -1,19 +1,19 @@
 /* css styles */
 .btn-success {
     --bs-btn-color: #fff;
-    --bs-btn-bg: rgb(185, 185, 1);
-    --bs-btn-border-color: rgb(185, 185, 1);
+    --bs-btn-bg: var(--brand-accent);
+    --bs-btn-border-color: var(--brand-accent);
     --bs-btn-hover-color: #fff;
-    --bs-btn-hover-bg: rgb(101, 100, 39);
-    --bs-btn-hover-border-color: rgb(101, 100, 39);
+    --bs-btn-hover-bg: var(--brand-accent-dark);
+    --bs-btn-hover-border-color: var(--brand-accent-dark);
     --bs-btn-focus-shadow-rgb: 38, 198, 157;
     --bs-btn-active-color: #fff;
-    --bs-btn-active-bg: rgb(101, 100, 39);
-    --bs-btn-active-border-color: rgb(101, 100, 39);
+    --bs-btn-active-bg: var(--brand-accent-dark);
+    --bs-btn-active-border-color: var(--brand-accent-dark);
     --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
     --bs-btn-disabled-color: #fff;
-    --bs-btn-disabled-bg: rgb(185, 185, 1);
-    --bs-btn-disabled-border-color: rgb(185, 185, 1);
+    --bs-btn-disabled-bg: var(--brand-accent);
+    --bs-btn-disabled-border-color: var(--brand-accent);
 }
 
 @media (max-width: 991.98px) {
@@ -27,7 +27,7 @@
 }
 
 .accented-text {
-    color: rgb(185, 185, 1);
+    color: var(--brand-accent);
 }
 
 .navbar-logo {
@@ -116,7 +116,7 @@
 }
 
 .bg-yellow {
-    background-color: rgb(73, 73, 45);
+    background-color: var(--brand-bg-yellow);
 }
 
 /* Performance */
@@ -137,9 +137,9 @@
     border: 0;
 }
 .panel-tabset .nav-link.active {
-    color: rgb(185, 185, 1);
+    color: var(--brand-accent);
     border: 0;
-    border-bottom: solid 2px rgb(185, 185, 1);
+    border-bottom: solid 2px var(--brand-accent);
 }
 .panel-tabset .tab-content {
     margin: 0;
@@ -200,7 +200,7 @@
 
 .feature-card h2 {
     margin-top: 0;
-    color: rgb(241, 240, 150);
+    color: var(--brand-accent-light);
 }
 
 @media screen and (max-width: 800px) {
@@ -257,7 +257,7 @@
     padding-right: 2rem;
     text-align: left;
     background-color: rgb(255, 255, 255);
-    box-shadow: 12px 12px 2px 1px rgba(155, 154, 69, 0.63);
+    box-shadow: 12px 12px 2px 1px var(--brand-accent-shadow);
     color: black;
     border-radius: 1rem;
     width: 30%;
@@ -274,7 +274,7 @@
 }
 
 .pricing-card.accented {
-    background-color: rgb(184, 184, 107);
+    background-color: var(--brand-accent-soft);
 }
 
 @media screen and (max-width: 900px) {


### PR DESCRIPTION
## What

Centralize the scattered yellow/olive brand colors into a single source of truth.

- **`custom.scss`** — define the 6-color brand palette as SCSS variables; drive `$link-color` from it; expose the same values as `:root` CSS custom properties so plain CSS and inline styles can reference them.
- **`styles.css`** — replace 11 color literals (15 references) with `var(--brand-*)`. The `.btn-success` override is kept intact (structure unchanged), only its color literals swapped, to avoid any contrast-driven visual shift.
- **`_quarto.yml`** — "Try Free" navbar button inline `rgb(185,185,1)` → `var(--brand-accent)`.

## Why

Changing the brand color previously required editing ~11 places across 3 files. Now it's one edit in `custom.scss`. This is groundwork before a larger styling change.

## Visual impact

None. Every replacement is literal-equivalent (`var()` resolves to the same RGB). Verified via `quarto render index.qmd` (exit 0): all 6 custom properties emit with their original values and `styles.css` references resolve unchanged.

## Scope

Neutral colors (`#fff`, `#222`, gray, `black`, the teal focus-shadow) intentionally left as-is — not part of the yellow brand family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)