### PR TITLE
refactor: extract inline styles from index.qmd into CSS classes

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -22,7 +22,7 @@ hide-description: true
 :::
 
 :::
-<video id="myVideo" autoplay muted playsinline loop controls style="width: 70%; height: auto; display: block; margin: 0 auto; border-radius: 1rem; padding: 0; margin-top: 50px;">
+<video id="myVideo" class="hero-video" autoplay muted playsinline loop controls>
   <source src="images/opening.mp4" type="video/mp4">
 </video>
 
@@ -43,7 +43,7 @@ Our latest technology shows significant increase from baseline Pytorch runtime i
 🚀 without largely lowering accuracy
 :::
 <div class="perf-container">
-  <img src="images/perf_bar.png" style="width: 100%;" alt="Performance Barchart">
+  <img src="images/perf_bar.png" alt="Performance Barchart">
 </div>
 
 ## Progress
@@ -51,7 +51,7 @@ Our latest technology shows significant increase from baseline Pytorch runtime i
 We are constantly working to improve our technology! See our latest progress in [Performance page](performance.ipynb).
 :::
 <div class="perf-container">
-  <img src="images/perf_progress.png" style="width: 100%;" alt="Performance Progress">
+  <img src="images/perf_progress.png" alt="Performance Progress">
 </div>
 
 ## Blogs

--- a/styles.css
+++ b/styles.css
@@ -90,6 +90,15 @@
     padding-bottom: 2rem;
 }
 
+.hero-video {
+    width: 70%;
+    height: auto;
+    display: block;
+    margin: 50px auto 0;
+    border-radius: 1rem;
+    padding: 0;
+}
+
 /*Sub-banners*/
 .banner {
     margin-top: 1rem;
@@ -122,6 +131,10 @@
 /* Performance */
 .perf-container {
     padding: 0;
+}
+
+.perf-container img {
+    width: 100%;
 }
 
 .panel-tabset {


### PR DESCRIPTION
## What

Move presentational inline styles out of `index.qmd` markup into `styles.css`:

- Hero `<video>` inline `style="..."` → `.hero-video` class.
- Two `.perf-container` `<img style="width:100%">` → a single `.perf-container img { width: 100%; }` rule (removes the duplication).

## Why

Keeps content (`.qmd`) and presentation (`.css`) separated, and de-duplicates the repeated image width. Groundwork before larger styling changes.

## Visual impact

None. Values are carried over verbatim; the video's redundant `margin: 0 auto` + `margin-top: 50px` is collapsed to the equivalent `margin: 50px auto 0`. Verified `quarto render index.qmd` (exit 0); no `style=` attributes remain in `index.qmd`.

## Scope

The `_quarto.yml` "Try Free" navbar button still carries inline layout props — left as-is (one-off in raw navbar HTML; extracting it is more invasive than it's worth right now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)