### PR TITLE
feat: Blogs as default home tab, 5 latest posts as image grid

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -13,9 +13,9 @@ listing:
       - "blogs/*.qmd"
       - "blogs/*.ipynb"
     sort: "date desc"
-    max-items: 3
-    type: default
-    fields: [title, description, date]
+    max-items: 5
+    type: grid
+    fields: [image, title, description, date]
 ---
 
 ::: {.hero-title}
@@ -43,6 +43,13 @@ Run by [NinjaLABO](https://ninjalabo.ai).
 # Latest Updates!
 ::: {.panel-tabset}
 
+## Blogs
+
+::: {#latest-blogs}
+:::
+
+[See all blogs](blog.qmd)
+
 ## Performance
 ::: {.perf-text}
 Our latest technology shows significant increase from baseline Pytorch runtime in terms of:
@@ -62,14 +69,6 @@ We are constantly working to improve our technology! See our latest progress in 
 <div class="perf-container">
   <img src="images/perf_progress.png" alt="Performance Progress">
 </div>
-
-## Blogs
-Check out our latest posts for exciting updates and up-to-date information about edge AI technology!
-
-::: {#latest-blogs}
-:::
-
-[See all blogs](blog.qmd)
 :::
 :::
 


### PR DESCRIPTION
## What

Builds on #59. Three changes to the "Latest Updates!" section on `index.qmd`:

1. **Blogs is now the default tab** — moved it to the front of the `.panel-tabset`, so it shows first instead of Performance.
2. **Removed** the "Check out our latest posts…" intro sentence.
3. **Listing → 5-item image grid** (`type: grid`, `max-items: 5`, `fields: [image, title, description, date]`), replacing the 3-item text list.

## Images without per-post config

No `blogs/*.qmd` has an explicit `image:` field, but Quarto auto-derives each card's thumbnail from the **first image in the post body**. Verified in the render — the 5 cards show real images: `elc2019-001.png`, `CamTalks0.png`, `DataTalks0.png`, `talkingteddy_01.png`, `kaukoschool_1.png`.

## Verification

`quarto render index.qmd` (exit 0). Rendered `_site/index.html`: Blogs tab carries `nav-link active` / `tab-pane active` (default-selected); 5 `quarto-grid-item` cards each with a `thumbnail-image`. Performance/Progress tabs are byte-identical to before.

## Note

The grid sits inside the `.banner` block which has 15% left/right padding, so its width is bounded by that. Happy to widen it (reduce the padding for this section, or set `grid-columns`) if you want it to span more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)