### PR TITLE
feat: show latest blog posts on the home page

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -7,6 +7,15 @@ editor: source
 description: |
   AI compression as-a-Service with optimized tiny Runtime for Deep Neural Network (DNN)
 hide-description: true
+listing:
+  - id: latest-blogs
+    contents:
+      - "blogs/*.qmd"
+      - "blogs/*.ipynb"
+    sort: "date desc"
+    max-items: 3
+    type: default
+    fields: [title, description, date]
 ---
 
 ::: {.hero-title}
@@ -55,11 +64,12 @@ We are constantly working to improve our technology! See our latest progress in 
 </div>
 
 ## Blogs
-Check out our [latest blogs](blog.qmd) for exciting updates or up-to-date information about edge AI technology!
+Check out our latest posts for exciting updates and up-to-date information about edge AI technology!
 
-```{=html}
-<iframe width="100%" height="500" src="https://ninjalabo.ai/blog.html" scrolling="no" title="NinjaLABO Blogs" disabled></iframe>
-```
+::: {#latest-blogs}
+:::
+
+[See all blogs](blog.qmd)
 :::
 :::
 


### PR DESCRIPTION
## What

Make new blog posts surface on the home page automatically.

The Blogs tab on `index.qmd` previously embedded the whole blog index via a hardcoded `<iframe src="https://ninjalabo.ai/blog.html" height=500 scrolling=no>`. That URL was absolute (breaks on local preview / other environments) and the fixed height cut the content off.

This replaces it with a **native Quarto listing** of the 3 most recent posts:

```yaml
listing:
  - id: latest-blogs
    contents: ["blogs/*.qmd", "blogs/*.ipynb"]
    sort: "date desc"
    max-items: 3
    type: default
    fields: [title, description, date]
```

…rendered into a `::: {#latest-blogs}` placeholder, with a "See all blogs" link to `blog.qmd`.

## Why

New posts now appear on the front page on every rebuild — no manual step, no iframe, styled by the site theme. Theme stays `darkly` (unchanged); impact is limited to `index.qmd`.

## Verification

`quarto render index.qmd` (exit 0). Rendered `_site/index.html` shows the 3 newest posts by real date — *Distributed ML on Unikernel for IoT* (2025-05-28), *CamTalks* (2025-05-09), *DataTalks* (2025-05-09) — with titles, descriptions, dates and links. Old `blog.html` iframe reference is gone. All `blogs/*.qmd` have a `date:` field, so undated posts can't float to the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)