### PR TITLE
fix: blog grid full-width + widen Latest Updates section

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -172,6 +172,20 @@
     }
 }
 
+/* Blogs listing tab: full width (override the perf tabs' 1fr/2fr split) */
+.panel-tabset .tab-pane:has(#listing-latest-blogs) {
+    display: block;
+}
+#listing-latest-blogs + p {
+    margin-top: 1.5rem;
+}
+
+/* Widen only the Latest Updates section that holds the tabset */
+.banner:has(.panel-tabset) {
+    padding-left: 5%;
+    padding-right: 5%;
+}
+
 /*Partners*/
 .partner-grid {
     display: grid;


### PR DESCRIPTION
## Problem

In the screenshot from #60, the home-page blog grid was cramped into the left third with "See all blogs" floating top-right and a large empty area.

**Root cause:** `styles.css` has a generic rule meant for the Performance/Progress tabs:

```css
.panel-tabset .tab-pane { display: grid; grid-template-columns: 1fr 2fr; }
```

Now that Blogs is also a tab, that 1fr/2fr split applied to it too — the listing landed in the 1fr column and the "See all blogs" `<p>` in the 2fr column.

## Fix (CSS-only, `styles.css`)

```css
/* Blogs listing tab: full width (override the perf tabs' 1fr/2fr split) */
.panel-tabset .tab-pane:has(#listing-latest-blogs) { display: block; }
#listing-latest-blogs + p { margin-top: 1.5rem; }

/* Widen only the Latest Updates section that holds the tabset */
.banner:has(.panel-tabset) { padding-left: 5%; padding-right: 5%; }
```

- Scoped with `:has()` so **Performance/Progress tabs are untouched** and **other `.banner` sections (Partners, features) keep their 15% padding**.
- The real listing id is `#listing-latest-blogs` (Quarto prefixes the YAML `id` with `listing-`).

## Result

Blog grid now spans the full width (3-column, equal-height cards with thumbnails), "See all blogs" sits below the grid, and the section is wider. Verified locally by rendering `index.qmd` and screenshotting the page in a headless browser (Blogs is the default tab; grid fills the width).

🤖 Generated with [Claude Code](https://claude.com/claude-code)