### PR TITLE
refactor: standardize media-query breakpoints to Bootstrap values

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -153,7 +153,7 @@
     gap: 1rem;
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 767.98px) {
     .panel-tabset .tab-pane {
         display: block;
     }
@@ -178,7 +178,7 @@
     border-radius: 1rem;
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 767.98px) {
     .partner-grid {
         grid-template-columns: repeat(3, 1fr);
     }
@@ -203,7 +203,7 @@
     color: rgb(241, 240, 150);
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 767.98px) {
     .feature-card {
         display: block;
         padding-top: 2rem;
@@ -277,7 +277,7 @@
     background-color: rgb(184, 184, 107);
 }
 
-@media screen and (max-width: 900px) {
+@media screen and (max-width: 991.98px) {
     .pricing-grid {
         flex-direction: column;
         align-items: center;


### PR DESCRIPTION
## What

Replace the ad-hoc responsive breakpoints in `styles.css` with Bootstrap's standard `breakpoint-down` values:

| Component | Before | After |
|---|---|---|
| panel-tabset, partner grid, feature cards | `max-width: 800px` | `max-width: 767.98px` (md) |
| pricing grid | `max-width: 900px` | `max-width: 991.98px` (lg) |

This matches the `991.98px` query already present in the file, so all breakpoints now follow one convention.

## Why

The mix of 800 / 900 / 991.98px was arbitrary and undocumented. Aligning to Bootstrap's grid breakpoints makes the responsive behavior predictable and consistent with the theme.

## Behavior change (intentional)

Unlike the color refactor, this shifts where layouts collapse:
- Pricing cards now stack at **≤991.98px** instead of ≤900px (i.e. on tablets up to ~991px).
- The other three components switch at **≤767.98px** instead of ≤800px.

Verified `quarto render index.qmd` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)